### PR TITLE
Ensure that the Docker client is working before returning it

### DIFF
--- a/internal/executor/instance/containerbackend/docker.go
+++ b/internal/executor/instance/containerbackend/docker.go
@@ -25,6 +25,11 @@ func NewDocker() (ContainerBackend, error) {
 		return nil, err
 	}
 
+	_, err = cli.Ping(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
 	return &Docker{
 		cli: cli,
 	}, nil


### PR DESCRIPTION
Fixes the CLI's container backend auto-detection mode by not returning an unusable Docker client to the caller.