### PR TITLE
Prevent local filesystem traversal

### DIFF
--- a/STARLARK.md
+++ b/STARLARK.md
@@ -250,8 +250,6 @@ Cirrus CLI always uses HTTPS to fetch files from Git.
 
 While builtins provide functionality that is considered non-altering to the local system, there are some cases when this may not be enough:
 
-* `cirrus.fs` methods can traverse upwards the project root and read files and folders there
-
 * `cirrus.http` methods can access local services running on `127.0.0.1` or inside of LAN and potentially interact with the services running on these hosts in malicious ways
 
 It's recommended that you don't run Starlark scripts from potentially untrusted sources, similarly to how you probably wouldn't run build scripts from random repositories found on the internet.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/cirruslabs/cirrus-ci-agent v1.11.0
 	github.com/cirruslabs/echelon v1.3.0
 	github.com/containerd/containerd v1.4.0 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
+github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/commands/internal/test.go
+++ b/internal/commands/internal/test.go
@@ -54,7 +54,9 @@ func test(cmd *cobra.Command, args []string) error {
 		}
 
 		// Create Starlark executor and run .cirrus.star to generate the configuration
-		fs := local.New(testDir)
+		fs := local.New(".")
+		fs.Chdir(testDir)
+
 		lrk := larker.New(larker.WithFileSystem(fs))
 
 		sourceBytes, err := ioutil.ReadFile(filepath.Join(testDir, ".cirrus.star"))

--- a/pkg/larker/fs/local/local.go
+++ b/pkg/larker/fs/local/local.go
@@ -28,12 +28,7 @@ func (lfs *Local) Stat(ctx context.Context, path string) (*fs.FileInfo, error) {
 }
 
 func (lfs *Local) Get(ctx context.Context, path string) ([]byte, error) {
-	// To make Starlark scripts cross-platform, load statements are expected to always use slashes,
-	// but to actually make this work on non-Unix platforms we need to adapt the path
-	// to the current platform
-	adaptedPath := filepath.FromSlash(path)
-
-	return ioutil.ReadFile(lfs.pivot(adaptedPath))
+	return ioutil.ReadFile(lfs.pivot(path))
 }
 
 func (lfs *Local) ReadDir(ctx context.Context, path string) ([]string, error) {
@@ -51,5 +46,10 @@ func (lfs *Local) ReadDir(ctx context.Context, path string) ([]string, error) {
 }
 
 func (lfs *Local) pivot(path string) string {
-	return filepath.Join(lfs.root, path)
+	// To make Starlark scripts cross-platform, load statements are expected to always use slashes,
+	// but to actually make this work on non-Unix platforms we need to adapt the path
+	// to the current platform
+	adaptedPath := filepath.FromSlash(path)
+
+	return filepath.Join(lfs.root, adaptedPath)
 }

--- a/pkg/larker/fs/local/local_test.go
+++ b/pkg/larker/fs/local/local_test.go
@@ -77,3 +77,14 @@ func TestGetNonExistentFile(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, os.ErrNotExist))
 }
+
+func TestPivotNoDotDotBreakout(t *testing.T) {
+	lfs := local.New("/chroot")
+
+	pivotedPath, err := lfs.Pivot("../../../../etc/passwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "/chroot/etc/passwd", pivotedPath)
+}

--- a/pkg/larker/fs/local/local_test.go
+++ b/pkg/larker/fs/local/local_test.go
@@ -88,3 +88,16 @@ func TestPivotNoDotDotBreakout(t *testing.T) {
 
 	assert.Equal(t, "/chroot/etc/passwd", pivotedPath)
 }
+
+func TestChdir(t *testing.T) {
+	lfs := local.New("/tmp")
+
+	lfs.Chdir("working-directory")
+
+	pivotedPath, err := lfs.Pivot(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "/tmp/working-directory", pivotedPath)
+}


### PR DESCRIPTION
No need do document security pitfalls if we can avoid them.