### PR TITLE
Consistent version format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ before:
 
 builds:
   - main: cmd/cirrus/main.go
-    ldflags: "-X github.com/cirruslabs/cirrus-cli/internal/commands.version={{.Version}}-{{.ShortCommit}}"
+    ldflags: "-X main.version={{.Version}} -X main.commit={{.ShortCommit}}"
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,9 @@ before:
 
 builds:
   - main: cmd/cirrus/main.go
-    ldflags: "-X main.version={{.Version}} -X main.commit={{.ShortCommit}}"
+    ldflags: >
+      -X github.com/cirruslabs/cirrus-cli/internal/commands.version={{.Version}}
+      -X github.com/cirruslabs/cirrus-cli/internal/commands.commit={{.ShortCommit}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/cirrus/main.go
+++ b/cmd/cirrus/main.go
@@ -8,6 +8,11 @@ import (
 	"os/signal"
 )
 
+var (
+	version = "unknown"
+	commit = "unknown"
+)
+
 func main() {
 	// Set up signal interruptible context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -24,7 +29,7 @@ func main() {
 	}()
 
 	// Run the command
-	if err := commands.NewRootCmd().ExecuteContext(ctx); err != nil {
+	if err := commands.NewRootCmd(version, commit).ExecuteContext(ctx); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/cirrus/main.go
+++ b/cmd/cirrus/main.go
@@ -8,11 +8,6 @@ import (
 	"os/signal"
 )
 
-var (
-	version = "unknown"
-	commit = "unknown"
-)
-
 func main() {
 	// Set up signal interruptible context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -29,7 +24,7 @@ func main() {
 	}()
 
 	// Run the command
-	if err := commands.NewRootCmd(version, commit).ExecuteContext(ctx); err != nil {
+	if err := commands.NewRootCmd().ExecuteContext(ctx); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
+	github.com/hashicorp/go-version v1.2.1
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c // indirect
 	github.com/lestrrat-go/jsref v0.0.0-20181205001954-1b590508f37d // indirect
 	github.com/lestrrat-go/jsschema v0.0.0-20181205002244-5c81c58ffcc3

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 h1:0IKlLyQ3Hs9nDaiK5cSHAGmcQ
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -4,13 +4,22 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"runtime/debug"
+	goversion "github.com/hashicorp/go-version"
 )
 
 func NewRootCmd(version, commit string) *cobra.Command {
 	if version == "unknown" {
 		info, ok := debug.ReadBuildInfo()
 		if ok {
-			version = info.Main.Version
+			// We parse the version here for two reasons:
+			// * to weed out the "(devel)" version and fallback to "unknown" instead
+			//   (see https://github.com/golang/go/issues/29228 for details on when this might happen)
+			// * to remove the "v" prefix from the BuildInfo's version (e.g. "v0.7.0") and thus be consistent
+			//   with the binary builds, where the version string would be "0.7.0" instead
+			semver, err := goversion.NewSemver(info.Main.Version)
+			if err == nil {
+				version = semver.String()
+			}
 		}
 	}
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -7,7 +7,12 @@ import (
 	goversion "github.com/hashicorp/go-version"
 )
 
-func NewRootCmd(version, commit string) *cobra.Command {
+var (
+	version = "unknown"
+	commit  = "unknown"
+)
+
+func NewRootCmd() *cobra.Command {
 	if version == "unknown" {
 		info, ok := debug.ReadBuildInfo()
 		if ok {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -10,7 +10,7 @@ var version string
 func NewRootCmd() *cobra.Command {
 	if version == "" {
 		info, ok := debug.ReadBuildInfo()
-		if ok && info != nil {
+		if ok {
 			version = info.Main.Version
 		}
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -2,9 +2,9 @@ package commands
 
 import (
 	"fmt"
+	goversion "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
 	"runtime/debug"
-	goversion "github.com/hashicorp/go-version"
 )
 
 var (

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1,14 +1,13 @@
 package commands
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"runtime/debug"
 )
 
-var version string
-
-func NewRootCmd() *cobra.Command {
-	if version == "" {
+func NewRootCmd(version, commit string) *cobra.Command {
+	if version == "unknown" {
 		info, ok := debug.ReadBuildInfo()
 		if ok {
 			version = info.Main.Version
@@ -18,7 +17,7 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cirrus",
 		Short:   "Cirrus CLI",
-		Version: version,
+		Version: fmt.Sprintf("%s-%s", version, commit),
 	}
 
 	cmd.AddCommand(


### PR DESCRIPTION
Make sure the `--version` is always present and adheres to the `version-commit` format.

This also ensures that version of the `cirrus` installed via `go get` is consistent with the binary builds versions (currently it's `v0.7.0` vs `0.7.0`).

See #73.