### PR TITLE
Starlark filesystem builtins

### DIFF
--- a/pkg/larker/builtin/fs.go
+++ b/pkg/larker/builtin/fs.go
@@ -1,0 +1,80 @@
+package builtin
+
+import (
+	"context"
+	"errors"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
+	"go.starlark.net/starlark"
+	"os"
+)
+
+func FS(ctx context.Context, fs fs.FileSystem) starlark.StringDict {
+	return starlark.StringDict{
+		"exists":  exists(ctx, fs),
+		"read":    read(ctx, fs),
+		"readdir": readdir(ctx, fs),
+	}
+}
+
+func exists(ctx context.Context, fs fs.FileSystem) starlark.Value {
+	const funcName = "exists"
+
+	return starlark.NewBuiltin(funcName, func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var path string
+		if err := starlark.UnpackPositionalArgs(funcName, args, kwargs, 1, &path); err != nil {
+			return nil, err
+		}
+
+		_, err := fs.Stat(ctx, path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return starlark.Bool(false), nil
+			}
+
+			return nil, err
+		}
+
+		return starlark.Bool(true), nil
+	})
+}
+
+func read(ctx context.Context, fs fs.FileSystem) starlark.Value {
+	const funcName = "read"
+
+	return starlark.NewBuiltin(funcName, func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var path string
+		if err := starlark.UnpackPositionalArgs(funcName, args, kwargs, 1, &path); err != nil {
+			return nil, err
+		}
+
+		fileBytes, err := fs.Get(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+
+		return starlark.String(fileBytes), nil
+	})
+}
+
+func readdir(ctx context.Context, fs fs.FileSystem) starlark.Value {
+	const funcName = "readdir"
+
+	return starlark.NewBuiltin(funcName, func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var path string
+		if err := starlark.UnpackPositionalArgs(funcName, args, kwargs, 1, &path); err != nil {
+			return nil, err
+		}
+
+		entries, err := fs.ReadDir(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+
+		var starlarkEntries []starlark.Value
+		for _, entry := range entries {
+			starlarkEntries = append(starlarkEntries, starlark.String(entry))
+		}
+
+		return starlark.NewList(starlarkEntries), nil
+	})
+}

--- a/pkg/larker/builtin/fs.go
+++ b/pkg/larker/builtin/fs.go
@@ -49,6 +49,10 @@ func read(ctx context.Context, fs fs.FileSystem) starlark.Value {
 
 		fileBytes, err := fs.Get(ctx, path)
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return starlark.None, nil
+			}
+
 			return nil, err
 		}
 
@@ -67,6 +71,10 @@ func readdir(ctx context.Context, fs fs.FileSystem) starlark.Value {
 
 		entries, err := fs.ReadDir(ctx, path)
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return starlark.None, nil
+			}
+
 			return nil, err
 		}
 

--- a/pkg/larker/fs/dummy/dummy.go
+++ b/pkg/larker/fs/dummy/dummy.go
@@ -12,7 +12,7 @@ func New() *Dummy {
 	return &Dummy{}
 }
 
