### PR TITLE
Share executor's base and user environment variables with Starlark

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -218,7 +218,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Environment
-	executorOpts = append(executorOpts, executor.WithEnvironment(envMap))
+	executorOpts = append(executorOpts, executor.WithUserSpecifiedEnvironment(envMap))
 
 	// Run
 	e, err := executor.New(".", result.Tasks, executorOpts...)

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/commands"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"
@@ -160,7 +161,12 @@ func TestRunEnvironmentStarlark(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	commitHash, err := worktree.Commit("0.1.0 release", &git.CommitOptions{})
+	commitHash, err := worktree.Commit("0.1.0 release", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Charlie Root",
+			Email: "root@localhost",
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/commands/testdata/run-environment-starlark/.cirrus.star
+++ b/internal/commands/testdata/run-environment-starlark/.cirrus.star
@@ -1,0 +1,25 @@
+load("cirrus", "env")
+
+def main(ctx):
+    # Check that at least one base variable is present and has expected value
+    variable_name = "CIRRUS_TAG"
+    actual_value = env.get("CIRRUS_TAG")
+    expected_value = "v0.1.0"
+    if actual_value != expected_value:
+        fail("expected %s variable to be %s, but got %s instead" % (variable_name, expected_value, actual_value))
+
+    # Check that user variable is present and has expected value
+    variable_name = "USER_VARIABLE"
+    actual_value = env.get("USER_VARIABLE")
+    expected_value = "user variable value"
+    if actual_value != expected_value:
+        fail("expected %s variable to be %s, but got %s instead" % (variable_name, expected_value, actual_value))
+
+    # Return dummy configuration
+    return [
+        {
+            "container": {
+                "image": "debian:latest",
+            },
+        },
+    ]

--- a/internal/executor/environment/environment.go
+++ b/internal/executor/environment/environment.go
@@ -32,10 +32,14 @@ func Copy(env map[string]string) (result map[string]string) {
 	return
 }
 
-func Static() map[string]string {
+func ContainerSpecific() map[string]string {
 	return map[string]string{
 		"CIRRUS_WORKING_DIR": path.Join(instance.WorkingVolumeMountpoint, instance.WorkingVolumeWorkingDir),
+	}
+}
 
+func Static() map[string]string {
+	return map[string]string{
 		"CI":                     "true",
 		"CONTINUOUS_INTEGRATION": "true",
 		"CIRRUS_CI":              "true",

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -34,7 +34,12 @@ type Executor struct {
 
 func New(projectDir string, tasks []*api.Task, opts ...Option) (*Executor, error) {
 	e := &Executor{
-		taskFilter:               taskfilter.MatchAnyTask(),
+		taskFilter: taskfilter.MatchAnyTask(),
+		baseEnvironment: environment.Merge(
+			environment.Static(),
+			environment.BuildID(),
+			environment.ProjectSpecific(projectDir),
+		),
 		userSpecifiedEnvironment: make(map[string]string),
 	}
 
@@ -47,13 +52,6 @@ func New(projectDir string, tasks []*api.Task, opts ...Option) (*Executor, error
 	if e.logger == nil {
 		renderer := renderers.NewSimpleRenderer(ioutil.Discard, nil)
 		e.logger = echelon.NewLogger(echelon.InfoLevel, renderer)
-	}
-	if e.baseEnvironment == nil {
-		e.baseEnvironment = environment.Merge(
-			environment.Static(),
-			environment.BuildID(),
-			environment.ProjectSpecific(projectDir),
-		)
 	}
 
 	// Filter tasks (e.g. if a user wants to run only a specific task without dependencies)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -52,7 +52,11 @@ func New(projectDir string, tasks []*api.Task, opts ...Option) (*Executor, error
 	tasks = e.taskFilter(tasks)
 
 	// Enrich task environments
-	commonToAllTasks := environment.Merge(environment.Static(), environment.BuildID())
+	commonToAllTasks := environment.Merge(
+		environment.Static(),
+		environment.BuildID(),
+		environment.ProjectSpecific(projectDir),
+	)
 	for _, task := range tasks {
 		task.Environment = environment.Merge(
 			// Lowest priority

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -61,6 +61,7 @@ func New(projectDir string, tasks []*api.Task, opts ...Option) (*Executor, error
 		task.Environment = environment.Merge(
 			// Lowest priority
 			commonToAllTasks,
+			environment.ContainerSpecific(),
 			environment.NodeInfo(task.LocalGroupId, int64(len(tasks))),
 			environment.TaskInfo(task.Name, task.LocalGroupId),
 

--- a/internal/executor/options.go
+++ b/internal/executor/options.go
@@ -20,7 +20,7 @@ func WithTaskFilter(taskFilter taskfilter.TaskFilter) Option {
 	}
 }
 
-func WithEnvironment(environment map[string]string) Option {
+func WithUserSpecifiedEnvironment(environment map[string]string) Option {
 	return func(e *Executor) {
 		e.userSpecifiedEnvironment = environment
 	}

--- a/internal/executor/options.go
+++ b/internal/executor/options.go
@@ -20,6 +20,12 @@ func WithTaskFilter(taskFilter taskfilter.TaskFilter) Option {
 	}
 }
 
+func WithBaseEnvironmentOverride(environment map[string]string) Option {
+	return func(e *Executor) {
+		e.baseEnvironment = environment
+	}
+}
+
 func WithUserSpecifiedEnvironment(environment map[string]string) Option {
 	return func(e *Executor) {
 		e.userSpecifiedEnvironment = environment


### PR DESCRIPTION
Also inject project-specific environment variables into the executor, which was not done previously for some reason.