### PR TITLE
Generic Proto Instance Parser

### DIFF
--- a/pkg/parser/instance/additionalcontainer.go
+++ b/pkg/parser/instance/additionalcontainer.go
@@ -93,6 +93,32 @@ func NewAdditionalContainer(mergedEnv map[string]string) *AdditionalContainer {
 		return nil
 	})
 
+	ac.OptionalField(nameable.NewSimpleNameable("cpu"), schema.TodoSchema, func(node *node.Node) error {
+		cpu, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+		cpuFloat, err := strconv.ParseFloat(cpu, 32)
+		if err != nil {
+			return err
+		}
+		ac.proto.Cpu = float32(cpuFloat)
+		return nil
+	})
+
+	ac.OptionalField(nameable.NewSimpleNameable("memory"), schema.TodoSchema, func(node *node.Node) error {
+		memory, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+		memoryParsed, err := ParseMegaBytes(memory)
+		if err != nil {
+			return err
+		}
+		ac.proto.Memory = uint32(memoryParsed)
+		return nil
+	})
+
 	return ac
 }
 

--- a/pkg/parser/instance/container.go
+++ b/pkg/parser/instance/container.go
@@ -75,7 +75,7 @@ func NewCommunityContainer(mergedEnv map[string]string) *Container {
 		if err != nil {
 			return err
 		}
-		container.proto.Memory = memoryParsed
+		container.proto.Memory = uint32(memoryParsed)
 		return nil
 	})
 

