### PR TITLE
JSONSchema() RPC method + dynamic instance support when generating schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.2
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
-	github.com/cirruslabs/cirrus-ci-agent v1.16.0
+	github.com/cirruslabs/cirrus-ci-agent v1.20.0
 	github.com/cirruslabs/echelon v1.4.0
 	github.com/cirruslabs/podmanapi v0.1.0
 	github.com/containerd/containerd v1.4.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/yudai/gojsondiff v1.0.0
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cirruslabs/cirrus-ci-agent v1.16.0 h1:GdJvQ8KGxJSAfg1vKGOFSBqmtJ2lfDEuuazCRMIIi/8=
-github.com/cirruslabs/cirrus-ci-agent v1.16.0/go.mod h1:ga2zCGBfC+/+tnlHWa5cHwEuBPnhFuaf1PgTpWPGJWo=
+github.com/cirruslabs/cirrus-ci-agent v1.20.0 h1:b38J1H1MDCxZIg32cY9+9VFLvUyx+tY0hkXfmUAfNs8=
+github.com/cirruslabs/cirrus-ci-agent v1.20.0/go.mod h1:ga2zCGBfC+/+tnlHWa5cHwEuBPnhFuaf1PgTpWPGJWo=
 github.com/cirruslabs/cirrus-ci-annotations v0.0.0-20200908203753-b813f63941d7/go.mod h1:98qD7HLlBx5aNqWiCH80OTTqTTsbXT69wxnlnrnoL0E=
 github.com/cirruslabs/echelon v1.4.0 h1:xubCf8BLFEBl1kamBZ1zjBrcw5p4z4anvJUBeR3E5YY=
 github.com/cirruslabs/echelon v1.4.0/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -173,7 +173,7 @@ proto_task:
 
 	response, err := evaluateHelper(t, &api.EvaluateConfigRequest{
 		YamlConfig: yamlConfig,
-		AdditionalInstancesInfo: &api.EvaluateConfigRequest_AdditionalInstancesInfo{
+		AdditionalInstancesInfo: &api.AdditionalInstancesInfo{
 			Instances: map[string]string{
 				"proto_container": "org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
 			},

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -2,11 +2,14 @@ package evaluator_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-cli/internal/evaluator"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protodesc"
@@ -17,7 +20,7 @@ import (
 	"testing"
 )
 
-func evaluateHelper(t *testing.T, request *api.EvaluateConfigRequest) (*api.EvaluateConfigResponse, error) {
+func getClient(t *testing.T) api.CirrusConfigurationEvaluatorServiceClient {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	lis, err := net.Listen("tcp", "localhost:0")
@@ -31,27 +34,28 @@ func evaluateHelper(t *testing.T, request *api.EvaluateConfigRequest) (*api.Eval
 		errChan <- evaluator.Serve(ctx, lis)
 	}()
 
-	defer func() {
+	t.Cleanup(func() {
 		cancel()
 
 		if err := <-errChan; err != nil && !errors.Is(err, context.Canceled) {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	client := api.NewCirrusConfigurationEvaluatorServiceClient(conn)
+	return api.NewCirrusConfigurationEvaluatorServiceClient(conn)
+}
 
-	response, err := client.EvaluateConfig(context.Background(), request)
-	if err != nil {
-		return nil, err
-	}
+func evaluateHelper(t *testing.T, request *api.EvaluateConfigRequest) (*api.EvaluateConfigResponse, error) {
+	return getClient(t).EvaluateConfig(context.Background(), request)
+}
 
-	return response, nil
+func schemaHelper(t *testing.T, request *api.JSONSchemaRequest) (*api.JSONSchemaResponse, error) {
+	return getClient(t).JSONSchema(context.Background(), request)
 }
 
 // TestCrossDependencies ensures that tasks declared in YAML and generated from Starlark can reference each other.
@@ -190,4 +194,30 @@ proto_task:
 	require.NoError(t, err)
 	require.Len(t, response.Tasks, 2)
 	require.JSONEq(t, protojson.Format(response.Tasks[0].Instance), protojson.Format(response.Tasks[1].Instance))
+}
+
+func TestSchemaHasFileMatch(t *testing.T) {
+	response, err := schemaHelper(t, &api.JSONSchemaRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var schemaObject map[string]interface{}
+	if err := json.Unmarshal([]byte(response.Schema), &schemaObject); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, []interface{}{".cirrus.yml"}, schemaObject["fileMatch"])
+}
+
+func TestSchemaValid(t *testing.T) {
+	response, err := schemaHelper(t, &api.JSONSchemaRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader := gojsonschema.NewStringLoader(response.Schema)
+	if _, err := gojsonschema.NewSchema(loader); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/internal/executor/instance/instance.go
+++ b/internal/executor/instance/instance.go
@@ -69,7 +69,7 @@ func NewFromProto(anyInstance *any.Any, commands []*api.Command) (Instance, erro
 
 		return &PrebuiltInstance{
 			Image:      image,
-			Dockerfile: instance.DockerfilePath,
+			Dockerfile: instance.Dockerfile,
 			Arguments:  instance.Arguments,
 		}, nil
 	case *api.PersistentWorkerInstance:

--- a/pkg/parser/instance/container.go
+++ b/pkg/parser/instance/container.go
@@ -43,7 +43,7 @@ func NewCommunityContainer(mergedEnv map[string]string, boolevator *boolevator.B
 		if err != nil {
 			return err
 		}
-		container.proto.DockerfilePath = dockerfile
+		container.proto.Dockerfile = dockerfile
 		return nil
 	})
 

--- a/pkg/parser/labels.go
+++ b/pkg/parser/labels.go
@@ -55,14 +55,14 @@ func instanceLabels(
 
 	switch instance := dynamicAny.(type) {
 	case *api.ContainerInstance:
-		if instance.DockerfilePath == "" {
+		if instance.Dockerfile == "" {
 			labels = append(labels, fmt.Sprintf("container:%s", instance.Image))
 
-			if instance.OperationSystemVersion != "" {
-				labels = append(labels, fmt.Sprintf("os:%s", instance.OperationSystemVersion))
+			if instance.OsVersion != "" {
+				labels = append(labels, fmt.Sprintf("os:%s", instance.OsVersion))
 			}
 		} else {
-			labels = append(labels, fmt.Sprintf("Dockerfile:%s", instance.DockerfilePath))
+			labels = append(labels, fmt.Sprintf("Dockerfile:%s", instance.Dockerfile))
 
 			for key, value := range instance.DockerArguments {
 				labels = append(labels, fmt.Sprintf("%s:%s", key, value))

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -76,7 +76,7 @@ func New(opts ...Option) *Parser {
 
 	// Register parsers
 	parser.parsers = map[nameable.Nameable]parseable.Parseable{
-		nameable.NewRegexNameable("^(.*)task$"): task.NewTask(nil, nil, nil),
+		nameable.NewRegexNameable("^(.*)task$"): task.NewTask(nil, nil, parser.additionalInstances),
 		nameable.NewRegexNameable("^(.*)pipe$"): task.NewDockerPipe(nil, nil),
 	}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -314,11 +314,11 @@ func (p *Parser) createServiceTask(
 	taskContainer *api.ContainerInstance,
 ) (*api.Task, error) {
 	prebuiltInstance := &api.PrebuiltImageInstance{
-		Repository:     fmt.Sprintf("cirrus-ci-community/%s", dockerfileHash),
-		Reference:      "latest",
-		Platform:       taskContainer.Platform,
-		DockerfilePath: taskContainer.DockerfilePath,
-		Arguments:      taskContainer.DockerArguments,
+		Repository: fmt.Sprintf("cirrus-ci-community/%s", dockerfileHash),
+		Reference:  "latest",
+		Platform:   taskContainer.Platform,
+		Dockerfile: taskContainer.Dockerfile,
+		Arguments:  taskContainer.DockerArguments,
 	}
 
 	anyInstance, err := ptypes.MarshalAny(prebuiltInstance)
@@ -349,7 +349,7 @@ func (p *Parser) createServiceTask(
 	}
 
 	serviceTask := &api.Task{
-		Name:         fmt.Sprintf("Prebuild %s%s", taskContainer.DockerfilePath, buildArgs),
+		Name:         fmt.Sprintf("Prebuild %s%s", taskContainer.Dockerfile, buildArgs),
 		LocalGroupId: p.NextTaskID(),
 		Instance:     anyInstance,
 		Commands: []*api.Command{
@@ -362,7 +362,7 @@ func (p *Parser) createServiceTask(
 							"--file %s%s "+
 							"${CIRRUS_DOCKER_CONTEXT:-$CIRRUS_WORKING_DIR}",
 							prebuiltInstance.Repository, prebuiltInstance.Reference,
-							taskContainer.DockerfilePath, dockerBuildArgs)},
+							taskContainer.Dockerfile, dockerBuildArgs)},
 					},
 				},
 			},
@@ -422,7 +422,7 @@ func (p *Parser) createServiceTasks(ctx context.Context, protoTasks []*api.Task)
 				parsererror.ErrParsing, taskContainer.Platform.String())
 		}
 
-		if taskContainer.DockerfilePath == "" {
+		if taskContainer.Dockerfile == "" {
 			continue
 		}
 
@@ -434,13 +434,13 @@ func (p *Parser) createServiceTasks(ctx context.Context, protoTasks []*api.Task)
 		sort.Strings(hashableArgsSlice)
 		hashableArgs := strings.Join(hashableArgsSlice, ", ")
 
-		dockerfileHash, err := p.fileHash(ctx, taskContainer.DockerfilePath, []byte(hashableArgs))
+		dockerfileHash, err := p.fileHash(ctx, taskContainer.Dockerfile, []byte(hashableArgs))
 		if err != nil {
 			return nil, err
 		}
 
 		// Find or create service task
-		serviceTaskKey := taskContainer.DockerfilePath + hashableArgs
+		serviceTaskKey := taskContainer.Dockerfile + hashableArgs
 
 		serviceTask, ok := serviceTasks[serviceTaskKey]
 		if !ok {

--- a/pkg/parser/schema/schema.go
+++ b/pkg/parser/schema/schema.go
@@ -5,10 +5,6 @@ import (
 	"regexp"
 )
 
-var (
-	TodoSchema = &schema.Schema{}
-)
-
 func Map(description string) *schema.Schema {
 	if description == "" {
 		description = "Map represented as an object."
@@ -39,6 +35,20 @@ func Condition(description string) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.PrimitiveTypes{schema.StringType},
 		Description: fullDescription,
+	}
+}
+
+func Boolean(description string) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.PrimitiveTypes{schema.BooleanType},
+		Description: description,
+	}
+}
+
+func Integer(description string) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.PrimitiveTypes{schema.IntegerType},
+		Description: description,
 	}
 }
 
@@ -75,16 +85,20 @@ func StringOrListOfStrings(description string) *schema.Schema {
 	}
 }
 
-func TriggerType() *schema.Schema {
+func Enum(items []interface{}, description string) *schema.Schema {
 	return &schema.Schema{
-		Description: "Trigger type",
-		Enum: []interface{}{
-			"automatic",
-			"manual",
-		},
+		Description:          description,
+		Enum:                 items,
 		AdditionalItems:      &schema.AdditionalItems{Schema: nil},
 		AdditionalProperties: &schema.AdditionalProperties{Schema: nil},
 	}
+}
+
+func TriggerType() *schema.Schema {
+	return Enum([]interface{}{
+		"automatic",
+		"manual",
+	}, "Trigger type")
 }
 
 func Script(description string) *schema.Schema {

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -113,26 +113,26 @@ func NewTask(
 	for instanceName, descriptor := range additionalInstances {
 		scopedInstanceName := instanceName
 		scopedDescriptor := descriptor
-		task.CollectibleField(scopedInstanceName,
-			instance.NewProtoParser(scopedDescriptor, environment.Merge(task.proto.Environment, env), boolevator).Schema(),
-			func(node *node.Node) error {
-				parser := instance.NewProtoParser(scopedDescriptor, environment.Merge(task.proto.Environment, env), boolevator)
-				parserInstance, err := parser.Parse(node)
-				if err != nil {
-					return err
-				}
-				anyInstance, err := anypb.New(parserInstance)
-				if err != nil {
-					return err
-				}
-				task.proto.Instance = anyInstance
-				task.proto.Environment = environment.Merge(
-					task.proto.Environment, map[string]string{
-						"CIRRUS_OS": instance.GuessPlatform(anyInstance, scopedDescriptor),
-					},
-				)
-				return nil
-			})
+
+		instanceSchema := instance.NewProtoParser(scopedDescriptor, nil, nil).Schema()
+		task.CollectibleField(scopedInstanceName, instanceSchema, func(node *node.Node) error {
+			parser := instance.NewProtoParser(scopedDescriptor, environment.Merge(task.proto.Environment, env), boolevator)
+			parserInstance, err := parser.Parse(node)
+			if err != nil {
+				return err
+			}
+			anyInstance, err := anypb.New(parserInstance)
+			if err != nil {
+				return err
+			}
+			task.proto.Instance = anyInstance
+			task.proto.Environment = environment.Merge(
+				task.proto.Environment, map[string]string{
+					"CIRRUS_OS": instance.GuessPlatform(anyInstance, scopedDescriptor),
+				},
+			)
+			return nil
+		})
 	}
 
 	task.OptionalField(nameable.NewSimpleNameable("name"), schema.String(""), func(node *node.Node) error {

--- a/pkg/parser/testdata/via-rpc/container_build-arguments.json
+++ b/pkg/parser/testdata/via-rpc/container_build-arguments.json
@@ -25,7 +25,7 @@
         "bar": "baz",
         "foo": "bar"
       },
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "image": "gcr.io/cirrus-ci-community/e02d522efc69d3863e49972eb177dd6a:latest",
       "memory": 4096
     },
@@ -77,7 +77,7 @@
         "bar": "baz",
         "foo": "bar"
       },
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "reference": "latest",
       "repository": "cirrus-ci-community/e02d522efc69d3863e49972eb177dd6a"
     },

--- a/pkg/parser/testdata/via-rpc/container_build-complexArguments.json
+++ b/pkg/parser/testdata/via-rpc/container_build-complexArguments.json
@@ -23,7 +23,7 @@
       "dockerArguments": {
         "foo": "bar"
       },
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "image": "gcr.io/cirrus-ci-community/2b4c0074861f1fe6525d23e24dd12e99:latest",
       "memory": 4096
     },
@@ -70,7 +70,7 @@
       "dockerArguments": {
         "bar": "baz baz"
       },
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "image": "gcr.io/cirrus-ci-community/930472895952b2e55cd88ac886de4bf3:latest",
       "memory": 4096
     },
@@ -125,7 +125,7 @@
       "arguments": {
         "foo": "bar"
       },
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "reference": "latest",
       "repository": "cirrus-ci-community/2b4c0074861f1fe6525d23e24dd12e99"
     },
@@ -174,7 +174,7 @@
       "arguments": {
         "bar": "baz baz"
       },
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "reference": "latest",
       "repository": "cirrus-ci-community/930472895952b2e55cd88ac886de4bf3"
     },

--- a/pkg/parser/testdata/via-rpc/container_build-context.json
+++ b/pkg/parser/testdata/via-rpc/container_build-context.json
@@ -22,7 +22,7 @@
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
       "cpu": 2,
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "image": "gcr.io/cirrus-ci-community/2906b436f40f094d79f1352b647c261d:latest",
       "memory": 4096
     },
@@ -71,7 +71,7 @@
     },
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PrebuiltImageInstance",
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "reference": "latest",
       "repository": "cirrus-ci-community/2906b436f40f094d79f1352b647c261d"
     },

--- a/pkg/parser/testdata/via-rpc/container_build-simple.json
+++ b/pkg/parser/testdata/via-rpc/container_build-simple.json
@@ -21,7 +21,7 @@
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
       "cpu": 2,
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "image": "gcr.io/cirrus-ci-community/2906b436f40f094d79f1352b647c261d:latest",
       "memory": 4096
     },
@@ -69,7 +69,7 @@
     },
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PrebuiltImageInstance",
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "reference": "latest",
       "repository": "cirrus-ci-community/2906b436f40f094d79f1352b647c261d"
     },

