### PR TITLE
Output logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://api.cirrus-ci.com/github/cirruslabs/cirrus-cli.svg)](https://cirrus-ci.com/github/cirruslabs/cirrus-cli)
 
-WIP CLI for executing Cirrus tasks locally. Currently can only validate Cirrus CI configuration file.
+CLI for executing Cirrus tasks locally.
 
 ## Installation
 
@@ -24,8 +24,21 @@ To be able to run `cirrus` command from anywhere, make sure that the `$GOPATH/bi
 
 ## Usage
 
+### Validate
+
 To validate a Cirrus CI configuration, simply switch to a directory where the `.cirrus.yml` is located and run:
 
 ```
 cirrus validate
 ```
+
+### Running
+
+To run Cirrus CI tasks locally, simply switch to a directory where the `.cirrus.yml` is located and run:
+                                
+```
+cirrus run
+```
+
+**Note:** Cirrus CLI only support [Linux `container`s](https://cirrus-ci.org/guide/linux/#linux-containers) instances at the moment.
+

--- a/internal/executor/build/task.go
+++ b/internal/executor/build/task.go
@@ -44,7 +44,7 @@ func NewFromProto(protoTask *api.Task) (*Task, error) {
 			Instruction: &api.Command_ScriptInstruction{
 				ScriptInstruction: &api.ScriptInstruction{
 					Scripts: []string{
-						"echo 'Coping mounted project to a working directory...'",
+						"echo 'Copying mounted project directory to a working directory...'",
 						"cp -rT $CIRRUS_PROJECT_DIR .",
 					},
 				},

--- a/internal/executor/build/task.go
+++ b/internal/executor/build/task.go
@@ -43,7 +43,10 @@ func NewFromProto(protoTask *api.Task) (*Task, error) {
 			Name: command.Name,
 			Instruction: &api.Command_ScriptInstruction{
 				ScriptInstruction: &api.ScriptInstruction{
-					Scripts: []string{"cp -rT $CIRRUS_PROJECT_DIR ."},
+					Scripts: []string{
+						"echo 'Coping mounted project to a working directory...'",
+						"cp -rT $CIRRUS_PROJECT_DIR .",
+					},
 				},
 			},
 		}

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"net"
 	"runtime"
+	"strings"
 	"sync"
 
 	// Registers a gzip compressor needed for streaming logs from the agent
@@ -253,7 +254,12 @@ func (r *RPC) StreamLogs(stream api.CirrusCIService_StreamLogsServer) error {
 			r.logger.WithFields(map[string]interface{}{
 				"task":    currentTaskName,
 				"command": currentCommand,
-			}).Debugf("received chunk: %s", string(x.Chunk.Data))
+			}).Debugf("received chunk of %d bytes", len(x.Chunk.Data))
+
+			logLines := strings.Split(string(x.Chunk.Data), "\n")
+			for _, logLine := range logLines {
+				r.logger.WithContext(stream.Context()).Info(logLine)
+			}
 		}
 	}
 


### PR DESCRIPTION
Since we are not running tasks in parallel yet we can simply output logs for troubleshooting.