### PR TITLE
Respect additional instances while serving

### DIFF
--- a/pkg/parser/labels.go
+++ b/pkg/parser/labels.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/golang/protobuf/ptypes"
@@ -32,7 +33,7 @@ func instanceLabels(taskInstance *any.Any) ([]string, error) {
 
 	err := ptypes.UnmarshalAny(taskInstance, &dynamicAny)
 
-	if err == protoregistry.NotFound {
+	if errors.Is(err, protoregistry.NotFound) {
 		return labels, nil
 	}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -398,7 +398,7 @@ func (p *Parser) createServiceTasks(ctx context.Context, protoTasks []*api.Task)
 		var dynamicInstance ptypes.DynamicAny
 		err := ptypes.UnmarshalAny(protoTask.Instance, &dynamicInstance)
 
-		if err == protoregistry.NotFound {
+		if errors.Is(err, protoregistry.NotFound) {
 			continue
 		}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -19,6 +19,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/lestrrat-go/jsschema"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
@@ -395,7 +396,13 @@ func (p *Parser) createServiceTasks(ctx context.Context, protoTasks []*api.Task)
 
 	for _, protoTask := range protoTasks {
 		var dynamicInstance ptypes.DynamicAny
-		if err := ptypes.UnmarshalAny(protoTask.Instance, &dynamicInstance); err != nil {
+		err := ptypes.UnmarshalAny(protoTask.Instance, &dynamicInstance)
+
+		if err == protoregistry.NotFound {
+			continue
+		}
+
+		if err != nil {
 			return nil, fmt.Errorf("%w: %v", ErrInternal, err)
 		}
 


### PR DESCRIPTION
Make sure additional instances are respected and since proto messages are not getting added to the global proto type registry handle `NotFound` errors properly.

Still TBD how to generate proper labels for additional instances and how to generate docker builders for GKEContianer instances with `dockerfile` set. But theses two issues are for a separate PR.