--- a/pkg/parser/testdata/via-rpc/container_build-twoTasksSameContainer.json
+++ b/pkg/parser/testdata/via-rpc/container_build-twoTasksSameContainer.json
@@ -20,7 +20,7 @@
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
       "cpu": 2,
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "image": "gcr.io/cirrus-ci-community/2906b436f40f094d79f1352b647c261d:latest",
       "memory": 4096
     },
@@ -61,7 +61,7 @@
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
       "cpu": 2,
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "image": "gcr.io/cirrus-ci-community/2906b436f40f094d79f1352b647c261d:latest",
       "memory": 4096
     },
@@ -110,7 +110,7 @@
     },
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PrebuiltImageInstance",
-      "dockerfilePath": "ci/Dockerfile",
+      "dockerfile": "ci/Dockerfile",
       "reference": "latest",
       "repository": "cirrus-ci-community/2906b436f40f094d79f1352b647c261d"
     },

--- a/pkg/parser/testdata/via-rpc/environment-complex4.json
+++ b/pkg/parser/testdata/via-rpc/environment-complex4.json
@@ -95,7 +95,7 @@
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
       "cpu": 4,
-      "dockerfilePath": "dev/ci/docker_linux/Dockerfile",
+      "dockerfile": "dev/ci/docker_linux/Dockerfile",
       "image": "gcr.io/cirrus-ci-community/d41d8cd98f00b204e9800998ecf8427e:latest",
       "memory": 8192
     },
