### PR TITLE
Introduce run's --docker-no-pull argument

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -209,7 +209,8 @@ func newRunCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "")
 
 	// Docker-related flags
-	cmd.PersistentFlags().BoolVar(&dockerNoPull, "docker-no-pull", false, "don't attempt to pull the images before starting containers")
+	cmd.PersistentFlags().BoolVar(&dockerNoPull, "docker-no-pull", false,
+		"don't attempt to pull the images before starting containers")
 
 	return cmd
 }

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -209,7 +209,7 @@ func newRunCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "")
 
 	// Docker-related flags
-	cmd.PersistentFlags().BoolVar(&dockerNoPull, "docker-no-pull", false, "don't pull the images when starting containers")
+	cmd.PersistentFlags().BoolVar(&dockerNoPull, "docker-no-pull", false, "don't attempt to pull the images before starting containers")
 
 	return cmd
 }

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -152,3 +152,22 @@ func TestRunYAMLAndStarlarkMerged(t *testing.T) {
 	assert.Contains(t, buf.String(), "'from_yaml' succeeded")
 	assert.Contains(t, buf.String(), "'from_starlark' succeeded")
 }
+
+// TestRunDockerNoPull ensures that --docker-no-pull argument actually disables the container image pulling.
+func TestRunDockerNoPull(t *testing.T) {
+	testutil.TempChdirPopulatedWith(t, "testdata/docker-no-pull")
+
+	// Create os.Stderr writer that duplicates it's output to buf
+	buf := bytes.NewBufferString("")
+	writer := io.MultiWriter(os.Stderr, buf)
+
+	command := commands.NewRootCmd()
+	command.SetArgs([]string{"run", "-v", "--docker-no-pull"})
+	command.SetOut(writer)
+	command.SetErr(writer)
+	err := command.Execute()
+
+	require.NotNil(t, err)
+	assert.NotContains(t, buf.String(), "pulling image")
+	assert.Contains(t, buf.String(), "No such image")
+}

--- a/internal/commands/testdata/docker-no-pull/.cirrus.yml
+++ b/internal/commands/testdata/docker-no-pull/.cirrus.yml
@@ -1,0 +1,5 @@
+container:
+  image: nonexistent.invalid/does/it/really/exist:nope
+
+task:
+  script: true

--- a/internal/executor/build/build.go
+++ b/internal/executor/build/build.go
@@ -50,6 +50,14 @@ func New(projectDir string, tasks []*api.Task) (*Build, error) {
 	}, nil
 }
 
+func (b *Build) Tasks() (result []*Task) {
+	for _, task := range b.tasks {
+		result = append(result, task)
+	}
+
+	return
+}
+
 func (b *Build) GetTask(id int64) *Task {
 	task, found := b.tasks[id]
 	if !found {

--- a/internal/executor/options.go
+++ b/internal/executor/options.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/taskfilter"
 	"github.com/cirruslabs/echelon"
 )
@@ -28,5 +29,11 @@ func WithEnvironment(environment map[string]string) Option {
 func WithDirtyMode() Option {
 	return func(e *Executor) {
 		e.dirtyMode = true
+	}
+}
+
+func WithDockerOptions(dockerOptions options.DockerOptions) Option {
+	return func(e *Executor) {
+		e.dockerOptions = dockerOptions
 	}
 }

--- a/internal/executor/options/docker.go
+++ b/internal/executor/options/docker.go
@@ -1,0 +1,20 @@
+package options
+
+type DockerOptions struct {
+	NoPull       bool
+	NoPullImages []string
+}
+
+func (do DockerOptions) ShouldPullImage(image string) bool {
+	if do.NoPull {
+		return false
+	}
+
+	for _, noPullImage := range do.NoPullImages {
+		if noPullImage == image {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/executor/options/docker_test.go
+++ b/internal/executor/options/docker_test.go
@@ -1,0 +1,26 @@
+package options_test
+
+import (
+	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestShouldPullImagePositive(t *testing.T) {
+	do := options.DockerOptions{
+		NoPullImages: []string{"nonexistent.invalid/should/not/be:pulled"},
+	}
+
+	assert.False(t, do.ShouldPullImage("nonexistent.invalid/should/not/be:pulled"))
+	assert.True(t, do.ShouldPullImage("nonexistent.invalid/some/other:image"))
+}
+
+func TestShouldPullImageNegative(t *testing.T) {
+	do := options.DockerOptions{
+		NoPull:       true,
+		NoPullImages: []string{"nonexistent.invalid/should/not/be:pulled"},
+	}
+
+	assert.False(t, do.ShouldPullImage("nonexistent.invalid/should/not/be:pulled"))
+	assert.False(t, do.ShouldPullImage("nonexistent.invalid/some/other:image"))
+}


### PR DESCRIPTION
This brings back the old behavior where we always attempted to pull the latest container image before starting, but lets the user turn it off in case they want to run CI tasks with locally-built container images.

Always pulling images also avoids some tricky-to-diagnose cases like in cirruslabs/cirrus-ci-annotations#22, where running two similar configurations resulted in different results due to stale state in the Docker daemon.