### PR TITLE
Unique task description

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PaesslerAG/gval v1.1.0
 	github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894
 	github.com/cirruslabs/cirrus-ci-agent v1.10.0
-	github.com/cirruslabs/echelon v1.2.2
+	github.com/cirruslabs/echelon v1.3.0
 	github.com/containerd/containerd v1.4.0 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/cirruslabs/cirrus-ci-agent v1.10.0/go.mod h1:65sDHJabJzn0QjEaOAHEJQqd
 github.com/cirruslabs/cirrus-ci-annotations v0.0.0-20200908203753-b813f63941d7/go.mod h1:98qD7HLlBx5aNqWiCH80OTTqTTsbXT69wxnlnrnoL0E=
 github.com/cirruslabs/echelon v1.2.2 h1:MDxR6E+ARV/EIpf8uDrkSrwPQmxeRgAhMRGVnWgTx1Y=
 github.com/cirruslabs/echelon v1.2.2/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=
+github.com/cirruslabs/echelon v1.3.0 h1:tWz5i4IFJa8AZbtoqeIurb+NE+DApsLAeOA2n0dCVMI=
+github.com/cirruslabs/echelon v1.3.0/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/containerd v1.4.0 h1:aWJB3lbDEaOxg1mkTBAINY2a+NsoKbAeRYefJPPRY+o=

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -149,8 +149,8 @@ func TestRunYAMLAndStarlarkMerged(t *testing.T) {
 	err := command.Execute()
 
 	require.Nil(t, err)
-	assert.Contains(t, buf.String(), "'from_yaml' succeeded")
-	assert.Contains(t, buf.String(), "'from_starlark' succeeded")
+	assert.Contains(t, buf.String(), "'from_yaml script' succeeded")
+	assert.Contains(t, buf.String(), "'from_starlark script' succeeded")
 }
 
 // TestRunDockerNoPull ensures that --docker-no-pull argument actually disables the container image pulling.

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -149,8 +149,8 @@ func TestRunYAMLAndStarlarkMerged(t *testing.T) {
 	err := command.Execute()
 
 	require.Nil(t, err)
-	assert.Contains(t, buf.String(), "'from_yaml script' succeeded")
-	assert.Contains(t, buf.String(), "'from_starlark script' succeeded")
+	assert.Contains(t, buf.String(), "'from_yaml' script succeeded")
+	assert.Contains(t, buf.String(), "'from_starlark' script succeeded")
 }
 
 // TestRunDockerNoPull ensures that --docker-no-pull argument actually disables the container image pulling.

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -36,15 +36,19 @@ func TestRunTaskFiltering(t *testing.T) {
 		ExpectedStrings []string
 	}{
 		"first single task": {"first_working", []string{
+			"Started 'first_working' task",
 			"task first_working (0) succeeded",
 		}},
 		"second single task": {"Second Working", []string{
+			"Started 'Second Working' Task",
 			"task Second Working (2) succeeded",
 		}},
 		"first task case insensitivity": {"FiRsT_WoRkInG", []string{
+			"Started 'first_working' task",
 			"task first_working (0) succeeded",
 		}},
 		"second task case insensitivity": {"SECOND WORKING", []string{
+			"Started 'Second Working' Task",
 			"task Second Working (2) succeeded",
 		}},
 	}

--- a/internal/executor/build/task.go
+++ b/internal/executor/build/task.go
@@ -89,11 +89,11 @@ func (task *Task) ProtoCommands() []*api.Command {
 	return result
 }
 
