### PR TITLE
Disable SELinux for service container and --dirty containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ cirrus run --environment CIRRUS_HTTP_CACHE_HOST=http-cache-host.internal:8080
 Cirrus CLI tries to run in different environments, but in some environments we choose to provide more usability at the cost of a few security trade-offs:
 
 * SELinux
-  * service container that copies the project directory into a per-task Docker volume using `rsync` always runs unconfined
   * task container runs unconfined only if the `--dirty` flag is used
+  * service container that copies the project directory into a per-task Docker volume using `rsync` always runs unconfined
 
 Please [open an issue](https://github.com/cirruslabs/cirrus-cli/issues/new) if your use-case requires a different approach.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ To start using your own HTTP caching server simply pass it's hostname as `CIRRUS
 cirrus run --environment CIRRUS_HTTP_CACHE_HOST=http-cache-host.internal:8080
 ```
 
+## Security
+
+Cirrus CLI tries to run in different environments, but in some environments we choose to provide more usability at the cost of a few security trade-offs:
+
+* SELinux
+  * service container that copies the project directory into a per-task Docker volume using `rsync` always runs unconfined
+  * task container runs unconfined only if the `--dirty` flag is used
+
+Please [open an issue](https://github.com/cirruslabs/cirrus-cli/issues/new) if your use-case requires a different approach.
+
 ## FAQ
 
 <details>

--- a/internal/executor/instance/instance.go
+++ b/internal/executor/instance/instance.go
@@ -184,6 +184,10 @@ func RunDockerizedAgent(ctx context.Context, config *RunConfig, params *Params) 
 			Source: config.ProjectDir,
 			Target: path.Join(WorkingVolumeMountpoint, WorkingVolumeWorkingDir),
 		})
+
+		// Disable SELinux confinement for this container, otherwise
+		// the agent might fail when accessing the project directory
+		hostConfig.SecurityOpt = []string{"label=disable"}
 	}
 
 	// In case the additional containers are used, tell the agent to wait for them

--- a/internal/executor/instance/volume.go
+++ b/internal/executor/instance/volume.go
@@ -121,6 +121,10 @@ func CreateWorkingVolume(
 			Target:   projectDirMountpoint,
 			ReadOnly: true,
 		})
+
+		// Disable SELinux confinement for this container, otherwise
+		// the rsync might fail when accessing the project directory
+		hostConfig.SecurityOpt = []string{"label=disable"}
 	}
 
 	cont, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, "")


### PR DESCRIPTION
Unfortunately, taking the least-privilege path by running the container with the current users context (using `--security-opt="label=user:USER"`) and other labels doesn't work, because the container filesystem seems to be already labeled with the container-specific labels, which prevents us from even running the entrypoint binary.

See #124.