-func (dfs *Dummy) Stat(ctx context.Context, path string) (fs.FileInfo, error) {
+func (dfs *Dummy) Stat(ctx context.Context, path string) (*fs.FileInfo, error) {
 	return nil, os.ErrNotExist
 }
 

--- a/pkg/larker/fs/dummy/dummy.go
+++ b/pkg/larker/fs/dummy/dummy.go
@@ -2,6 +2,7 @@ package dummy
 
 import (
 	"context"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"os"
 )
 
@@ -11,6 +12,14 @@ func New() *Dummy {
 	return &Dummy{}
 }
 
+func (dfs *Dummy) Stat(ctx context.Context, path string) (fs.FileInfo, error) {
+	return nil, os.ErrNotExist
+}
+
 func (dfs *Dummy) Get(ctx context.Context, path string) ([]byte, error) {
+	return nil, os.ErrNotExist
+}
+
+func (dfs *Dummy) ReadDir(ctx context.Context, path string) ([]string, error) {
 	return nil, os.ErrNotExist
 }

--- a/pkg/larker/fs/fs.go
+++ b/pkg/larker/fs/fs.go
@@ -5,11 +5,11 @@ import (
 )
 
 type FileSystem interface {
-	Stat(ctx context.Context, path string) (FileInfo, error)
+	Stat(ctx context.Context, path string) (*FileInfo, error)
 	Get(ctx context.Context, path string) ([]byte, error)
 	ReadDir(ctx context.Context, path string) ([]string, error)
 }
 
-type FileInfo interface {
-	IsDir() bool
+type FileInfo struct {
+	IsDir bool
 }

--- a/pkg/larker/fs/fs.go
+++ b/pkg/larker/fs/fs.go
@@ -5,5 +5,11 @@ import (
 )
 
 type FileSystem interface {
+	Stat(ctx context.Context, path string) (FileInfo, error)
 	Get(ctx context.Context, path string) ([]byte, error)
+	ReadDir(ctx context.Context, path string) ([]string, error)
+}
+
+type FileInfo interface {
+	IsDir() bool
 }

--- a/pkg/larker/fs/github/github.go
+++ b/pkg/larker/fs/github/github.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
 	"net/http"
@@ -21,6 +22,12 @@ type GitHub struct {
 	reference string
 }
 
+type IsDir bool
+
+func (isDir IsDir) IsDir() bool {
+	return bool(isDir)
+}
+
 func New(owner, repo, reference, token string) *GitHub {
 	return &GitHub{
 		token:     token,
@@ -30,18 +37,23 @@ func New(owner, repo, reference, token string) *GitHub {
 	}
 }
 
-func (gh *GitHub) Get(ctx context.Context, path string) ([]byte, error) {
-	fileContent, _, resp, err := gh.client(ctx).Repositories.GetContents(ctx, gh.owner, gh.repo, path,
-		&github.RepositoryContentGetOptions{
-			Ref: gh.reference,
-		},
-	)
+func (gh *GitHub) Stat(ctx context.Context, path string) (fs.FileInfo, error) {
+	_, directoryContent, err := gh.getContentsWrapper(ctx, path)
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return nil, os.ErrNotExist
-		}
+		return nil, err
+	}
 
-		return nil, fmt.Errorf("%w: %v", ErrAPI, err)
+	if directoryContent != nil {
+		return IsDir(true), nil
+	}
+
+	return IsDir(false), nil
+}
+
+func (gh *GitHub) Get(ctx context.Context, path string) ([]byte, error) {
+	fileContent, _, err := gh.getContentsWrapper(ctx, path)
+	if err != nil {
+		return nil, err
 	}
 
 	// Simulate os.Read() behavior in case the supplied path points to a directory
@@ -57,6 +69,25 @@ func (gh *GitHub) Get(ctx context.Context, path string) ([]byte, error) {
 	return fileBytes, nil
 }
 
+func (gh *GitHub) ReadDir(ctx context.Context, path string) ([]string, error) {
+	_, directoryContent, err := gh.getContentsWrapper(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Simulate ioutil.ReadDir() behavior in case the supplied path points to a file
+	if directoryContent == nil {
+		return nil, syscall.ENOTDIR
+	}
+
+	var entries []string
+	for _, fileContent := range directoryContent {
+		entries = append(entries, *fileContent.Name)
+	}
+
+	return entries, nil
+}
+
 func (gh *GitHub) client(ctx context.Context) *github.Client {
 	var client *http.Client
 
@@ -68,4 +99,24 @@ func (gh *GitHub) client(ctx context.Context) *github.Client {
 	}
 
 	return github.NewClient(client)
+}
+
+func (gh *GitHub) getContentsWrapper(
+	ctx context.Context,
+	path string,
+) (*github.RepositoryContent, []*github.RepositoryContent, error) {
+	fileContent, directoryContent, resp, err := gh.client(ctx).Repositories.GetContents(ctx, gh.owner, gh.repo, path,
+		&github.RepositoryContentGetOptions{
+			Ref: gh.reference,
+		},
+	)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, nil, os.ErrNotExist
+		}
+
+		return nil, nil, fmt.Errorf("%w: %v", ErrAPI, err)
+	}
+
+	return fileContent, directoryContent, nil
 }

--- a/pkg/larker/fs/github/github.go
+++ b/pkg/larker/fs/github/github.go
@@ -22,12 +22,6 @@ type GitHub struct {
 	reference string
 }
 
-type IsDir bool
-
-func (isDir IsDir) IsDir() bool {
-	return bool(isDir)
-}
-
 func New(owner, repo, reference, token string) *GitHub {
 	return &GitHub{
 		token:     token,
@@ -37,17 +31,17 @@ func New(owner, repo, reference, token string) *GitHub {
 	}
 }
 
-func (gh *GitHub) Stat(ctx context.Context, path string) (fs.FileInfo, error) {
+func (gh *GitHub) Stat(ctx context.Context, path string) (*fs.FileInfo, error) {
 	_, directoryContent, err := gh.getContentsWrapper(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 
 	if directoryContent != nil {
-		return IsDir(true), nil
+		return &fs.FileInfo{IsDir: true}, nil
 	}
 
-	return IsDir(false), nil
+	return &fs.FileInfo{IsDir: false}, nil
 }
 
 func (gh *GitHub) Get(ctx context.Context, path string) ([]byte, error) {

--- a/pkg/larker/fs/github/github_test.go
+++ b/pkg/larker/fs/github/github_test.go
@@ -22,7 +22,7 @@ func TestStatFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.False(t, stat.IsDir())
+	assert.False(t, stat.IsDir)
 }
 
 func TestStatDirectory(t *testing.T) {
@@ -31,7 +31,7 @@ func TestStatDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.True(t, stat.IsDir())
+	assert.True(t, stat.IsDir)
 }
 
 func TestGetFile(t *testing.T) {

--- a/pkg/larker/fs/github/github_test.go
+++ b/pkg/larker/fs/github/github_test.go
@@ -16,6 +16,24 @@ func selfFS() fs.FileSystem {
 	return github.New("cirruslabs", "cirrus-cli", "master", "")
 }
 
+func TestStatFile(t *testing.T) {
+	stat, err := selfFS().Stat(context.Background(), "go.mod")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.False(t, stat.IsDir())
+}
+
+func TestStatDirectory(t *testing.T) {
+	stat, err := selfFS().Stat(context.Background(), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, stat.IsDir())
+}
+
 func TestGetFile(t *testing.T) {
 	fileBytes, err := selfFS().Get(context.Background(), "go.mod")
 	if err != nil {
@@ -34,6 +52,29 @@ func TestGetDirectory(t *testing.T) {
 
 func TestGetNonExistentFile(t *testing.T) {
 	_, err := selfFS().Get(context.Background(), "the-file-that-should-not-exist.txt")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+}
+
+func TestReadDirFile(t *testing.T) {
+	_, err := selfFS().ReadDir(context.Background(), "go.mod")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, syscall.ENOTDIR))
+}
+
+func TestReadDirDirectory(t *testing.T) {
+	entries, err := selfFS().ReadDir(context.Background(), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, entries, "go.mod", "go.sum")
+}
+
+func TestReadDirNonExistentDirectory(t *testing.T) {
+	_, err := selfFS().ReadDir(context.Background(), "the-directory-that-should-not-exist")
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, os.ErrNotExist))

--- a/pkg/larker/fs/local/local.go
+++ b/pkg/larker/fs/local/local.go
@@ -18,8 +18,13 @@ func New(root string) *Local {
 	}
 }
 
-func (lfs *Local) Stat(ctx context.Context, path string) (fs.FileInfo, error) {
-	return os.Stat(lfs.pivot(path))
+func (lfs *Local) Stat(ctx context.Context, path string) (*fs.FileInfo, error) {
+	fileInfo, err := os.Stat(lfs.pivot(path))
+	if err != nil {
+		return nil, err
+	}
+
+	return &fs.FileInfo{IsDir: fileInfo.IsDir()}, nil
 }
 
 func (lfs *Local) Get(ctx context.Context, path string) ([]byte, error) {

--- a/pkg/larker/fs/local/local.go
+++ b/pkg/larker/fs/local/local.go
@@ -2,7 +2,9 @@ package local
 
 import (
 	"context"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -16,11 +18,33 @@ func New(root string) *Local {
 	}
 }
 
+func (lfs *Local) Stat(ctx context.Context, path string) (fs.FileInfo, error) {
+	return os.Stat(lfs.pivot(path))
+}
+
 func (lfs *Local) Get(ctx context.Context, path string) ([]byte, error) {
 	// To make Starlark scripts cross-platform, load statements are expected to always use slashes,
 	// but to actually make this work on non-Unix platforms we need to adapt the path
 	// to the current platform
 	adaptedPath := filepath.FromSlash(path)
 
-	return ioutil.ReadFile(filepath.Join(lfs.root, adaptedPath))
+	return ioutil.ReadFile(lfs.pivot(adaptedPath))
+}
+
+func (lfs *Local) ReadDir(ctx context.Context, path string) ([]string, error) {
+	fileInfos, err := ioutil.ReadDir(lfs.pivot(path))
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, fileInfo := range fileInfos {
+		result = append(result, fileInfo.Name())
+	}
+
+	return result, nil
+}
+
+func (lfs *Local) pivot(path string) string {
+	return filepath.Join(lfs.root, path)
 }

--- a/pkg/larker/fs/local/local_test.go
+++ b/pkg/larker/fs/local/local_test.go
@@ -14,9 +14,38 @@ import (
 	"testing"
 )
 
+func TestStatFile(t *testing.T) {
+	// Prepare temporary directory
+	dir := testutil.TempDir(t)
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "some-file.txt"), []byte("some-contents"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stat, err := local.New(dir).Stat(context.Background(), "some-file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.False(t, stat.IsDir())
+}
+
+func TestStatDirectory(t *testing.T) {
+	// Prepare temporary directory
+	dir := testutil.TempDir(t)
+
+	stat, err := local.New(dir).Stat(context.Background(), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, stat.IsDir())
+}
+
 func TestGetFile(t *testing.T) {
 	// Prepare temporary directory
 	dir := testutil.TempDir(t)
+
 	if err := ioutil.WriteFile(filepath.Join(dir, "some-file.txt"), []byte("some-contents"), 0600); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/larker/fs/local/local_test.go
+++ b/pkg/larker/fs/local/local_test.go
@@ -27,7 +27,7 @@ func TestStatFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.False(t, stat.IsDir())
+	assert.False(t, stat.IsDir)
 }
 
 func TestStatDirectory(t *testing.T) {
@@ -39,7 +39,7 @@ func TestStatDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.True(t, stat.IsDir())
+	assert.True(t, stat.IsDir)
 }
 
 func TestGetFile(t *testing.T) {

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -155,3 +155,21 @@ func TestLoadTypoStarVsStart(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "instead of the .start?")
 }
+
+// TestBuiltinFS ensures that filesystem-related builtins provided by the cirrus.fs module work correctly.
+func TestBuiltinFS(t *testing.T) {
+	dir := testutil.TempDirPopulatedWith(t, "testdata/builtin-fs")
+
+	// Read the source code
+	source, err := ioutil.ReadFile(filepath.Join(dir, ".cirrus.star"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the source code
+	lrk := larker.New(larker.WithFileSystem(local.New(dir)))
+	_, err = lrk.Main(context.Background(), string(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/larker/loader/loader.go
+++ b/pkg/larker/loader/loader.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/builtin"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/loader/git"
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,6 +61,16 @@ func (loader *Loader) LoadFunc() func(thread *starlark.Thread, module string) (s
 
 			// Return cached results
 			return entry.globals, entry.err
+		}
+
+		// A special case for loading Cirrus-provided builtins (e.g. load("cirrus", "fs"))
+		if module == "cirrus" {
+			return starlark.StringDict{
+				"fs": &starlarkstruct.Module{
+					Name:    "fs",
+					Members: builtin.FS(loader.ctx, loader.fs),
+				},
+			}, nil
 		}
 
 		// Retrieve module source code

--- a/pkg/larker/testdata/builtin-fs/.cirrus.star
+++ b/pkg/larker/testdata/builtin-fs/.cirrus.star
@@ -16,7 +16,7 @@ def test_exists():
 
     shouldNotExist = "exists-should-not-exist.txt"
     if fs.exists(shouldNotExist):
-        fail("%s exists, but shouldn't" % shouldNotExist)
+        fail("file %s should not exist" % shouldNotExist)
 
     if not fs.exists("."):
         fail("current directory does not exist, but should")
@@ -28,6 +28,10 @@ def test_read():
     if expectedContents != actualContents:
         fail("%s contains '%s' instead of '%s'" % (someFile, actualContents, expectedContents))
 
+    shouldNotExist = "read-should-not-exist.txt"
+    if fs.read(shouldNotExist) != None:
+        fail("non-existent file %s should not be readable" % shouldNotExist)
+
 def test_readdir():
     expectedFiles = [
         ".cirrus.star",
@@ -38,3 +42,7 @@ def test_readdir():
 
     if expectedFiles != actualFiles:
         fail("directory contains %s instead of %s" % (expectedFiles, actualFiles))
+
+    shouldNotExist = "readdir-should-not-exist"
+    if fs.readdir(shouldNotExist) != None:
+        fail("non-existent directory %s should not be readable" % shouldNotExist)

--- a/pkg/larker/testdata/builtin-fs/.cirrus.star
+++ b/pkg/larker/testdata/builtin-fs/.cirrus.star
@@ -1,0 +1,40 @@
+load("cirrus", "fs")
+
+shouldExist = "exists-should-exist.txt"
+someFile = "read-some-file.txt"
+
+def main(ctx):
+    test_exists()
+    test_read()
+    test_readdir()
+
+    return []
+
+def test_exists():
+    if not fs.exists(shouldExist):
+        fail("%s does not exist, but should" % shouldExist)
+
+    shouldNotExist = "exists-should-not-exist.txt"
+    if fs.exists(shouldNotExist):
+        fail("%s exists, but shouldn't" % shouldNotExist)
+
+    if not fs.exists("."):
+        fail("current directory does not exist, but should")
+
+def test_read():
+    expectedContents = "some-contents\n"
+    actualContents = fs.read(someFile)
+
+    if expectedContents != actualContents:
+        fail("%s contains '%s' instead of '%s'" % (someFile, actualContents, expectedContents))
+
+def test_readdir():
+    expectedFiles = [
+        ".cirrus.star",
+        shouldExist,
+        someFile,
+    ]
+    actualFiles = fs.readdir(".")
+
+    if expectedFiles != actualFiles:
+        fail("directory contains %s instead of %s" % (expectedFiles, actualFiles))

--- a/pkg/larker/testdata/builtin-fs/read-some-file.txt
+++ b/pkg/larker/testdata/builtin-fs/read-some-file.txt
@@ -1,0 +1,1 @@
+some-contents


### PR DESCRIPTION
See #53.

Example use-case:

```python
load("cirrus", "fs")

def main(ctx):
    tasks = base_tasks()

    if fs.exists(".goreleaser.yml"):
        tasks += goreleaser_tasks()

    return tasks
```

What I don't particularly like at the moment is how we handle the lack of exceptions, e.g. `fs.readdir()` on a non-directory will result in non-recoverable error. The question is: is it actually that bad as it sounds?