### PR TITLE
.goreleaser.yml: build and publish Docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,10 @@ brews:
     homepage: https://github.com/cirruslabs/cirrus-cli
     description: CLI for running Cirrus Tasks locally in Docker containers
     skip_upload: auto
+
+dockers:
+  - image_templates:
+      - "ghcr.io/cirruslabs/cirrus-cli:{{ .Version }}"
+    goos: linux
+    goarch: amd64
+    skip_push: auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+COPY cirrus /usr/local/bin/cirrus
+
+ENTRYPOINT ["/usr/local/bin/cirrus"]


### PR DESCRIPTION
An attempt to achieve #97 without using GitHub Actions.