### PR TITLE
Use Unix socket to communicate with the agent on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,10 @@ cirrus run --environment CIRRUS_HTTP_CACHE_HOST=http-cache-host.internal:8080
 
 ## Security
 
-Cirrus CLI tries to run in different environments, but in some environments we choose to provide more usability at the cost of a few security trade-offs:
+Cirrus CLI aims to run in different environments, but in some environments we choose to provide more usability at the cost of some security trade-offs:
 
 * SELinux
-  * task container runs unconfined only if the `--dirty` flag is used
-  * service container that copies the project directory into a per-task Docker volume using `rsync` always runs unconfined
+  * both the task container and the service container that copies the project directory into a per-task Docker volume using `rsync` run unconfined
 
 Please [open an issue](https://github.com/cirruslabs/cirrus-cli/issues/new) if your use-case requires a different approach.
 

--- a/internal/executor/heuristic/heuristic.go
+++ b/internal/executor/heuristic/heuristic.go
@@ -10,51 +10,6 @@ import (
 // https://cloud.google.com/cloud-build/docs/build-config#network
 const CloudBuildNetworkName = "cloudbuild"
 
-func getDockerBridgeInterface(ctx context.Context) string {
-	const assumedBridgeInterface = "docker0"
-
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		return assumedBridgeInterface
-	}
-	defer cli.Close()
-
-	network, err := cli.NetworkInspect(ctx, "bridge", types.NetworkInspectOptions{})
-	if err != nil {
-		return assumedBridgeInterface
-	}
-
-	bridgeInterface, ok := network.Options["com.docker.network.bridge.name"]
-	if !ok {
-		return assumedBridgeInterface
-	}
-
-	return bridgeInterface
-}
-
-func GetDockerBridgeIP(ctx context.Context) string {
-	iface, err := net.InterfaceByName(getDockerBridgeInterface(ctx))
-	if err != nil {
-		return ""
-	}
-
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return ""
-	}
-
-	if len(addrs) != 0 {
-		ip, _, err := net.ParseCIDR(addrs[0].String())
-		if err != nil {
-			return ""
-		}
-
-		return ip.String()
-	}
-
-	return ""
-}
-
 func getCloudBuildSubnet(ctx context.Context) string {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -121,8 +121,12 @@ func (r *RPC) Start(ctx context.Context) error {
 
 // Endpoint returns RPC server address suitable for use in agent's "-api-endpoint" flag.
 func (r *RPC) Endpoint() string {
-	if r.listener.Addr().Network() == networkUnix {
-		return "unix://" + r.listener.Addr().String()
+	if runtime.GOOS == "linux" {
+		if r.listener.Addr().Network() == networkUnix {
+			return "unix://" + r.listener.Addr().String()
+		}
+
+		return fmt.Sprintf("http://%s", r.listener.Addr().String())
 	}
 
 	port := r.listener.Addr().(*net.TCPAddr).Port


### PR DESCRIPTION
This approach somewhat simplifies the communication with the agent on Linux by making the Docker bridge heuristic obsolete and resolves the #124 by essentially bypassing the Netfilter altogether.

Unfortunately, Cloud Build heuristic had to be kept in place, because in Cloud Build the CLI runs inside a container (as a part of the build step), but when asking the Docker daemon to bind-mount something we need to pass a path accessible on the host, not inside the container.

Also, SELinux confinement had to be disabled even when not using `--dirty` mode because using Docker's [`:z` relabelling feature](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label) on Unix domain sockets doesn't seem to work the same way it works on files: the label of the process that listens the socket (in our case this is the CLI) is what affects the decision, not the file label itself.

In the testing environment when the agent tried to connect to the CLI's socket, `audit2allow` generated the following policy allow rule, despite the fact that the `:z` option was supplied and the labels were updated accordingly:

```
allow container_t unconfined_t:unix_stream_socket connectto;
```

One way to workaround this could be to inherit the `container_t` rules, make the adjustment above and generate a new policy. But this already a seems like a lot of out-of-scope things to do and I'm not even sure you can update SELinux policies when running as an ordinary user. On top of that, nothing guarantees that CLI runs with `unconfined_t` type, so we'll need to also account for that too.

Another possible workaround might be for the CLI itself to enter into a separate IPC namespace and pass it via the [`--ipc` flag](https://docs.docker.com/engine/reference/run/#ipc-settings---ipc) when running container. This seems to be a lot more fine-grained than using `--ipc host` as suggested in the Stack Exchange question below, however, a quick look at this flag reveals that it can only reference other containers, so in order for this to work we would need to manually craft an intermediate Docker-like container from which the Docker can later inherit our IPC namespace from.

More details on this problem:

* https://unix.stackexchange.com/questions/386767/selinux-and-docker-allow-access-to-x-unix-socket-in-tmp-x11-unix
* https://github.com/containers/container-selinux