### PR TITLE
CI: move golangci-lint's arguments to .golangci.yml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
   container:
     image: golangci/golangci-lint:latest
   name: Lint
-  script: golangci-lint run -v --out-format json --max-issues-per-linter 0 --max-same-issues 0 -p bugs,complexity,format,performance,style,unused -D goimports,wsl,gochecknoglobals,funlen,noctx,gofumpt > golangci.json
+  script: golangci-lint run -v --out-format json > golangci.json
   always:
     artifacts:
       path: golangci.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,9 +41,6 @@ linters:
     - goimports
     - funlen
 
-    # We've been sending HTTP requests without context.Context before when validating configurations via GraphQL.
-    - noctx
-
 issues:
   # Don't hide multiple issues that belong to one class. since GitHub annotations can handle them all nicely.
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,6 @@ linters:
     - funlen
 
 issues:
-  # Don't hide multiple issues that belong to one class. since GitHub annotations can handle them all nicely.
+  # Don't hide multiple issues that belong to one class since GitHub annotations can handle them all nicely.
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,15 @@ linters-settings:
     default-signifies-exhaustive: true
 
 linters:
+  # Selecting all available presets effectively enables all linters
+  presets:
+    - bugs
+    - complexity
+    - format
+    - performance
+    - style
+    - unused
+
   disable:
     # Messages like "struct of size 104 bytes could be of size 96 bytes" from a package
     # that was last updated 2 years ago[1] are barely helpful.
@@ -22,3 +31,20 @@ linters:
 
     # New linters that require a lot of codebase churn and noise, but perhaps we can enable them in the future.
     - nlreturn
+
+    # Unfortunately, we use globals due to how spf13/cobra works.
+    - gochecknoglobals
+
+    # Style linters that are total nuts.
+    - wsl
+    - gofumpt
+    - goimports
+    - funlen
+
+    # We've been sending HTTP requests without context.Context before when validating configurations via GraphQL.
+    - noctx
+
+issues:
+  # Don't hide multiple issues that belong to one class. since GitHub annotations can handle them all nicely.
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ linters-settings:
     default-signifies-exhaustive: true
 
 linters:
-  # Selecting all available presets effectively enables all linters
+  # Selecting all available presets effectively enables all linters.
   presets:
     - bugs
     - complexity


### PR DESCRIPTION
This helps with documenting the reasons behind disabling various linters
and fosters re-usability in other repos like [cirrus-ci-agent](https://github.com/cirruslabs/cirrus-ci-agent).