--- a/pkg/parser/instance/proto.go
+++ b/pkg/parser/instance/proto.go
@@ -1,0 +1,206 @@
+package instance
+
+import (
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/nameable"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parseable"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/schema"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+	"strconv"
+	"strings"
+)
+
+type ProtoInstance struct {
+	proto *dynamicpb.Message
+
+	parseable.DefaultParser
+}
+
+//nolint:gocognit // it's a parser, there is a lot of boilerplate
+func NewProtoParser(desc protoreflect.MessageDescriptor, mergedEnv map[string]string) *ProtoInstance {
+	instance := &ProtoInstance{
+		proto: dynamicpb.NewMessage(desc),
+	}
+
+	fields := desc.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		fieldName := string(field.Name())
+		switch field.Kind() {
+		case protoreflect.MessageKind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				if field.IsMap() {
+					fieldInstance := instance.proto.NewField(field)
+					mapping, err := node.GetStringMapping()
+					if err != nil {
+						return err
+					}
+					for key, value := range mapping {
+						fieldInstance.Map().Set(
+							protoreflect.ValueOfString(key).MapKey(),
+							protoreflect.ValueOfString(value),
+						)
+					}
+					instance.proto.Set(field, fieldInstance)
+					return nil
+				} else if field.IsList() {
+					fieldInstance := instance.proto.NewField(field)
+					for _, child := range node.Children {
+						childParser := NewProtoParser(field.Message(), mergedEnv)
+						parserChild, err := childParser.Parse(child)
+						if err != nil {
+							return err
+						}
+						fieldInstance.List().Append(protoreflect.ValueOfMessage(parserChild))
+					}
+					instance.proto.Set(field, fieldInstance)
+					return nil
+				} else {
+					childParser := NewProtoParser(field.Message(), mergedEnv)
+					parserChild, err := childParser.Parse(node)
+					if err != nil {
+						return err
+					}
+					instance.proto.Set(field, protoreflect.ValueOfMessage(parserChild))
+					return nil
+				}
+			})
+		case protoreflect.EnumKind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				value, err := node.GetExpandedStringValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				enumValueDescriptor := field.Enum().Values().ByName(protoreflect.Name(strings.ToUpper(value)))
+				instance.proto.Set(field, protoreflect.ValueOfEnum(enumValueDescriptor.Number()))
+				return nil
+			})
+		case protoreflect.StringKind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				value, err := node.GetExpandedStringValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				instance.proto.Set(field, protoreflect.ValueOfString(value))
+				return nil
+			})
+		case protoreflect.Int64Kind, protoreflect.Sint64Kind,
+			protoreflect.Fixed64Kind, protoreflect.Sfixed64Kind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				value, err := node.GetExpandedStringValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				var parsedValue int64
+				if strings.EqualFold(fieldName, "memory") {
+					parsedValue, err = ParseMegaBytes(value)
+				} else {
+					parsedValue, err = strconv.ParseInt(value, 10, 64)
+				}
+				if err != nil {
+					return err
+				}
+				instance.proto.Set(field, protoreflect.ValueOfInt64(parsedValue))
+				return nil
+			})
+		case protoreflect.Uint64Kind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				value, err := node.GetExpandedStringValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				var parsedValue int64
+				if strings.EqualFold(fieldName, "memory") {
+					parsedValue, err = ParseMegaBytes(value)
+				} else {
+					parsedValue, err = strconv.ParseInt(value, 10, 64)
+				}
+				if err != nil {
+					return err
+				}
+				instance.proto.Set(field, protoreflect.ValueOfUint64(uint64(parsedValue)))
+				return nil
+			})
+		case protoreflect.Int32Kind, protoreflect.Sint32Kind,
+			protoreflect.Fixed32Kind, protoreflect.Sfixed32Kind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				value, err := node.GetExpandedStringValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				parsedValue, err := strconv.ParseInt(value, 10, 32)
+				if strings.EqualFold(fieldName, "memory") {
+					parsedValue, err = ParseMegaBytes(value)
+				}
+				if err != nil {
+					return err
+				}
+				instance.proto.Set(field, protoreflect.ValueOfInt32(int32(parsedValue)))
+				return nil
+			})
+		case protoreflect.Uint32Kind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				value, err := node.GetExpandedStringValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				parsedValue, err := strconv.ParseInt(value, 10, 32)
+				if strings.EqualFold(fieldName, "memory") {
+					parsedValue, err = ParseMegaBytes(value)
+				}
+				if err != nil {
+					return err
+				}
+				instance.proto.Set(field, protoreflect.ValueOfUint32(uint32(parsedValue)))
+				return nil
+			})
+		case protoreflect.BoolKind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				evaluation, err := node.GetBoolValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				instance.proto.Set(field, protoreflect.ValueOfBool(evaluation))
+				return nil
+			})
+		case protoreflect.FloatKind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				value, err := node.GetExpandedStringValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				parsedValue, err := strconv.ParseFloat(value, 32)
+				if err != nil {
+					return err
+				}
+				instance.proto.Set(field, protoreflect.ValueOfFloat32(float32(parsedValue)))
+				return nil
+			})
+		case protoreflect.DoubleKind:
+			instance.OptionalField(nameable.NewSimpleNameable(fieldName), schema.TodoSchema, func(node *node.Node) error {
+				value, err := node.GetExpandedStringValue(mergedEnv)
+				if err != nil {
+					return err
+				}
+				parsedValue, err := strconv.ParseFloat(value, 64)
+				if err != nil {
+					return err
+				}
+				instance.proto.Set(field, protoreflect.ValueOfFloat64(parsedValue))
+				return nil
+			})
+		case protoreflect.GroupKind, protoreflect.BytesKind:
+			// not supported
+		}
+	}
+
+	return instance
+}
+
+func (p *ProtoInstance) Parse(node *node.Node) (*dynamicpb.Message, error) {
+	if err := p.DefaultParser.Parse(node); err != nil {
+		return nil, err
+	}
+	return p.proto, nil
+}

--- a/pkg/parser/instance/resources.go
+++ b/pkg/parser/instance/resources.go
@@ -13,7 +13,7 @@ const (
 	kibi                    = 1024
 )
 
