### PR TITLE
Fixed generation of empty list

### DIFF
--- a/pkg/larker/larker.go
+++ b/pkg/larker/larker.go
@@ -105,6 +105,10 @@ func (larker *Larker) Main(ctx context.Context, source string) (string, error) {
 	// starlark.Dict's to yaml.MapSlice's to make them YAML-serializable
 	yamlList := convertList(starlarkList)
 
+	if len(yamlList) == 0 {
+		return "", nil
+	}
+
 	// Adapt a list of tasks to a YAML configuration format that expects a map on it's outer layer
 	var serializableMainResult yaml.MapSlice
 	for _, listItem := range yamlList {

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -26,7 +26,8 @@ func TestSugarCoatedTask(t *testing.T) {
 	validateExpected(t, "testdata/sugar-coated-task")
 }
 
-// TestNoTasks ensures that .cirrus.star that return empty list still generates valid YAML.
+// TestNoTasks ensures that .cirrus.star that return empty list still generates a YAML
+// that can be joined with another YAML using only string concatenation.
 func TestNoTasks(t *testing.T) {
 	validateExpected(t, "testdata/no-tasks")
 }

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -26,7 +26,7 @@ func TestSugarCoatedTask(t *testing.T) {
 	validateExpected(t, "testdata/sugar-coated-task")
 }
 
-// TestNoTasks ensures that .cirrus.star that return empty list still generates valid YAML
+// TestNoTasks ensures that .cirrus.star that return empty list still generates valid YAML.
 func TestNoTasks(t *testing.T) {
 	validateExpected(t, "testdata/no-tasks")
 }

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -26,6 +26,11 @@ func TestSugarCoatedTask(t *testing.T) {
 	validateExpected(t, "testdata/sugar-coated-task")
 }
 
+// TestNoTasks ensures that .cirrus.star that return empty list still generates valid YAML
+func TestNoTasks(t *testing.T) {
+	validateExpected(t, "testdata/no-tasks")
+}
+
 func validateExpected(t *testing.T, testDir string) {
 	dir := testutil.TempDirPopulatedWith(t, testDir)
 

--- a/pkg/larker/testdata/no-tasks/.cirrus.star
+++ b/pkg/larker/testdata/no-tasks/.cirrus.star
@@ -1,0 +1,2 @@
+def main(ctx):
+    return []


### PR DESCRIPTION
For some reason `yaml.Marshal` of an empty map resulted in `{}` instead of an empty string.