### PR TITLE
Parser JSON tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	golang.org/x/sys v0.0.0-20200819141100-7c7a22168250 // indirect
 	google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70 // indirect
 	google.golang.org/grpc v1.32.0
+	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	gotest.tools v2.2.0+incompatible // indirect

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"errors"
+	"fmt"
+	"github.com/cirruslabs/cirrus-cli/internal/testutil"
 	"github.com/cirruslabs/cirrus-cli/pkg/rpcparser"
 	"github.com/spf13/cobra"
 	"log"
@@ -10,6 +12,7 @@ import (
 var ErrValidate = errors.New("validate failed")
 
 var validateFile string
+var yaml bool
 
 func validate(cmd *cobra.Command, args []string) error {
 	// https://github.com/spf13/cobra/issues/340#issuecomment-374617413
@@ -29,6 +32,10 @@ func validate(cmd *cobra.Command, args []string) error {
 		return ErrValidate
 	}
 
+	if yaml {
+		fmt.Println(string(testutil.TasksToJSON(nil, result.Tasks)))
+	}
+
 	return nil
 }
 
@@ -40,6 +47,13 @@ func newValidateCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&validateFile, "file", "f", ".cirrus.yml", "use file as the configuration file")
+
+	// A hidden flag to dump YAML representation of tasks and aid in generating test
+	// cases for smooth rpcparser → parser transition
+	cmd.PersistentFlags().BoolVar(&yaml, "json", false, "emit a JSON list with tasks contained in the configuration file")
+	if err := cmd.PersistentFlags().MarkHidden("json"); err != nil {
+		panic(err)
+	}
 
 	return cmd
 }

--- a/internal/testutil/api.go
+++ b/internal/testutil/api.go
@@ -22,7 +22,7 @@ func TasksToJSON(t *testing.T, tasks []*api.Task) []byte {
 			t.Fatal(err)
 		}
 
-		unmarshalledTasks = append(unmarshalledTasks, task)
+		unmarshalledTasks = append(unmarshalledTasks, unmarshalledTask)
 	}
 
 	res, err := json.MarshalIndent(unmarshalledTasks, "", "  ")

