### PR TITLE
TestAdditionalContainers: fix flakiness by using wait-for-it

### DIFF
--- a/internal/executor/testdata/additional-containers/.cirrus.yml
+++ b/internal/executor/testdata/additional-containers/.cirrus.yml
@@ -15,8 +15,8 @@ task:
         env:
           POSTGRES_PASSWORD: insecure
   prepare_script:
-    - apt-get update && apt-get -y install netcat-openbsd
+    - apt-get update && apt-get -y install netcat-openbsd wait-for-it
   mysql_test_script:
-    - nc -z 127.0.0.1 3306
+    - wait-for-it --timeout=0 --strict 127.0.0.1:3306 -- true
   postgres_test_script:
-    - nc -z 127.0.0.1 5432
+    - wait-for-it --timeout=0 --strict 127.0.0.1:5432 -- true


### PR DESCRIPTION
Turns out that MySQL is simply taking too long to start up (initializing InnoDB storages) when running multiple tests in parallel and we need to wait a little longer than 60 seconds mandated by the agent.