### PR TITLE
When printing logs from RPC don’t print an extraneous newline

### DIFF
--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -260,7 +260,12 @@ func (r *RPC) StreamLogs(stream api.CirrusCIService_StreamLogsServer) error {
 
 			streamLogger.Debugf("received log chunk of %d bytes", len(x.Chunk.Data))
 
-			logLines := strings.Split(string(x.Chunk.Data), "\n")
+			// Ignore the newline at the end of the chunk,
+			// echelon's Infof() below already adds one
+			log := strings.TrimSuffix(string(x.Chunk.Data), "\n")
+
+			logLines := strings.Split(log, "\n")
+
 			for _, logLine := range logLines {
 				streamLogger.Infof(logLine)
 			}

--- a/internal/executor/testdata/logging-no-extra-newlines/.cirrus.yml
+++ b/internal/executor/testdata/logging-no-extra-newlines/.cirrus.yml
@@ -1,0 +1,9 @@
+task:
+  container:
+    image: debian:latest
+  big_gap_script:
+    - echo -en "big gap incoming\n\nwe're still alive\n"
+  no_newline_script:
+    - echo -en "no newline in the output"
+  double_script:
+    - echo -en "double newline in the output\n\n"


### PR DESCRIPTION
Resolves #146.