### PR TITLE
Fix Docker bridge IP detection on Linux

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -79,7 +79,9 @@ func New(projectDir string, tasks []*api.Task, opts ...Option) (*Executor, error
 }
 
 func (e *Executor) Run(ctx context.Context) error {
-	e.rpc.Start()
+	if err := e.rpc.Start(); err != nil {
+		return err
+	}
 	defer e.rpc.Stop()
 
 	for {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -79,7 +79,7 @@ func New(projectDir string, tasks []*api.Task, opts ...Option) (*Executor, error
 }
 
 func (e *Executor) Run(ctx context.Context) error {
-	if err := e.rpc.Start(); err != nil {
+	if err := e.rpc.Start(ctx); err != nil {
 		return err
 	}
 	defer e.rpc.Stop()

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -76,7 +76,7 @@ func (r *RPC) ClientSecret() string {
 }
 
 func getDockerBridgeInterface(ctx context.Context) string {
-	const assumedBridgeInterface = "bridge0"
+	const assumedBridgeInterface = "docker0"
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {


### PR DESCRIPTION
Previously, CLI was looking up `bridge0` instead of the `docker0` interface to find out the bridge IP on which the RPC server for the agent should run. This was essentially a typo and it worked because the fallback IP (`172.17.0.1`) returned otherwise works on default configurations.

This also adds a dynamic interface discovery via `docker network inspect bridge`, with fallback to the aforementioned `docker0` if that fails.

See #61.