### PR TITLE
Fallback to connector mode in case we fail to bind to Docker's bridge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/PaesslerAG/gval v1.1.0
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
-	github.com/cirruslabs/cirrus-ci-agent v1.11.0
+	github.com/cirruslabs/cirrus-ci-agent v1.11.1-0.20201006195014-51add510c4b5
 	github.com/cirruslabs/echelon v1.3.0
 	github.com/containerd/containerd v1.4.0 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible
-	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.1.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cirruslabs/cirrus-ci-agent v1.11.0 h1:PlupgllTldtR8fI6KJHPg/n0QG1f0tWxXjdUU2eZwaU=
-github.com/cirruslabs/cirrus-ci-agent v1.11.0/go.mod h1:r+XDZvxP39UaEPrW9u/xPECglHVJdc/iqo1g69kAtD4=
+github.com/cirruslabs/cirrus-ci-agent v1.11.1-0.20201006195014-51add510c4b5 h1:jhgzTXAPgwNtQK9xc6oq92RDNildD2cANSudjMXmmFU=
+github.com/cirruslabs/cirrus-ci-agent v1.11.1-0.20201006195014-51add510c4b5/go.mod h1:r+XDZvxP39UaEPrW9u/xPECglHVJdc/iqo1g69kAtD4=
 github.com/cirruslabs/cirrus-ci-annotations v0.0.0-20200908203753-b813f63941d7/go.mod h1:98qD7HLlBx5aNqWiCH80OTTqTTsbXT69wxnlnrnoL0E=
 github.com/cirruslabs/echelon v1.3.0 h1:tWz5i4IFJa8AZbtoqeIurb+NE+DApsLAeOA2n0dCVMI=
 github.com/cirruslabs/echelon v1.3.0/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -119,6 +119,7 @@ func (e *Executor) Run(ctx context.Context) error {
 		instanceRunOpts := instance.RunConfig{
 			ProjectDir:    e.build.ProjectDir,
 			Endpoint:      e.rpc.Endpoint(),
+			ConnectorMode: e.rpc.ConnectorMode(),
 			ServerSecret:  e.rpc.ServerSecret(),
 			ClientSecret:  e.rpc.ClientSecret(),
 			TaskID:        task.ID,

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -167,6 +167,13 @@ func (r *RPC) Start(ctx context.Context) error {
 
 		r.logger.Warnf("failed to assign Docker network bridge address %s (is Docker running?), switching to connector mode",
 			address)
+
+		address = "localhost:0"
+		listener, err = net.Listen("tcp", address)
+		if err != nil {
+			return fmt.Errorf("%w: failed to start RPC service on %s: %v", ErrRPCFailed, address, err)
+		}
+
 		r.connectorMode = true
 	}
 	r.listener = listener


### PR DESCRIPTION
This makes running on Google Cloud Build (#57) and similar configurations (when CLI is started inside of a container, but Docker is nevertheless available) possible and potentially fixes a lot of other corner cases when we fail to detect Docker's bridge IP properly.

Note that this requires two more things before this gets merged:

* proper go.mod reference to github.com/cirruslabs/cirrus-ci-agent
* proper AgentImage reference in volume.go