### PR TITLE
Build for more platforms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,12 @@ builds:
       - linux
       - darwin
       - windows
+      - freebsd
+      - solaris
     goarch:
       - amd64
+      - arm
+      - arm64
 
 archives:
   - id: binary

--- a/internal/commands/helpers/helpers.go
+++ b/internal/commands/helpers/helpers.go
@@ -1,0 +1,22 @@
+package helpers
+
+import "github.com/spf13/cobra"
+
+func ConsumeSubCommands(cmd *cobra.Command, subCommands []*cobra.Command) *cobra.Command {
+	var hasValidSubcommands bool
+
+	for _, subCommand := range subCommands {
+		if cmd == nil {
+			continue
+		}
+
+		cmd.AddCommand(subCommand)
+		hasValidSubcommands = true
+	}
+
+	if hasValidSubcommands {
+		return cmd
+	}
+
+	return nil
+}

--- a/internal/commands/internal/internal.go
+++ b/internal/commands/internal/internal.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"github.com/cirruslabs/cirrus-cli/internal/commands/helpers"
 	"github.com/cirruslabs/cirrus-cli/internal/commands/internal/test"
 	"github.com/spf13/cobra"
 )
@@ -12,9 +13,9 @@ func NewRootCmd() *cobra.Command {
 		Hidden: true,
 	}
 
-	cmd.AddCommand(
+	commands := []*cobra.Command{
 		test.NewTestCmd(),
-	)
+	}
 
-	return cmd
+	return helpers.ConsumeSubCommands(cmd, commands)
 }

--- a/internal/commands/internal/test/test.go
+++ b/internal/commands/internal/test/test.go
@@ -1,3 +1,5 @@
+// +build linux darwin windows
+
 package test
 
 import (

--- a/internal/commands/internal/test/test_unsupported.go
+++ b/internal/commands/internal/test/test_unsupported.go
@@ -1,0 +1,9 @@
+// +build !linux,!darwin,!windows
+
+package test
+
+import "github.com/spf13/cobra"
+
+func NewTestCmd() *cobra.Command {
+	return nil
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/cirruslabs/cirrus-cli/internal/commands/helpers"
 	"github.com/cirruslabs/cirrus-cli/internal/commands/internal"
 	"github.com/cirruslabs/cirrus-cli/internal/commands/worker"
 	"github.com/cirruslabs/cirrus-cli/internal/version"
@@ -14,13 +15,13 @@ func NewRootCmd() *cobra.Command {
 		Version: version.FullVersion,
 	}
 
-	cmd.AddCommand(
+	commands := []*cobra.Command{
 		newValidateCmd(),
 		newRunCmd(),
 		newServeCmd(),
 		internal.NewRootCmd(),
 		worker.NewRootCmd(),
-	)
+	}
 
-	return cmd
+	return helpers.ConsumeSubCommands(cmd, commands)
 }

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -1,3 +1,5 @@
+// +build linux darwin windows
+
 package commands
 
 import (

--- a/internal/commands/run_unsupported.go
+++ b/internal/commands/run_unsupported.go
@@ -1,0 +1,9 @@
+// +build !linux,!darwin,!windows
+
+package commands
+
+import "github.com/spf13/cobra"
+
+func newRunCmd() *cobra.Command {
+	return nil
+}

--- a/internal/commands/serve.go
+++ b/internal/commands/serve.go
@@ -1,3 +1,5 @@
+// +build !solaris
+
 package commands
 
 import (

--- a/internal/commands/serve_unsupported.go
+++ b/internal/commands/serve_unsupported.go
@@ -1,0 +1,9 @@
+// +build solaris
+
+package commands
+
+import "github.com/spf13/cobra"
+
+func newServeCmd() *cobra.Command {
+	return nil
+}

--- a/internal/commands/worker/worker.go
+++ b/internal/commands/worker/worker.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"github.com/cirruslabs/cirrus-cli/internal/commands/helpers"
 	"github.com/spf13/cobra"
 )
 
@@ -10,9 +11,9 @@ func NewRootCmd() *cobra.Command {
 		Short: "Persistent worker mode",
 	}
 
-	cmd.AddCommand(
+	commands := []*cobra.Command{
 		NewRunCmd(),
-	)
+	}
 
-	return cmd
+	return helpers.ConsumeSubCommands(cmd, commands)
 }

--- a/internal/executor/heuristic/common.go
+++ b/internal/executor/heuristic/common.go
@@ -1,0 +1,4 @@
+package heuristic
+
+// https://cloud.google.com/cloud-build/docs/build-config#network
+const CloudBuildNetworkName = "cloudbuild"

--- a/internal/executor/heuristic/heuristic.go
+++ b/internal/executor/heuristic/heuristic.go
@@ -1,3 +1,5 @@
+// +build linux darwin windows
+
 package heuristic
 
 import (
@@ -6,9 +8,6 @@ import (
 	"github.com/docker/docker/client"
 	"net"
 )
-
-// https://cloud.google.com/cloud-build/docs/build-config#network
-const CloudBuildNetworkName = "cloudbuild"
 
 func getCloudBuildSubnet(ctx context.Context) string {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())

--- a/internal/executor/heuristic/heuristic_unsupported.go
+++ b/internal/executor/heuristic/heuristic_unsupported.go
@@ -1,0 +1,9 @@
+// +build !linux,!darwin,!windows
+
+package heuristic
+
+import "context"
+
+func GetCloudBuildIP(ctx context.Context) string {
+	return ""
+}

--- a/internal/executor/instance/containerbackend/docker.go
+++ b/internal/executor/instance/containerbackend/docker.go
@@ -1,3 +1,5 @@
+// +build linux darwin windows
+
 package containerbackend
 
 import (

--- a/internal/executor/instance/containerbackend/docker_unsupported.go
+++ b/internal/executor/instance/containerbackend/docker_unsupported.go
@@ -1,0 +1,11 @@
+// +build !linux,!darwin,!windows
+
+package containerbackend
+
+import "fmt"
+
+type Docker struct {}
+
+func NewDocker() (ContainerBackend, error) {
+	return nil, fmt.Errorf("%w: Docker is only supported on Linux, macOS and Windows", ErrNewFailed)
+}


### PR DESCRIPTION
Sync operating systems and architectures with the cirrus-ci-agent's [`.goreleaser.yml`](https://github.com/cirruslabs/cirrus-ci-agent/blob/master/.goreleaser.yml).

Resolves #149.