-func ParseMegaBytes(s string) (uint32, error) {
+func ParseMegaBytes(s string) (int64, error) {
 	// Split the string into two parts
 	sLower := strings.ToLower(s)
 	cutAfter := strings.LastIndexFunc(sLower, unicode.IsDigit)
@@ -21,11 +21,10 @@ func ParseMegaBytes(s string) (uint32, error) {
 	suffixPart := sLower[cutAfter+1:]
 
 	// Parse the digits part
-	memory, err := strconv.ParseUint(digitsPart, 10, 32)
+	memoryResult, err := strconv.ParseUint(digitsPart, 10, 32)
 	if err != nil {
 		return 0, err
 	}
-	memoryResult := uint32(memory)
 
 	// Modify the digits part depending on the suffix part
 	switch suffixPart {
@@ -50,5 +49,5 @@ func ParseMegaBytes(s string) (uint32, error) {
 		return 0, fmt.Errorf("%w: unsupported digital information unit suffix: '%s'", parsererror.ErrParsing, suffixPart)
 	}
 
-	return memoryResult, nil
+	return int64(memoryResult), nil
 }

--- a/pkg/parser/instance/resources_test.go
+++ b/pkg/parser/instance/resources_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func parseMegaBytesHelper(t *testing.T, s string) uint32 {
+func parseMegaBytesHelper(t *testing.T, s string) int64 {
 	result, err := instance.ParseMegaBytes(s)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/parser/node/accessor.go
+++ b/pkg/parser/node/accessor.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"fmt"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/boolevator"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/parsererror"
 	"sort"
 	"strings"
@@ -14,6 +15,20 @@ func (node *Node) GetStringValue() (string, error) {
 	}
 
 	return valueNode.Value, nil
+}
+
+func (node *Node) GetBoolValue(env map[string]string) (bool, error) {
+	expression, err := node.GetStringValue()
+	if err != nil {
+		return false, err
+	}
+
+	evaluation, err := boolevator.Eval(expression, env, nil)
+	if err != nil {
+		return false, err
+	}
+
+	return evaluation, nil
 }
 
 func (node *Node) GetExpandedStringValue(env map[string]string) (string, error) {

--- a/pkg/parser/options.go
+++ b/pkg/parser/options.go
@@ -1,9 +1,19 @@
 package parser
 
+import (
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
 type Option func(*Parser)
 
 func WithEnvironment(environment map[string]string) Option {
 	return func(parser *Parser) {
 		parser.environment = environment
+	}
+}
+
+func WithAdditionalInstances(additionalInstances map[string]protoreflect.MessageDescriptor) Option {
+	return func(parser *Parser) {
+		parser.additionalInstances = additionalInstances
 	}
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/lestrrat-go/jsschema"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
@@ -33,8 +34,9 @@ type Parser struct {
 	// Paths and contents of the files that might influence the parser.
 	filesContents map[string]string
 
-	parsers   map[nameable.Nameable]parseable.Parseable
-	numbering int64
+	parsers             map[nameable.Nameable]parseable.Parseable
+	numbering           int64
+	additionalInstances map[string]protoreflect.MessageDescriptor
 }
 
 type Result struct {
@@ -70,7 +72,7 @@ func (p *Parser) parseTasks(tree *node.Node) ([]task.ParseableTaskLike, error) {
 			var taskLike task.ParseableTaskLike
 			switch value.(type) {
 			case *task.Task:
-				taskLike = task.NewTask(environment.Copy(p.environment))
+				taskLike = task.NewTask(environment.Copy(p.environment), p.additionalInstances)
 			case *task.DockerPipe:
 				taskLike = task.NewDockerPipe(environment.Copy(p.environment))
 			default:

--- a/pkg/parser/task/command.go
+++ b/pkg/parser/task/command.go
@@ -61,7 +61,7 @@ func NewCacheCommand(mergedEnv map[string]string) *CacheCommand {
 	})
 
 	cache.OptionalField(nameable.NewSimpleNameable("reupload_on_changes"), schema.TodoSchema, func(node *node.Node) error {
-		evaluation, err := handleBoolevatorField(node, mergedEnv)
+		evaluation, err := node.GetBoolValue(mergedEnv)
 		if err != nil {
 			return err
 		}

--- a/pkg/parser/task/handler.go
+++ b/pkg/parser/task/handler.go
@@ -2,25 +2,10 @@ package task
 
 import (
 	"github.com/cirruslabs/cirrus-ci-agent/api"
-	"github.com/cirruslabs/cirrus-cli/pkg/parser/boolevator"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/nameable"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"strconv"
 )
-
-func handleBoolevatorField(node *node.Node, mergedEnv map[string]string) (bool, error) {
-	onlyIfExpression, err := node.GetStringValue()
-	if err != nil {
-		return false, err
-	}
-
-	evaluation, err := boolevator.Eval(onlyIfExpression, mergedEnv, nil)
-	if err != nil {
-		return false, err
-	}
-
-	return evaluation, nil
-}
 
 func handleBackgroundScript(node *node.Node, nameable *nameable.RegexNameable) (*api.Command, error) {
 	scripts, err := node.GetSliceOfNonEmptyStrings()

--- a/pkg/parser/task/pipe.go
+++ b/pkg/parser/task/pipe.go
@@ -76,7 +76,7 @@ func NewDockerPipe(env map[string]string) *DockerPipe {
 		return nil
 	})
 	pipe.OptionalField(nameable.NewSimpleNameable("allow_failures"), schema.TodoSchema, func(node *node.Node) error {
-		evaluation, err := handleBoolevatorField(node, environment.Merge(pipe.proto.Environment, env))
+		evaluation, err := node.GetBoolValue(environment.Merge(pipe.proto.Environment, env))
 		if err != nil {
 			return err
 		}

--- a/pkg/parser/testdata/proto-instance.json
+++ b/pkg/parser/testdata/proto-instance.json
@@ -1,0 +1,75 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      }
+    ],
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "additionalContainers": [
+        {
+          "cpu": 1,
+          "environment": {
+            "MYSQL_ROOT_PASSWORD": ""
+          },
+          "image": "mysql:latest",
+          "memory": 1024,
+          "name": "mysql"
+        }
+      ],
+      "cpu": 2.5,
+      "image": "alpine:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allowFailures": "false",
+        "executionLock": "null",
+        "experimentalFeaturesEnabled": "false",
+        "indexWithinBuild": "0",
+        "timeoutInSeconds": "3600",
+        "triggerType": "AUTOMATIC"
+      }
+    },
+    "name": "regular"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      }
+    ],
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "additionalContainers": [
+        {
+          "cpu": 1,
+          "environment": {
+            "MYSQL_ROOT_PASSWORD": ""
+          },
+          "image": "mysql:latest",
+          "memory": 1024,
+          "name": "mysql"
+        }
+      ],
+      "cpu": 2.5,
+      "image": "alpine:latest",
+      "memory": 4096
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allowFailures": "false",
+        "executionLock": "null",
+        "experimentalFeaturesEnabled": "false",
+        "indexWithinBuild": "1",
+        "timeoutInSeconds": "3600",
+        "triggerType": "AUTOMATIC"
+      }
+    },
+    "name": "proto"
+  }
+]

--- a/pkg/parser/testdata/proto-instance.yml
+++ b/pkg/parser/testdata/proto-instance.yml
@@ -1,0 +1,20 @@
+aliases: &container_body
+  image: alpine:latest
+  platform: linux
+  cpu: 2.5
+  memory: 4G
+  additional_containers:
+    - name: mysql
+      image: mysql:latest
+      cpu: 1
+      memory: 1024
+      environment:
+        MYSQL_ROOT_PASSWORD: ""
+
+regular_task:
+  container:
+    <<: *container_body
+
+proto_task:
+  proto_container:
+    <<: *container_body


### PR DESCRIPTION
This an implementation of a parser that can take a type descriptor (basically a serializable definition) and parse it back into a proto message. This is need for the future of the CLI when it will be able to act a service for evaluating of the YAML and Starlark configs for the Cirrus Cloud. `EvaluateConfigRequest` will need to be modified: `AdditionalInstancesInfo` will be added.

```protobuf
message EvaluateConfigRequest {
  message AdditionalInstancesInfo {
    map<string, string> instances = 1; // field name to proto FQN
    google.protobuf.FileDescriptorSet descriptor = 2;
  }

  string yaml_config = 1;
  string starlark_config = 2;
  map<string, string> environment = 3;
  repeated string affected_files = 4;
  map<string, string> files_contents = 5;
  AdditionalInstancesInfo additional_instances_info = 6;
}
```