--- a/internal/testutil/api.go
+++ b/internal/testutil/api.go
@@ -1,0 +1,34 @@
+package testutil
+
+import (
+	"encoding/json"
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"google.golang.org/protobuf/encoding/protojson"
+	"testing"
+)
+
+func TasksToJSON(t *testing.T, tasks []*api.Task) []byte {
+	var unmarshalledTasks []interface{}
+
+	for _, task := range tasks {
+		var unmarshalledTask interface{}
+
+		marshalled, err := protojson.MarshalOptions{Indent: "  "}.Marshal(task)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := json.Unmarshal(marshalled, &unmarshalledTask); err != nil {
+			t.Fatal(err)
+		}
+
+		unmarshalledTasks = append(unmarshalledTasks, task)
+	}
+
+	res, err := json.MarshalIndent(unmarshalledTasks, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return res
+}

--- a/pkg/parser/boolevator/boolevator.go
+++ b/pkg/parser/boolevator/boolevator.go
@@ -49,6 +49,9 @@ func Eval(expr string, env map[string]string, functions map[string]Function) (bo
 	}
 
 	languageBases := []gval.Language{
+		// Constants
+		gval.Constant("true", "true"),
+		gval.Constant("false", "false"),
 		// gval-provided prefixes and meta prefixes
 		gval.Parentheses(),
 		gval.Ident(),

--- a/pkg/parser/instance/additionalcontainer.go
+++ b/pkg/parser/instance/additionalcontainer.go
@@ -9,6 +9,11 @@ import (
 	"strconv"
 )
 
+const (
+	defaultAdditionalCPU    = 0.5
+	defaultAdditionalMemory = 512
+)
+
 type AdditionalContainer struct {
 	proto *api.AdditionalContainer
 
@@ -65,6 +70,14 @@ func NewAdditionalContainer(mergedEnv map[string]string) *AdditionalContainer {
 func (ac *AdditionalContainer) Parse(node *node.Node) (*api.AdditionalContainer, error) {
 	if err := ac.DefaultParser.Parse(node); err != nil {
 		return nil, err
+	}
+
+	// Resource defaults
+	if ac.proto.Cpu == 0 {
+		ac.proto.Cpu = defaultAdditionalCPU
+	}
+	if ac.proto.Memory == 0 {
+		ac.proto.Memory = defaultAdditionalMemory
 	}
 
 	return ac.proto, nil

--- a/pkg/parser/instance/additionalcontainer.go
+++ b/pkg/parser/instance/additionalcontainer.go
@@ -1,12 +1,16 @@
 package instance
 
 import (
+	"fmt"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/nameable"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/parseable"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parsererror"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/schema"
 	"strconv"
+	"strings"
+	"unicode"
 )
 
 const (
@@ -24,6 +28,31 @@ func NewAdditionalContainer(mergedEnv map[string]string) *AdditionalContainer {
 	ac := &AdditionalContainer{
 		proto: &api.AdditionalContainer{},
 	}
+
+	ac.OptionalField(nameable.NewSimpleNameable("name"), schema.TodoSchema, func(node *node.Node) error {
+		name, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+
+		if name == "main" {
+			return fmt.Errorf("%w: use of reserved name '%s' for an additional container, please choose another one",
+				parsererror.ErrParsing, name)
+		}
+
+		isNotLetter := func(r rune) bool {
+			return !unicode.IsLetter(r)
+		}
+
+		if strings.IndexFunc(name, isNotLetter) != -1 {
+			return fmt.Errorf("%w: additional container name '%s' is invalid, please only use letters without special symbols",
+				parsererror.ErrParsing, name)
+		}
+
+		ac.proto.Name = name
+
+		return nil
+	})
 
 	ac.OptionalField(nameable.NewSimpleNameable("environment"), schema.TodoSchema, func(node *node.Node) error {
 		environment, err := node.GetStringMapping()

--- a/pkg/parser/instance/container.go
+++ b/pkg/parser/instance/container.go
@@ -9,6 +9,11 @@ import (
 	"strconv"
 )
 
+const (
+	defaultCPU    = 2.0
+	defaultMemory = 4096
+)
+
 type Container struct {
 	proto *api.ContainerInstance
 
@@ -93,6 +98,14 @@ func NewCommunityContainer(mergedEnv map[string]string) *Container {
 func (container *Container) Parse(node *node.Node) (*api.ContainerInstance, error) {
 	if err := container.DefaultParser.Parse(node); err != nil {
 		return nil, err
+	}
+
+	// Resource defaults
+	if container.proto.Cpu == 0 {
+		container.proto.Cpu = defaultCPU
+	}
+	if container.proto.Memory == 0 {
+		container.proto.Memory = defaultMemory
 	}
 
 	return container.proto, nil

--- a/pkg/parser/node/accessor.go
+++ b/pkg/parser/node/accessor.go
@@ -74,7 +74,7 @@ func ExpandEnvironmentVariables(s string, env map[string]string) string {
 	for key := range env {
 		sortedKeys = append(sortedKeys, key)
 	}
-	sort.SliceStable(sortedKeys, func(i, j int) bool {
+	sort.Slice(sortedKeys, func(i, j int) bool {
 		return !(sortedKeys[i] < sortedKeys[j])
 	})
 

--- a/pkg/parser/node/accessor_test.go
+++ b/pkg/parser/node/accessor_test.go
@@ -82,3 +82,26 @@ func TestGetSliceOfNonEmptyStrings(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"command1", "command2"}, slice)
 }
+
+func TestExpandEnvironmentVariablesIsDeterministic(t *testing.T) {
+	env := map[string]string{
+		"C":             "not deterministic",
+		"CI":            "not deterministic",
+		"CIR":           "not deterministic",
+		"CIRR":          "not deterministic",
+		"CIRRU":         "not deterministic",
+		"CIRRUS":        "true",
+		"CIRRUS_BRANCH": "main",
+		"CIRRUS_":       "not deterministic",
+		"CIRRUS_B":      "not deterministic",
+		"CIRRUS_BR":     "not deterministic",
+		"CIRRUS_BRA":    "not deterministic",
+		"CIRRUS_BRAN":   "not deterministic",
+		"CIRRUS_BRANC":  "not deterministic",
+	}
+
+	assert.Equal(t, "main", node.ExpandEnvironmentVariables("$CIRRUS_BRANCH", env))
+
+	assert.Equal(t, "true main", node.ExpandEnvironmentVariables("$CIRRUS $CIRRUS_BRANCH", env))
+	assert.Equal(t, "main true", node.ExpandEnvironmentVariables("$CIRRUS_BRANCH $CIRRUS", env))
+}

--- a/pkg/parser/parseable/parseable.go
+++ b/pkg/parser/parseable/parseable.go
@@ -43,12 +43,23 @@ func (parser *DefaultParser) Parse(node *node.Node) error {
 	// Check required fields
 
 	for _, child := range node.Children {
-		for _, field := range parser.fields {
-			if field.name.Matches(child.Name) {
-				if err := field.onFound(child); err != nil {
-					return err
-				}
+		// Avoid processing the same node by different field handlers
+		// and possibly generating multiple scripts from a single
+		// script field
+		var firstMatchedField *Field
+		for i := range parser.fields {
+			if parser.fields[i].name.Matches(child.Name) {
+				firstMatchedField = &parser.fields[i]
+				break
 			}
+		}
+
+		if firstMatchedField == nil {
+			continue
+		}
+
+		if err := firstMatchedField.onFound(child); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3,7 +3,9 @@ package parser_test
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cirruslabs/cirrus-cli/internal/testutil"
 	"github.com/stretchr/testify/require"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -12,10 +14,10 @@ import (
 )
 
 var validCases = []string{
-	"example-android.yml",
-	"example-flutter-web.yml",
-	"example-mysql.yml",
-	"example-rust.yml",
+	"example-android",
+	"example-flutter-web",
+	"example-mysql",
+	"example-rust",
 }
 
 var invalidCases = []string{
@@ -31,10 +33,19 @@ func TestValidConfigs(t *testing.T) {
 		file := validCase
 		t.Run(file, func(t *testing.T) {
 			p := parser.New()
-			result, err := p.ParseFromFile(absolutize(file))
+			result, err := p.ParseFromFile(absolutize(file + ".yml"))
 
 			require.Nil(t, err)
-			assert.Empty(t, result.Errors)
+			require.Empty(t, result.Errors)
+
+			expected, err := ioutil.ReadFile(absolutize(file + ".json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual := testutil.TasksToJSON(t, result.Tasks)
+
+			assert.JSONEq(t, string(expected), string(actual))
 		})
 	}
 }

--- a/pkg/parser/task/behavior.go
+++ b/pkg/parser/task/behavior.go
@@ -19,18 +19,13 @@ func NewBehavior() *Behavior {
 
 	scriptNameable := nameable.NewRegexNameable("(.*)script")
 	b.OptionalField(scriptNameable, schema.TodoSchema, func(node *node.Node) error {
-		scripts, err := node.GetSliceOfNonEmptyStrings()
+		command, err := handleScript(node, scriptNameable)
 		if err != nil {
 			return err
 		}
-		b.commands = append(b.commands, &api.Command{
-			Name: scriptNameable.FirstGroupOrDefault(node.Name, "main"),
-			Instruction: &api.Command_ScriptInstruction{
-				ScriptInstruction: &api.ScriptInstruction{
-					Scripts: scripts,
-				},
-			},
-		})
+
+		b.commands = append(b.commands, command)
+
 		return nil
 	})
 

--- a/pkg/parser/task/default.go
+++ b/pkg/parser/task/default.go
@@ -1,0 +1,11 @@
+package task
+
+func getDefaultProperties() map[string]string {
+	return map[string]string{
+		"allowFailures":               "false",
+		"executionLock":               "null",
+		"experimentalFeaturesEnabled": "false",
+		"timeoutInSeconds":            "3600",
+		"triggerType":                 "AUTOMATIC",
+	}
+}

--- a/pkg/parser/task/handler.go
+++ b/pkg/parser/task/handler.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 )
 
-func handleOnlyIf(node *node.Node, mergedEnv map[string]string) (bool, error) {
+func handleBoolevatorField(node *node.Node, mergedEnv map[string]string) (bool, error) {
 	onlyIfExpression, err := node.GetStringValue()
 	if err != nil {
 		return false, err

--- a/pkg/parser/task/handler.go
+++ b/pkg/parser/task/handler.go
@@ -1,7 +1,9 @@
 package task
 
 import (
+	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/boolevator"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/nameable"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 )
 
@@ -17,4 +19,36 @@ func handleBoolevatorField(node *node.Node, mergedEnv map[string]string) (bool, 
 	}
 
 	return evaluation, nil
+}
+
+func handleBackgroundScript(node *node.Node, nameable *nameable.RegexNameable) (*api.Command, error) {
+	scripts, err := node.GetSliceOfNonEmptyStrings()
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.Command{
+		Name: nameable.FirstGroupOrDefault(node.Name, "main"),
+		Instruction: &api.Command_BackgroundScriptInstruction{
+			BackgroundScriptInstruction: &api.BackgroundScriptInstruction{
+				Scripts: scripts,
+			},
+		},
+	}, nil
+}
+
+func handleScript(node *node.Node, nameable *nameable.RegexNameable) (*api.Command, error) {
+	scripts, err := node.GetSliceOfNonEmptyStrings()
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.Command{
+		Name: nameable.FirstGroupOrDefault(node.Name, "main"),
+		Instruction: &api.Command_ScriptInstruction{
+			ScriptInstruction: &api.ScriptInstruction{
+				Scripts: scripts,
+			},
+		},
+	}, nil
 }

--- a/pkg/parser/task/pipe.go
+++ b/pkg/parser/task/pipe.go
@@ -124,8 +124,11 @@ func (pipe *DockerPipe) DependsOnNames() []string {
 	return pipe.dependsOn
 }
 
-func (pipe *DockerPipe) ID() int64      { return pipe.proto.LocalGroupId }
-func (pipe *DockerPipe) SetID(id int64) { pipe.proto.LocalGroupId = id }
+func (pipe *DockerPipe) ID() int64 { return pipe.proto.LocalGroupId }
+func (pipe *DockerPipe) SetID(id int64) {
+	pipe.proto.LocalGroupId = id
+	pipe.proto.Metadata.Properties["indexWithinBuild"] = strconv.FormatInt(id, 10)
+}
 
 func (pipe *DockerPipe) DependsOnIDs() []int64       { return pipe.proto.RequiredGroups }
 func (pipe *DockerPipe) SetDependsOnIDs(ids []int64) { pipe.proto.RequiredGroups = ids }

--- a/pkg/parser/task/pipe.go
+++ b/pkg/parser/task/pipe.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	DefaultCPU    = 2.0
-	DefaultMemory = 4096
+	defaultCPU    = 2.0
+	defaultMemory = 4096
 )
 
 type DockerPipe struct {
@@ -94,8 +94,8 @@ func (pipe *DockerPipe) Parse(node *node.Node) error {
 	}
 
 	instance := &api.PipeInstance{
-		Cpu:    DefaultCPU,
-		Memory: DefaultMemory,
+		Cpu:    defaultCPU,
+		Memory: defaultMemory,
 	}
 
 	anyInstance, err := ptypes.MarshalAny(instance)

--- a/pkg/parser/task/pipe.go
+++ b/pkg/parser/task/pipe.go
@@ -33,7 +33,7 @@ func NewDockerPipe(env map[string]string) *DockerPipe {
 	pipe := &DockerPipe{
 		enabled: true,
 	}
-	pipe.proto.Metadata = &api.Task_Metadata{Properties: map[string]string{}}
+	pipe.proto.Metadata = &api.Task_Metadata{Properties: getDefaultProperties()}
 
 	pipe.CollectibleField("environment", schema.TodoSchema, func(node *node.Node) error {
 		environment, err := node.GetStringMapping()

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -121,24 +121,7 @@ func NewTask(env map[string]string) *Task {
 		return nil
 	})
 
-	for id, name := range api.Command_CommandExecutionBehavior_name {
-		idCopy := id
-		task.OptionalField(nameable.NewSimpleNameable(strings.ToLower(name)), schema.TodoSchema, func(node *node.Node) error {
-			behavior := NewBehavior()
-			if err := behavior.Parse(node); err != nil {
-				return err
-			}
-
-			commands := behavior.Proto()
-
-			for _, command := range commands {
-				command.ExecutionBehaviour = api.Command_CommandExecutionBehavior(idCopy)
-				task.proto.Commands = append(task.proto.Commands, command)
-			}
-
-			return nil
-		})
-	}
+	registerExecutionBehaviorFields(task)
 
 	task.OptionalField(nameable.NewSimpleNameable("depends_on"), schema.TodoSchema, func(node *node.Node) error {
 		dependsOn, err := node.GetSliceOfNonEmptyStrings()
@@ -232,4 +215,25 @@ func (task *Task) Proto() interface{} {
 
 func (task *Task) Enabled() bool {
 	return task.enabled
+}
+
+func registerExecutionBehaviorFields(task *Task) {
+	for id, name := range api.Command_CommandExecutionBehavior_name {
+		idCopy := id
+		task.OptionalField(nameable.NewSimpleNameable(strings.ToLower(name)), schema.TodoSchema, func(node *node.Node) error {
+			behavior := NewBehavior()
+			if err := behavior.Parse(node); err != nil {
+				return err
+			}
+
+			commands := behavior.Proto()
+
+			for _, command := range commands {
+				command.ExecutionBehaviour = api.Command_CommandExecutionBehavior(idCopy)
+				task.proto.Commands = append(task.proto.Commands, command)
+			}
+
+			return nil
+		})
+	}
 }

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -227,8 +227,11 @@ func (task *Task) DependsOnNames() []string {
 	return task.dependsOn
 }
 
-func (task *Task) ID() int64      { return task.proto.LocalGroupId }
-func (task *Task) SetID(id int64) { task.proto.LocalGroupId = id }
+func (task *Task) ID() int64 { return task.proto.LocalGroupId }
+func (task *Task) SetID(id int64) {
+	task.proto.LocalGroupId = id
+	task.proto.Metadata.Properties["indexWithinBuild"] = strconv.FormatInt(id, 10)
+}
 
 func (task *Task) DependsOnIDs() []int64       { return task.proto.RequiredGroups }
 func (task *Task) SetDependsOnIDs(ids []int64) { task.proto.RequiredGroups = ids }

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -89,35 +89,25 @@ func NewTask(env map[string]string) *Task {
 
 	bgNameable := nameable.NewRegexNameable("(.*)background_script")
 	task.OptionalField(bgNameable, schema.TodoSchema, func(node *node.Node) error {
-		scripts, err := node.GetSliceOfNonEmptyStrings()
+		command, err := handleBackgroundScript(node, bgNameable)
 		if err != nil {
 			return err
 		}
-		task.proto.Commands = append(task.proto.Commands, &api.Command{
-			Name: bgNameable.FirstGroupOrDefault(node.Name, "main"),
-			Instruction: &api.Command_BackgroundScriptInstruction{
-				BackgroundScriptInstruction: &api.BackgroundScriptInstruction{
-					Scripts: scripts,
-				},
-			},
-		})
+
+		task.proto.Commands = append(task.proto.Commands, command)
+
 		return nil
 	})
 
 	scriptNameable := nameable.NewRegexNameable("(.*)script")
 	task.OptionalField(scriptNameable, schema.TodoSchema, func(node *node.Node) error {
-		scripts, err := node.GetSliceOfNonEmptyStrings()
+		command, err := handleScript(node, scriptNameable)
 		if err != nil {
 			return err
 		}
-		task.proto.Commands = append(task.proto.Commands, &api.Command{
-			Name: scriptNameable.FirstGroupOrDefault(node.Name, "main"),
-			Instruction: &api.Command_ScriptInstruction{
-				ScriptInstruction: &api.ScriptInstruction{
-					Scripts: scripts,
-				},
-			},
-		})
+
+		task.proto.Commands = append(task.proto.Commands, command)
+
 		return nil
 	})
 

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -30,7 +30,7 @@ func NewTask(env map[string]string) *Task {
 	task := &Task{
 		enabled: true,
 	}
-	task.proto.Metadata = &api.Task_Metadata{Properties: map[string]string{}}
+	task.proto.Metadata = &api.Task_Metadata{Properties: getDefaultProperties()}
 
 	task.CollectibleField("environment", schema.TodoSchema, func(node *node.Node) error {
 		taskEnv, err := node.GetStringMapping()

--- a/pkg/parser/testdata/example-android.json
+++ b/pkg/parser/testdata/example-android.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "check_android",
+    "metadata": {
+      "properties": {
+        "allowFailures": "false",
+        "executionLock": "null",
+        "experimentalFeaturesEnabled": "false",
+        "indexWithinBuild": "0",
+        "timeoutInSeconds": "3600",
+        "triggerType": "AUTOMATIC"
+      }
+    },
+    "instance": {
+      "type": "container",
+      "payload": "ChdjaXJydXNjaS9hbmRyb2lkLXNkazoyORUAAIBAGIBQ"
+    },
+    "commands": [
+      {
+        "name": "clone",
+        "Instruction": {
+          "CloneInstruction": {}
+        }
+      },
+      {
+        "name": "create_device",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "echo no | avdmanager create avd --force -n test -k \"system-images;android-29;default;armeabi-v7a\""
+            ]
+          }
+        }
+      },
+      {
+        "name": "start_emulator",
+        "Instruction": {
+          "BackgroundScriptInstruction": {
+            "scripts": [
+              "$ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window"
+            ]
+          }
+        }
+      },
+      {
+        "name": "wait_for_emulator",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "adb wait-for-device",
+              "adb shell input keyevent 82"
+            ]
+          }
+        }
+      },
+      {
+        "name": "check",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "./gradlew check connectedCheck"
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/pkg/parser/testdata/example-android.json
+++ b/pkg/parser/testdata/example-android.json
@@ -1,6 +1,50 @@
 [
   {
-    "name": "check_android",
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "create_device",
+        "scriptInstruction": {
+          "scripts": [
+            "echo no | avdmanager create avd --force -n test -k \"system-images;android-29;default;armeabi-v7a\""
+          ]
+        }
+      },
+      {
+        "backgroundScriptInstruction": {
+          "scripts": [
+            "$ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window"
+          ]
+        },
+        "name": "start_emulator"
+      },
+      {
+        "name": "wait_for_emulator",
+        "scriptInstruction": {
+          "scripts": [
+            "adb wait-for-device",
+            "adb shell input keyevent 82"
+          ]
+        }
+      },
+      {
+        "name": "check",
+        "scriptInstruction": {
+          "scripts": [
+            "./gradlew check connectedCheck"
+          ]
+        }
+      }
+    ],
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 4,
+      "image": "cirrusci/android-sdk:29",
+      "memory": 10240
+    },
     "metadata": {
       "properties": {
         "allowFailures": "false",
@@ -11,58 +55,6 @@
         "triggerType": "AUTOMATIC"
       }
     },
-    "instance": {
-      "type": "container",
-      "payload": "ChdjaXJydXNjaS9hbmRyb2lkLXNkazoyORUAAIBAGIBQ"
-    },
-    "commands": [
-      {
-        "name": "clone",
-        "Instruction": {
-          "CloneInstruction": {}
-        }
-      },
-      {
-        "name": "create_device",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "echo no | avdmanager create avd --force -n test -k \"system-images;android-29;default;armeabi-v7a\""
-            ]
-          }
-        }
-      },
-      {
-        "name": "start_emulator",
-        "Instruction": {
-          "BackgroundScriptInstruction": {
-            "scripts": [
-              "$ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window"
-            ]
-          }
-        }
-      },
-      {
-        "name": "wait_for_emulator",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "adb wait-for-device",
-              "adb shell input keyevent 82"
-            ]
-          }
-        }
-      },
-      {
-        "name": "check",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "./gradlew check connectedCheck"
-            ]
-          }
-        }
-      }
-    ]
+    "name": "check_android"
   }
 ]

--- a/pkg/parser/testdata/example-flutter-web.json
+++ b/pkg/parser/testdata/example-flutter-web.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "main",
+    "metadata": {
+      "properties": {
+        "allowFailures": "false",
+        "executionLock": "null",
+        "experimentalFeaturesEnabled": "false",
+        "indexWithinBuild": "0",
+        "timeoutInSeconds": "3600",
+        "triggerType": "AUTOMATIC"
+      }
+    },
+    "instance": {
+      "type": "container",
+      "payload": "Cg1kZWJpYW46bGF0ZXN0FQAAAEAYgCA="
+    },
+    "commands": [
+      {
+        "name": "clone",
+        "Instruction": {
+          "CloneInstruction": {}
+        }
+      },
+      {
+        "name": "main",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "true"
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/pkg/parser/testdata/example-flutter-web.json
+++ b/pkg/parser/testdata/example-flutter-web.json
@@ -1,6 +1,25 @@
 [
   {
-    "name": "main",
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
     "metadata": {
       "properties": {
         "allowFailures": "false",
@@ -11,27 +30,6 @@
         "triggerType": "AUTOMATIC"
       }
     },
-    "instance": {
-      "type": "container",
-      "payload": "Cg1kZWJpYW46bGF0ZXN0FQAAAEAYgCA="
-    },
-    "commands": [
-      {
-        "name": "clone",
-        "Instruction": {
-          "CloneInstruction": {}
-        }
-      },
-      {
-        "name": "main",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "true"
-            ]
-          }
-        }
-      }
-    ]
+    "name": "main"
   }
 ]

--- a/pkg/parser/testdata/example-mysql.json
+++ b/pkg/parser/testdata/example-mysql.json
@@ -1,6 +1,37 @@
 [
   {
-    "name": "main",
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "additionalContainers": [
+        {
+          "containerPort": 3306,
+          "cpu": 0.5,
+          "environment": {
+            "MYSQL_ROOT_PASSWORD": ""
+          },
+          "image": "mysql:latest",
+          "memory": 512,
+          "name": "mysql"
+        }
+      ],
+      "cpu": 2,
+      "image": "golang:latest",
+      "memory": 4096
+    },
     "metadata": {
       "properties": {
         "allowFailures": "false",
@@ -11,27 +42,6 @@
         "triggerType": "AUTOMATIC"
       }
     },
-    "instance": {
-      "type": "container",
-      "payload": "Cg1nb2xhbmc6bGF0ZXN0FQAAAEAYgCAiOQoFbXlzcWwSDG15c3FsOmxhdGVzdB0AAAA/IIAEKOoZMhcKE01ZU1FMX1JPT1RfUEFTU1dPUkQSAA=="
-    },
-    "commands": [
-      {
-        "name": "clone",
-        "Instruction": {
-          "CloneInstruction": {}
-        }
-      },
-      {
-        "name": "main",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "true"
-            ]
-          }
-        }
-      }
-    ]
+    "name": "main"
   }
 ]

--- a/pkg/parser/testdata/example-mysql.json
+++ b/pkg/parser/testdata/example-mysql.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "main",
+    "metadata": {
+      "properties": {
+        "allowFailures": "false",
+        "executionLock": "null",
+        "experimentalFeaturesEnabled": "false",
+        "indexWithinBuild": "0",
+        "timeoutInSeconds": "3600",
+        "triggerType": "AUTOMATIC"
+      }
+    },
+    "instance": {
+      "type": "container",
+      "payload": "Cg1nb2xhbmc6bGF0ZXN0FQAAAEAYgCAiOQoFbXlzcWwSDG15c3FsOmxhdGVzdB0AAAA/IIAEKOoZMhcKE01ZU1FMX1JPT1RfUEFTU1dPUkQSAA=="
+    },
+    "commands": [
+      {
+        "name": "clone",
+        "Instruction": {
+          "CloneInstruction": {}
+        }
+      },
+      {
+        "name": "main",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "true"
+            ]
+          }
+        }
+      }
+    ]
+  }
+]

--- a/pkg/parser/testdata/example-rust.json
+++ b/pkg/parser/testdata/example-rust.json
@@ -1,0 +1,157 @@
+[
+  {
+    "name": "test",
+    "metadata": {
+      "unique_labels": [
+        "container:rust:latest"
+      ],
+      "properties": {
+        "allowFailures": "false",
+        "executionLock": "null",
+        "experimentalFeaturesEnabled": "false",
+        "indexWithinBuild": "0",
+        "timeoutInSeconds": "3600",
+        "triggerType": "AUTOMATIC"
+      }
+    },
+    "instance": {
+      "type": "container",
+      "payload": "CgtydXN0OmxhdGVzdBUAAABAGIAg"
+    },
+    "commands": [
+      {
+        "name": "clone",
+        "Instruction": {
+          "CloneInstruction": {}
+        }
+      },
+      {
+        "name": "cargo",
+        "Instruction": {
+          "CacheInstruction": {
+            "folder": "$CARGO_HOME/registry",
+            "fingerprint_scripts": [
+              "cat Cargo.lock"
+            ]
+          }
+        }
+      },
+      {
+        "name": "build",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "cargo build"
+            ]
+          }
+        }
+      },
+      {
+        "name": "test",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "cargo test"
+            ]
+          }
+        }
+      },
+      {
+        "name": "before_cache",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "rm -rf $CARGO_HOME/registry/index"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Upload 'cargo' cache",
+        "Instruction": {
+          "UploadCacheInstruction": {
+            "cache_name": "cargo"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "local_group_id": 1,
+    "name": "test",
+    "metadata": {
+      "unique_labels": [
+        "container:rustlang/rust:nightly"
+      ],
+      "properties": {
+        "allowFailures": "true",
+        "executionLock": "null",
+        "experimentalFeaturesEnabled": "false",
+        "indexWithinBuild": "1",
+        "timeoutInSeconds": "3600",
+        "triggerType": "AUTOMATIC"
+      }
+    },
+    "instance": {
+      "type": "container",
+      "payload": "ChVydXN0bGFuZy9ydXN0Om5pZ2h0bHkVAAAAQBiAIA=="
+    },
+    "commands": [
+      {
+        "name": "clone",
+        "Instruction": {
+          "CloneInstruction": {}
+        }
+      },
+      {
+        "name": "cargo",
+        "Instruction": {
+          "CacheInstruction": {
+            "folder": "$CARGO_HOME/registry",
+            "fingerprint_scripts": [
+              "cat Cargo.lock"
+            ]
+          }
+        }
+      },
+      {
+        "name": "build",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "cargo build"
+            ]
+          }
+        }
+      },
+      {
+        "name": "test",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "cargo test"
+            ]
+          }
+        }
+      },
+      {
+        "name": "before_cache",
+        "Instruction": {
+          "ScriptInstruction": {
+            "scripts": [
+              "rm -rf $CARGO_HOME/registry/index"
+            ]
+          }
+        }
+      },
+      {
+        "name": "Upload 'cargo' cache",
+        "Instruction": {
+          "UploadCacheInstruction": {
+            "cache_name": "cargo"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/pkg/parser/testdata/example-rust.json
+++ b/pkg/parser/testdata/example-rust.json
@@ -1,10 +1,57 @@
 [
   {
-    "name": "test",
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "cacheInstruction": {
+          "fingerprintScripts": [
+            "cat Cargo.lock"
+          ],
+          "folder": "$CARGO_HOME/registry"
+        },
+        "name": "cargo"
+      },
+      {
+        "name": "build",
+        "scriptInstruction": {
+          "scripts": [
+            "cargo build"
+          ]
+        }
+      },
+      {
+        "name": "test",
+        "scriptInstruction": {
+          "scripts": [
+            "cargo test"
+          ]
+        }
+      },
+      {
+        "name": "before_cache",
+        "scriptInstruction": {
+          "scripts": [
+            "rm -rf $CARGO_HOME/registry/index"
+          ]
+        }
+      },
+      {
+        "name": "Upload 'cargo' cache",
+        "uploadCacheInstruction": {
+          "cacheName": "cargo"
+        }
+      }
+    ],
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "rust:latest",
+      "memory": 4096
+    },
     "metadata": {
-      "unique_labels": [
-        "container:rust:latest"
-      ],
       "properties": {
         "allowFailures": "false",
         "executionLock": "null",
@@ -12,77 +59,67 @@
         "indexWithinBuild": "0",
         "timeoutInSeconds": "3600",
         "triggerType": "AUTOMATIC"
-      }
+      },
+      "uniqueLabels": [
+        "container:rust:latest"
+      ]
     },
-    "instance": {
-      "type": "container",
-      "payload": "CgtydXN0OmxhdGVzdBUAAABAGIAg"
-    },
+    "name": "test"
+  },
+  {
     "commands": [
       {
-        "name": "clone",
-        "Instruction": {
-          "CloneInstruction": {}
-        }
+        "cloneInstruction": {},
+        "name": "clone"
       },
       {
-        "name": "cargo",
-        "Instruction": {
-          "CacheInstruction": {
-            "folder": "$CARGO_HOME/registry",
-            "fingerprint_scripts": [
-              "cat Cargo.lock"
-            ]
-          }
-        }
+        "cacheInstruction": {
+          "fingerprintScripts": [
+            "cat Cargo.lock"
+          ],
+          "folder": "$CARGO_HOME/registry"
+        },
+        "name": "cargo"
       },
       {
         "name": "build",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "cargo build"
-            ]
-          }
+        "scriptInstruction": {
+          "scripts": [
+            "cargo build"
+          ]
         }
       },
       {
         "name": "test",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "cargo test"
-            ]
-          }
+        "scriptInstruction": {
+          "scripts": [
+            "cargo test"
+          ]
         }
       },
       {
         "name": "before_cache",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "rm -rf $CARGO_HOME/registry/index"
-            ]
-          }
+        "scriptInstruction": {
+          "scripts": [
+            "rm -rf $CARGO_HOME/registry/index"
+          ]
         }
       },
       {
         "name": "Upload 'cargo' cache",
-        "Instruction": {
-          "UploadCacheInstruction": {
-            "cache_name": "cargo"
-          }
+        "uploadCacheInstruction": {
+          "cacheName": "cargo"
         }
       }
-    ]
-  },
-  {
-    "local_group_id": 1,
-    "name": "test",
+    ],
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "rustlang/rust:nightly",
+      "memory": 4096
+    },
+    "localGroupId": "1",
     "metadata": {
-      "unique_labels": [
-        "container:rustlang/rust:nightly"
-      ],
       "properties": {
         "allowFailures": "true",
         "executionLock": "null",
@@ -90,68 +127,11 @@
         "indexWithinBuild": "1",
         "timeoutInSeconds": "3600",
         "triggerType": "AUTOMATIC"
-      }
+      },
+      "uniqueLabels": [
+        "container:rustlang/rust:nightly"
+      ]
     },
