### PR TITLE
Handle premature instance termination

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -99,7 +99,14 @@ func (e *Executor) Run(ctx context.Context) error {
 			task.SetStatus(taskstatus.TimedOut)
 		}
 
-		e.logger.Infof("task %s %s", task.String(), task.Status().String())
+		switch task.Status() {
+		case taskstatus.Succeeded:
+			e.logger.Infof("task %s %s", task.String(), task.Status().String())
+		case taskstatus.New:
+			return fmt.Errorf("%w: instance terminated before the task %s had a chance to run", ErrBuildFailed, task.String())
+		default:
+			return fmt.Errorf("%w: task %s %s", ErrBuildFailed, task.String(), task.Status().String())
+		}
 
 		// Bail-out if the task has failed
 		if task.Status() != taskstatus.Succeeded {


### PR DESCRIPTION
Before:

```
time="2020-08-07T12:10:25+03:00" level=debug msg="cleaning up working volume ad48d026f3387e82d4e4a7e7ea6449842d0705c1b871ca8c078f40316bc44ac6"
time="2020-08-07T12:10:25+03:00" level=info msg="task test (0) new"
    TestEntrypoint: executor.go:49: build failed: task test (0) new
```

After:

```
time="2020-08-07T12:11:09+03:00" level=debug msg="cleaning up working volume d120d6e535864837d0b28589451e8f367a7491a009873e476a118b4835d99f1c"
    TestEntrypoint: executor.go:49: build failed: instance terminated before the task test (0) had a chance to run
```