-func (task *Task) UniqueName() string {
+func (task *Task) UniqueDescription() string {
 	if len(task.Labels) == 0 {
-		return task.Name
+		return fmt.Sprintf("%s Task", task.Name)
 	}
-	return task.Name + " " + strings.Join(task.Labels, " ")
+	return fmt.Sprintf("%s Task (%s)", task.Name, strings.Join(task.Labels, " "))
 }
 
 func (task *Task) FailedAtLeastOnce() bool {

--- a/internal/executor/build/task.go
+++ b/internal/executor/build/task.go
@@ -91,9 +91,9 @@ func (task *Task) ProtoCommands() []*api.Command {
 
 func (task *Task) UniqueDescription() string {
 	if len(task.Labels) == 0 {
-		return fmt.Sprintf("%s Task", task.Name)
+		return fmt.Sprintf("'%s' Task", task.Name)
 	}
-	return fmt.Sprintf("%s Task (%s)", task.Name, strings.Join(task.Labels, " "))
+	return fmt.Sprintf("'%s' Task (%s)", task.Name, strings.Join(task.Labels, " "))
 }
 
 func (task *Task) FailedAtLeastOnce() bool {

--- a/internal/executor/build/task.go
+++ b/internal/executor/build/task.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 const defaultTaskTimeout = 60 * time.Minute
@@ -90,10 +92,16 @@ func (task *Task) ProtoCommands() []*api.Command {
 }
 
 func (task *Task) UniqueDescription() string {
-	if len(task.Labels) == 0 {
-		return fmt.Sprintf("'%s' Task", task.Name)
+	name := task.Name
+	taskMessagePart := "task"
+	firstRune, _ := utf8.DecodeRuneInString(name)
+	if firstRune != utf8.RuneError && unicode.IsUpper(firstRune) {
+		taskMessagePart = "Task"
 	}
-	return fmt.Sprintf("'%s' Task (%s)", task.Name, strings.Join(task.Labels, " "))
+	if len(task.Labels) == 0 {
+		return fmt.Sprintf("'%s' %s", name, taskMessagePart)
+	}
+	return fmt.Sprintf("'%s' %s (%s)", name, taskMessagePart, strings.Join(task.Labels, " "))
 }
 
 func (task *Task) FailedAtLeastOnce() bool {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -104,7 +104,7 @@ func (e *Executor) Run(ctx context.Context) error {
 		}
 
 		e.logger.Debugf("running task %s", task.String())
-		taskLogger := e.logger.Scoped(task.UniqueName())
+		taskLogger := e.logger.Scoped(task.UniqueDescription())
 
 		// Prepare task's instance
 		taskInstance := task.Instance

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -230,14 +230,19 @@ func (r *RPC) getCommandLogger(task *build.Task, commandName string) *echelon.Lo
 	commandLoggerScope := commandName
 	// make pretty names for some instruction types
 	command := task.GetCommand(commandName)
-	if command == nil {
+	switch {
+	case command == nil:
 		// no found :-(
-	} else if command.ProtoCommand.GetScriptInstruction() != nil {
+		break
+	case command.ProtoCommand.GetScriptInstruction() != nil:
 		commandLoggerScope += " script"
-	} else if command.ProtoCommand.GetBackgroundScriptInstruction() != nil {
+		break
+	case command.ProtoCommand.GetBackgroundScriptInstruction() != nil:
 		commandLoggerScope += " background script"
-	} else if command.ProtoCommand.GetCacheInstruction() != nil {
+		break
+	case command.ProtoCommand.GetCacheInstruction() != nil:
 		commandLoggerScope += " cache"
+		break
 	}
 	return r.logger.Scoped(task.UniqueDescription()).Scoped(commandLoggerScope)
 }

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -204,7 +204,7 @@ func (r *RPC) ReportSingleCommand(
 		return nil, err
 	}
 
-	commandLogger := r.logger.Scoped(task.UniqueName()).Scoped(req.CommandName)
+	commandLogger := r.logger.Scoped(task.UniqueDescription()).Scoped(req.CommandName)
 
 	// Register whether the current command succeeded or failed
 	// so that the main loop can make the decision whether
@@ -251,7 +251,7 @@ func (r *RPC) StreamLogs(stream api.CirrusCIService_StreamLogsServer) error {
 			currentTaskName = task.Name
 			currentCommand = x.Key.CommandName
 
-			streamLogger = r.logger.Scoped(task.UniqueName()).Scoped(currentCommand)
+			streamLogger = r.logger.Scoped(task.UniqueDescription()).Scoped(currentCommand)
 			streamLogger.Debugf("begin streaming logs")
 		case *api.LogEntry_Chunk:
 			if currentTaskName == "" {
@@ -281,7 +281,7 @@ func (r *RPC) Heartbeat(ctx context.Context, req *api.HeartbeatRequest) (*api.He
 		return nil, err
 	}
 
-	r.logger.Scoped(task.UniqueName()).Debugf("received heartbeat")
+	r.logger.Scoped(task.UniqueDescription()).Debugf("received heartbeat")
 
 	return &api.HeartbeatResponse{}, nil
 }
@@ -292,7 +292,7 @@ func (r *RPC) ReportAgentError(ctx context.Context, req *api.ReportAgentProblemR
 		return nil, err
 	}
 
-	r.logger.Scoped(task.UniqueName()).Debugf("agent error: %s", req.Message)
+	r.logger.Scoped(task.UniqueDescription()).Debugf("agent error: %s", req.Message)
 
 	return &empty.Empty{}, nil
 }
@@ -303,7 +303,7 @@ func (r *RPC) ReportAgentWarning(ctx context.Context, req *api.ReportAgentProble
 		return nil, err
 	}
 
-	r.logger.Scoped(task.UniqueName()).Debugf("agent warning: %s", req.Message)
+	r.logger.Scoped(task.UniqueDescription()).Debugf("agent warning: %s", req.Message)
 
 	return &empty.Empty{}, nil
 }
@@ -314,7 +314,7 @@ func (r *RPC) ReportAgentSignal(ctx context.Context, req *api.ReportAgentSignalR
 		return nil, err
 	}
 
-	r.logger.Scoped(task.UniqueName()).Debugf("agent signal: %s", req.Signal)
+	r.logger.Scoped(task.UniqueDescription()).Debugf("agent signal: %s", req.Signal)
 
 	return &empty.Empty{}, nil
 }

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -236,13 +236,10 @@ func (r *RPC) getCommandLogger(task *build.Task, commandName string) *echelon.Lo
 		break
 	case command.ProtoCommand.GetScriptInstruction() != nil:
 		commandLoggerScope += " script"
-		break
 	case command.ProtoCommand.GetBackgroundScriptInstruction() != nil:
 		commandLoggerScope += " background script"
-		break
 	case command.ProtoCommand.GetCacheInstruction() != nil:
 		commandLoggerScope += " cache"
-		break
 	}
 	return r.logger.Scoped(task.UniqueDescription()).Scoped(commandLoggerScope)
 }

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -240,6 +240,8 @@ func (r *RPC) getCommandLogger(task *build.Task, commandName string) *echelon.Lo
 		commandLoggerScope += " background script"
 	case command.ProtoCommand.GetCacheInstruction() != nil:
 		commandLoggerScope += " cache"
+	case command.ProtoCommand.GetArtifactsInstruction() != nil:
+		commandLoggerScope += " artifacts"
 	}
 	return r.logger.Scoped(task.UniqueDescription()).Scoped(commandLoggerScope)
 }

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -227,7 +227,7 @@ func (r *RPC) ReportSingleCommand(
 }
 
 func (r *RPC) getCommandLogger(task *build.Task, commandName string) *echelon.Logger {
-	commandLoggerScope := commandName
+	commandLoggerScope := fmt.Sprintf("'%s'", commandName)
 	// make pretty names for some instruction types
 	command := task.GetCommand(commandName)
 	switch {


### PR DESCRIPTION
There is a problem sometimes to distinguish task's output from an instruction output in dumb terminal mode.

```yaml
test_task:
  test_script: ./.ci/test.sh
```

The above config will produce a bit confusing output with two identical "Started 'test'". This change will fix it by making tasks scopes more descriptive.