-    "instance": {
-      "type": "container",
-      "payload": "ChVydXN0bGFuZy9ydXN0Om5pZ2h0bHkVAAAAQBiAIA=="
-    },
-    "commands": [
-      {
-        "name": "clone",
-        "Instruction": {
-          "CloneInstruction": {}
-        }
-      },
-      {
-        "name": "cargo",
-        "Instruction": {
-          "CacheInstruction": {
-            "folder": "$CARGO_HOME/registry",
-            "fingerprint_scripts": [
-              "cat Cargo.lock"
-            ]
-          }
-        }
-      },
-      {
-        "name": "build",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "cargo build"
-            ]
-          }
-        }
-      },
-      {
-        "name": "test",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "cargo test"
-            ]
-          }
-        }
-      },
-      {
-        "name": "before_cache",
-        "Instruction": {
-          "ScriptInstruction": {
-            "scripts": [
-              "rm -rf $CARGO_HOME/registry/index"
-            ]
-          }
-        }
-      },
-      {
-        "name": "Upload 'cargo' cache",
-        "Instruction": {
-          "UploadCacheInstruction": {
-            "cache_name": "cargo"
-          }
-        }
-      }
-    ]
+    "name": "test"
   }
 ]


### PR DESCRIPTION
This makes sure that we compare the actual parsing results (and not merely check the absence of errors) with the expected fixture contents.

`cirrus validate --json` can be used to generate the fixtures.