### PR TITLE
Remove depth limit when fetching Starlark modules from Git

### DIFF
--- a/pkg/larker/loader/git/git.go
+++ b/pkg/larker/loader/git/git.go
@@ -88,8 +88,7 @@ func Retrieve(ctx context.Context, locator *Locator) ([]byte, error) {
 
 	// Clone the repository
 	repo, err := git.CloneContext(ctx, boundedStorage, boundedFilesystem, &git.CloneOptions{
-		URL:   locator.URL,
-		Depth: 1,
+		URL: locator.URL,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrRetrievalFailed, err)


### PR DESCRIPTION
This fixes the `TestLoadGitHelpers` test which otherwise fails because it requires a module from the revision excluded by the depth limit.