### PR TITLE
Fixed order of cleanups

### DIFF
--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 )
 
-func RestoreDirLater(t *testing.T) {
+func RestoreDirLater(t *testing.T, f func()) {
 	savedDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
+	f()
 	t.Cleanup(func() {
 		if err := os.Chdir(savedDir); err != nil {
 			t.Fatal(err)
@@ -47,11 +48,11 @@ func TempDir(t *testing.T) string {
 
 // TempChdir switches to a temporary per-test directory.
 func TempChdir(t *testing.T) {
-	RestoreDirLater(t)
-
-	if err := os.Chdir(TempDir(t)); err != nil {
-		t.Fatal(err)
-	}
+	RestoreDirLater(t, func() {
+		if err := os.Chdir(TempDir(t)); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 // TempChdirPopulatedWith creates a temporary per-test directory
@@ -69,9 +70,9 @@ func TempDirPopulatedWith(t *testing.T, sourceDir string) string {
 // TempChdirPopulatedWith creates a temporary per-test directory
 // filled with sourceDir contents and switches to it.
 func TempChdirPopulatedWith(t *testing.T, sourceDir string) {
-	RestoreDirLater(t)
-
-	if err := os.Chdir(TempDirPopulatedWith(t, sourceDir)); err != nil {
-		t.Fatal(err)
-	}
+	RestoreDirLater(t, func() {
+		if err := os.Chdir(TempDirPopulatedWith(t, sourceDir)); err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -8,12 +8,11 @@ import (
 	"testing"
 )
 
-func RestoreDirLater(t *testing.T, f func()) {
+func RestoreDirLater(t *testing.T) {
 	savedDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
-	f()
 	t.Cleanup(func() {
 		if err := os.Chdir(savedDir); err != nil {
 			t.Fatal(err)
@@ -48,11 +47,13 @@ func TempDir(t *testing.T) string {
 
 // TempChdir switches to a temporary per-test directory.
 func TempChdir(t *testing.T) {
-	RestoreDirLater(t, func() {
-		if err := os.Chdir(TempDir(t)); err != nil {
-			t.Fatal(err)
-		}
-	})
+	dir := TempDir(t)
+
+	RestoreDirLater(t)
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TempChdirPopulatedWith creates a temporary per-test directory
@@ -70,9 +71,11 @@ func TempDirPopulatedWith(t *testing.T, sourceDir string) string {
 // TempChdirPopulatedWith creates a temporary per-test directory
 // filled with sourceDir contents and switches to it.
 func TempChdirPopulatedWith(t *testing.T, sourceDir string) {
-	RestoreDirLater(t, func() {
-		if err := os.Chdir(TempDirPopulatedWith(t, sourceDir)); err != nil {
-			t.Fatal(err)
-		}
-	})
+	dir := TempDirPopulatedWith(t, sourceDir)
+
+	RestoreDirLater(t)
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Make sure to change PWD first and only then delete temp folder since Windows doesn't allow to delete current PWD.