### PR TITLE
Explicit Cloud Build Config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM goreleaser/goreleaser:latest as builder
 
+ENV GORELEASER_CURRENT_TAG=latest
+
 WORKDIR /build
 ADD . /build
 
-RUN goreleaser --skip-publish
+RUN goreleaser build --snapshot
 
 FROM alpine:latest
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/cirrus-cli/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/cirrus-ci-community/cirrus-cli:$TAG_NAME', '-t', 'gcr.io/cirrus-ci-community/cirrus-cli:latest', '.']
+images: ['gcr.io/cirrus-ci-community/cirrus-cli:$TAG_NAME', 'gcr.io/cirrus-ci-community/cirrus-cli:latest']


### PR DESCRIPTION
Config is similar to the agent repository.

Let's add an additional docker image location in gcr.io for easier integration with GCP service like Cloud Run.