### PR TITLE
Include unique labels in logs

### DIFF
--- a/internal/executor/build/task.go
+++ b/internal/executor/build/task.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/build/taskstatus"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -17,6 +18,7 @@ type Task struct {
 	ID          int64
 	RequiredIDs []int64
 	Name        string
+	Labels      []string
 	status      taskstatus.Status
 	Instance    instance.Instance
 	Timeout     time.Duration
@@ -65,6 +67,7 @@ func NewFromProto(protoTask *api.Task) (*Task, error) {
 		ID:          protoTask.LocalGroupId,
 		RequiredIDs: protoTask.RequiredGroups,
 		Name:        protoTask.Name,
+		Labels:      protoTask.Metadata.UniqueLabels,
 		Instance:    inst,
 		Timeout:     timeout,
 		Environment: protoTask.Environment,
@@ -80,6 +83,13 @@ func (task *Task) ProtoCommands() []*api.Command {
 	}
 
 	return result
+}
+
+func (task *Task) UniqueName() string {
+	if len(task.Labels) == 0 {
+		return task.Name
+	}
+	return task.Name + " " + strings.Join(task.Labels, " ")
 }
 
 func (task *Task) FailedAtLeastOnce() bool {

--- a/internal/executor/build/task.go
+++ b/internal/executor/build/task.go
@@ -63,11 +63,15 @@ func NewFromProto(protoTask *api.Task) (*Task, error) {
 		}
 	}
 
+	var uniqueLabels []string
+	if protoTask.Metadata != nil {
+		uniqueLabels = protoTask.Metadata.UniqueLabels
+	}
 	return &Task{
 		ID:          protoTask.LocalGroupId,
 		RequiredIDs: protoTask.RequiredGroups,
 		Name:        protoTask.Name,
-		Labels:      protoTask.Metadata.UniqueLabels,
+		Labels:      uniqueLabels,
 		Instance:    inst,
 		Timeout:     timeout,
 		Environment: protoTask.Environment,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -90,7 +90,7 @@ func (e *Executor) Run(ctx context.Context) error {
 		}
 
 		e.logger.Debugf("running task %s", task.String())
-		taskLogger := e.logger.Scoped(task.Name)
+		taskLogger := e.logger.Scoped(task.UniqueName())
 
 		// Prepare task's instance
 		taskInstance := task.Instance

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -178,7 +178,7 @@ func (r *RPC) ReportSingleCommand(
 		return nil, err
 	}
 
-	commandLogger := r.logger.Scoped(task.Name).Scoped(req.CommandName)
+	commandLogger := r.logger.Scoped(task.UniqueName()).Scoped(req.CommandName)
 
 	// Register whether the current command succeeded or failed
 	// so that the main loop can make the decision whether
@@ -225,7 +225,7 @@ func (r *RPC) StreamLogs(stream api.CirrusCIService_StreamLogsServer) error {
 			currentTaskName = task.Name
 			currentCommand = x.Key.CommandName
 
-			streamLogger = r.logger.Scoped(currentTaskName).Scoped(currentCommand)
+			streamLogger = r.logger.Scoped(task.UniqueName()).Scoped(currentCommand)
 			streamLogger.Debugf("begin streaming logs")
 		case *api.LogEntry_Chunk:
 			if currentTaskName == "" {
@@ -255,7 +255,7 @@ func (r *RPC) Heartbeat(ctx context.Context, req *api.HeartbeatRequest) (*api.He
 		return nil, err
 	}
 
-	r.logger.Scoped(task.Name).Debugf("received heartbeat")
+	r.logger.Scoped(task.UniqueName()).Debugf("received heartbeat")
 
 	return &api.HeartbeatResponse{}, nil
 }
@@ -266,7 +266,7 @@ func (r *RPC) ReportAgentError(ctx context.Context, req *api.ReportAgentProblemR
 		return nil, err
 	}
 
-	r.logger.Scoped(task.Name).Debugf("agent error: %s", req.Message)
+	r.logger.Scoped(task.UniqueName()).Debugf("agent error: %s", req.Message)
 
 	return &empty.Empty{}, nil
 }
@@ -277,7 +277,7 @@ func (r *RPC) ReportAgentWarning(ctx context.Context, req *api.ReportAgentProble
 		return nil, err
 	}
 
-	r.logger.Scoped(task.Name).Debugf("agent warning: %s", req.Message)
+	r.logger.Scoped(task.UniqueName()).Debugf("agent warning: %s", req.Message)
 
 	return &empty.Empty{}, nil
 }
@@ -288,7 +288,7 @@ func (r *RPC) ReportAgentSignal(ctx context.Context, req *api.ReportAgentSignalR
 		return nil, err
 	}
 
-	r.logger.Scoped(task.Name).Debugf("agent signal: %s", req.Signal)
+	r.logger.Scoped(task.UniqueName()).Debugf("agent signal: %s", req.Signal)
 
 	return &empty.Empty{}, nil
 }

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -116,7 +116,7 @@ func (r *RPC) Start() {
 
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("failed to start RPC service on %s:0 with '%v'. do ", host, err))
 	}
 	r.listener = listener
 

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -116,7 +116,7 @@ func (r *RPC) Start() {
 
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
-		panic(fmt.Sprintf("failed to start RPC service on %s:0 with '%v'. do ", host, err))
+		panic(fmt.Sprintf("failed to start RPC service on %s: %v", address, err))
 	}
 	r.listener = listener
 


### PR DESCRIPTION
During testing #61 I noticed CLI printed bunch of `matrix_test` tasks without labels which made it impossible to identify tasks. Let's include unique labels in an echelon scope.

![mtail](https://user-images.githubusercontent.com/989066/92316934-b6f18280-efc8-11ea-8808-03484532cbc0.png)