@@ -147,7 +147,7 @@
     },
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PrebuiltImageInstance",
-      "dockerfilePath": "dev/ci/docker_linux/Dockerfile",
+      "dockerfile": "dev/ci/docker_linux/Dockerfile",
       "reference": "latest",
       "repository": "cirrus-ci-community/d41d8cd98f00b204e9800998ecf8427e"
     },

--- a/pkg/parser/testdata/via-rpc/matrix-puppeteer.json
+++ b/pkg/parser/testdata/via-rpc/matrix-puppeteer.json
@@ -37,7 +37,7 @@
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
       "cpu": 2,
-      "dockerfilePath": ".ci/node6/Dockerfile.linux",
+      "dockerfile": ".ci/node6/Dockerfile.linux",
       "image": "gcr.io/cirrus-ci-community/e55f410835991439e5ec0ab4830daf29:latest",
       "memory": 4096
     },
@@ -111,7 +111,7 @@
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
       "cpu": 2,
-      "dockerfilePath": ".ci/node7/Dockerfile.linux",
+      "dockerfile": ".ci/node7/Dockerfile.linux",
       "image": "gcr.io/cirrus-ci-community/3687850f77ee15dd7dc5d1e5f025b885:latest",
       "memory": 4096
     },
@@ -161,7 +161,7 @@
     },
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PrebuiltImageInstance",
-      "dockerfilePath": ".ci/node6/Dockerfile.linux",
+      "dockerfile": ".ci/node6/Dockerfile.linux",
       "reference": "latest",
       "repository": "cirrus-ci-community/e55f410835991439e5ec0ab4830daf29"
     },
@@ -208,7 +208,7 @@
     },
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PrebuiltImageInstance",
-      "dockerfilePath": ".ci/node7/Dockerfile.linux",
+      "dockerfile": ".ci/node7/Dockerfile.linux",
       "reference": "latest",
       "repository": "cirrus-ci-community/3687850f77ee15dd7dc5d1e5f025b885"
     },


### PR DESCRIPTION
No more `schema.TodoSchema`.

However, the descriptions for the messages and fields used in the dynamic instances are currently empty. Once we figure out the best way to add descriptions, I'll add a synthetic test to validate dynamic instance schema generation.