### PR TITLE
Cache gRPC connections

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -44,6 +44,19 @@ const (
 var clientsMutex sync.Mutex
 var clientsCache = make(map[string]api.CirrusCIServiceClient)
 
+type Result struct {
+	Errors []string
+	Tasks  []*api.Task
+}
+
+func (p *Parser) rpcEndpoint() string {
+	if p.RPCEndpoint == "" {
+		return DefaultRPCEndpoint
+	}
+
+	return p.RPCEndpoint
+}
+
 func getRPCClient(ctx context.Context, endpoint string) (api.CirrusCIServiceClient, error) {
 	clientsMutex.Lock()
 	defer clientsMutex.Unlock()
@@ -76,19 +89,6 @@ func getRPCClient(ctx context.Context, endpoint string) (api.CirrusCIServiceClie
 	client := api.NewCirrusCIServiceClient(conn)
 	clientsCache[endpoint] = client
 	return client, nil
-}
-
-type Result struct {
-	Errors []string
-	Tasks  []*api.Task
-}
-
-func (p *Parser) rpcEndpoint() string {
-	if p.RPCEndpoint == "" {
-		return DefaultRPCEndpoint
-	}
-
-	return p.RPCEndpoint
 }
 
 func (p *Parser) Parse(config string) (*Result, error) {


### PR DESCRIPTION
There are occasional slowness in tests while dialing gRPC endpoint. My theory is that tests are running in parallel and creation of a new connection for every parsing causing the issue since usually you have a persistent connection for your app and don't create one for each RPC.