### PR TITLE
Windows containers support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 docker_builder:
-  name: Test (Docker)
+  name: Test (Linux with Docker)
   alias: Tests
   test_script:
     - wget --no-verbose -O - https://golang.org/dl/go1.15.linux-amd64.tar.gz | tar -C /usr/local -xz
@@ -9,7 +9,7 @@ docker_builder:
     HOME: /root
 
 docker_builder:
-  name: Test (Podman)
+  name: Test (Linux with Podman)
   alias: Tests
   install_podman_script:
     - . /etc/os-release
@@ -27,6 +27,17 @@ docker_builder:
   env:
     HOME: /root
     CIRRUS_CONTAINER_BACKEND: podman
+
+docker_builder:
+  name: Test (Windows)
+  alias: Tests
+  platform: windows
+  os_version: 2019
+  test_script:
+    - choco install -y golang
+    - refreshenv
+    - md C:\Windows\system32\config\systemprofile\AppData\Local\Temp
+    - go test ./...
 
 task:
   name: Release (Dry Run)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.2
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
-	github.com/cirruslabs/cirrus-ci-agent v1.22.0
+	github.com/cirruslabs/cirrus-ci-agent v1.24.0
 	github.com/cirruslabs/echelon v1.4.0
 	github.com/cirruslabs/podmanapi v0.1.0
 	github.com/containerd/containerd v1.4.1 // indirect
@@ -54,7 +54,7 @@ require (
 	go.starlark.net v0.0.0-20201118183435-e55f603d8c79
 	golang.org/x/net v0.0.0-20201022231255-08b38378de70 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
-	golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd // indirect
+	golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd
 	golang.org/x/text v0.3.3
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20201022181438-0ff5f38871d5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200507155900-a9f01edf17e3/go.mod h1:XT+cAw5wfvsodedcijoh1l9cf7v1x9FlFB/3VmF/O8s=
-github.com/cirruslabs/cirrus-ci-agent v1.22.0 h1:JT0C51Y3b9ZuXhELjiCDAKfjPV+Y6eVT3TtP+JoK1cE=
-github.com/cirruslabs/cirrus-ci-agent v1.22.0/go.mod h1:ga2zCGBfC+/+tnlHWa5cHwEuBPnhFuaf1PgTpWPGJWo=
+github.com/cirruslabs/cirrus-ci-agent v1.24.0 h1:GiK7hYgRP94Sz2pEDiy5oBFS/EaAjynns9EyKfmoOBc=
+github.com/cirruslabs/cirrus-ci-agent v1.24.0/go.mod h1:ga2zCGBfC+/+tnlHWa5cHwEuBPnhFuaf1PgTpWPGJWo=
 github.com/cirruslabs/cirrus-ci-annotations v0.0.0-20200908203753-b813f63941d7/go.mod h1:98qD7HLlBx5aNqWiCH80OTTqTTsbXT69wxnlnrnoL0E=
 github.com/cirruslabs/echelon v1.4.0 h1:xubCf8BLFEBl1kamBZ1zjBrcw5p4z4anvJUBeR3E5YY=
 github.com/cirruslabs/echelon v1.4.0/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=

--- a/internal/commands/internal/test/test_test.go
+++ b/internal/commands/internal/test/test_test.go
@@ -2,12 +2,14 @@ package test_test
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/cirruslabs/cirrus-cli/internal/commands"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -26,5 +28,7 @@ func TestSimple(t *testing.T) {
 	err := command.Execute()
 
 	require.Nil(t, err)
-	assert.Contains(t, buf.String(), "'dir/subdir' succeeded")
+
+	adaptedPath := filepath.FromSlash("dir/subdir")
+	assert.Contains(t, buf.String(), fmt.Sprintf("'%s' succeeded", adaptedPath))
 }

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package commands_test
 
 import (

--- a/internal/commands/run_windows_test.go
+++ b/internal/commands/run_windows_test.go
@@ -1,0 +1,26 @@
+package commands_test
+
+import (
+	"github.com/cirruslabs/cirrus-cli/internal/commands"
+	"github.com/cirruslabs/cirrus-cli/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"testing"
+)
+
+var validConfigWindows = []byte("windows_container:\n  image: mcr.microsoft.com/windows/servercore:ltsc2019\n\ntask:\n  script: \"(exit 0)\"\n")
+
+// TestRun ensures that the run command can handle the simplest possible configuration without problems.
+func TestRun(t *testing.T) {
+	testutil.TempChdir(t)
+
+	if err := ioutil.WriteFile(".cirrus.yml", validConfigWindows, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := commands.NewRootCmd()
+	command.SetArgs([]string{"run", "-v", "-o simple"})
+	err := command.Execute()
+
+	assert.Nil(t, err)
+}

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // A simplest possible, but valid configuration.
-var validConfig = []byte("container:\n  image: debian:latest\n\ntask:\n  script: true")
+var validConfig = []byte("container:\n  image: debian:latest\n\ntask:\n  script: true\n")
 
 func TestValidateNoArgsNoFile(t *testing.T) {
 	testutil.TempChdir(t)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package executor_test
 
 import (

--- a/internal/executor/executor_windows_test.go
+++ b/internal/executor/executor_windows_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cirruslabs/echelon"
 	"github.com/cirruslabs/echelon/renderers"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,4 +71,19 @@ func TestExecutorClone(t *testing.T) {
 	if err := e.Run(context.Background()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestDirtyMode ensures that files created in dirty mode exist on the host.
+func TestDirtyMode(t *testing.T) {
+	dir := testutil.TempDirPopulatedWith(t, "testdata/dirty-mode-windows")
+
+	renderer := renderers.NewSimpleRenderer(os.Stdout, nil)
+	logger := echelon.NewLogger(echelon.TraceLevel, renderer)
+
+	err := testutil.ExecuteWithOptions(t, dir, executor.WithLogger(logger), executor.WithDirtyMode())
+	assert.NoError(t, err)
+
+	// Check that the file was created
+	_, err = os.Stat(filepath.Join(dir, "file.txt"))
+	assert.NoError(t, err)
 }

--- a/internal/executor/executor_windows_test.go
+++ b/internal/executor/executor_windows_test.go
@@ -1,0 +1,73 @@
+package executor_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-cli/internal/executor"
+	"github.com/cirruslabs/cirrus-cli/internal/testutil"
+	"github.com/cirruslabs/echelon"
+	"github.com/cirruslabs/echelon/renderers"
+	"github.com/golang/protobuf/ptypes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExecutorClone ensures that Executor handles clone instruction properly.
+func TestExecutorClone(t *testing.T) {
+	dir := testutil.TempDir(t)
+
+	// Create a canary file
+	const canaryFile = "canary.file"
+	file, err := os.Create(filepath.Join(dir, canaryFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	instance, err := ptypes.MarshalAny(&api.ContainerInstance{
+		Image:     "mcr.microsoft.com/windows/servercore:ltsc2019",
+		Platform:  api.Platform_WINDOWS,
+		OsVersion: "2019",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renderer := renderers.NewSimpleRenderer(os.Stdout, nil)
+	logger := echelon.NewLogger(echelon.TraceLevel, renderer)
+
+	e, err := executor.New(dir, []*api.Task{
+		{
+			LocalGroupId: 0,
+			Name:         "main",
+			Commands: []*api.Command{
+				{
+					Name: "clone",
+					Instruction: &api.Command_CloneInstruction{
+						CloneInstruction: &api.CloneInstruction{},
+					},
+				},
+				{
+					Name: "check",
+					Instruction: &api.Command_ScriptInstruction{
+						ScriptInstruction: &api.ScriptInstruction{
+							Scripts: []string{fmt.Sprintf("type %s", canaryFile)},
+						},
+					},
+				},
+			},
+			Instance: instance,
+		},
+	}, executor.WithContainerBackend(testutil.ContainerBackendFromEnv(t)), executor.WithLogger(logger))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := e.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/executor/heuristic/heuristic.go
+++ b/internal/executor/heuristic/heuristic.go
@@ -59,3 +59,18 @@ func GetCloudBuildIP(ctx context.Context) string {
 
 	return ""
 }
+
+func IsRunningWindowsContainers(ctx context.Context) bool {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return false
+	}
+	defer cli.Close()
+
+	info, err := cli.Info(ctx)
+	if err != nil {
+		return false
+	}
+
+	return info.OSType == "windows"
+}

--- a/internal/executor/heuristic/heuristic_unsupported.go
+++ b/internal/executor/heuristic/heuristic_unsupported.go
@@ -7,3 +7,7 @@ import "context"
 func GetCloudBuildIP(ctx context.Context) string {
 	return ""
 }
+
+func IsRunningWindowsContainers(ctx context.Context) bool {
+	return false
+}

--- a/internal/executor/instance/container.go
+++ b/internal/executor/instance/container.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"path"
 )
 
@@ -11,10 +12,11 @@ type ContainerInstance struct {
 	CPU                  float32
 	Memory               uint32
 	AdditionalContainers []*api.AdditionalContainer
+	Platform             platform.Platform
 }
 
 func (inst *ContainerInstance) Run(ctx context.Context, config *RunConfig) (err error) {
-	workingVolume, err := CreateWorkingVolumeFromConfig(ctx, config)
+	workingVolume, err := CreateWorkingVolumeFromConfig(ctx, config, inst.Platform)
 	if err != nil {
 		return err
 	}
@@ -37,6 +39,7 @@ func (inst *ContainerInstance) Run(ctx context.Context, config *RunConfig) (err 
 		CPU:                  inst.CPU,
 		Memory:               inst.Memory,
 		AdditionalContainers: inst.AdditionalContainers,
+		Platform:             inst.Platform,
 		WorkingVolumeName:    workingVolume.Name(),
 	}
 
@@ -48,5 +51,5 @@ func (inst *ContainerInstance) Run(ctx context.Context, config *RunConfig) (err 
 }
 
 func (inst *ContainerInstance) WorkingDirectory(projectDir string, dirtyMode bool) string {
-	return path.Join(WorkingVolumeMountpoint, WorkingVolumeWorkingDir)
+	return path.Join(inst.Platform.WorkingVolumeMountpoint(), platform.WorkingVolumeWorkingDir)
 }

--- a/internal/executor/instance/instance.go
+++ b/internal/executor/instance/instance.go
@@ -51,7 +51,7 @@ func NewFromProto(anyInstance *any.Any, commands []*api.Command) (Instance, erro
 		case api.Platform_LINUX:
 			containerPlatform = platform.NewUnix()
 		case api.Platform_WINDOWS:
-			containerPlatform = platform.NewWindows()
+			containerPlatform = platform.NewWindows(instance.OsVersion)
 		default:
 			return nil, fmt.Errorf("%w: unsupported container instance platform: %s",
 				ErrFailedToCreateInstance, instance.Platform.String())

--- a/internal/executor/instance/instance.go
+++ b/internal/executor/instance/instance.go
@@ -157,7 +157,7 @@ func RunContainerizedAgent(ctx context.Context, config *RunConfig, params *Param
 	input := containerbackend.ContainerCreateInput{
 		Image: params.Image,
 		Entrypoint: []string{
-			path.Join(WorkingVolumeMountpoint, WorkingVolumeAgent),
+			path.Join(WorkingVolumeMountpoint, WorkingVolumeAgentBinary),
 			"-api-endpoint",
 			config.ContainerEndpoint,
 			"-server-token",

--- a/internal/executor/instance/persistentworker_test.go
+++ b/internal/executor/instance/persistentworker_test.go
@@ -3,6 +3,7 @@ package instance_test
 import (
 	"context"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"runtime"
@@ -13,7 +14,7 @@ import (
 func TestRetrieveAgentBinary(t *testing.T) {
 	// Does it work?
 	firstPath, err := instance.RetrieveAgentBinary(context.Background(),
-		instance.DefaultAgentVersion, runtime.GOOS, runtime.GOARCH)
+		platform.DefaultAgentVersion, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		t.Fatal()
 	}
@@ -26,7 +27,7 @@ func TestRetrieveAgentBinary(t *testing.T) {
 	cachedRetrievalStart := time.Now()
 
 	secondPath, err := instance.RetrieveAgentBinary(context.Background(),
-		instance.DefaultAgentVersion, runtime.GOOS, runtime.GOARCH)
+		platform.DefaultAgentVersion, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		t.Fatal()
 	}

--- a/internal/executor/instance/pipe.go
+++ b/internal/executor/instance/pipe.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"path"
 )
 
@@ -51,7 +52,9 @@ func PipeStagesFromCommands(commands []*api.Command) ([]PipeStage, error) {
 }
 
 func (pi *PipeInstance) Run(ctx context.Context, config *RunConfig) (err error) {
-	workingVolume, err := CreateWorkingVolumeFromConfig(ctx, config)
+	platform := platform.NewUnix()
+
+	workingVolume, err := CreateWorkingVolumeFromConfig(ctx, config, platform)
 	if err != nil {
 		return err
 	}
@@ -76,6 +79,7 @@ func (pi *PipeInstance) Run(ctx context.Context, config *RunConfig) (err error) 
 			Memory:            pi.Memory,
 			CommandFrom:       stage.CommandFrom,
 			CommandTo:         stage.CommandTo,
+			Platform:          platform,
 			WorkingVolumeName: workingVolume.Name(),
 		}
 
@@ -88,5 +92,5 @@ func (pi *PipeInstance) Run(ctx context.Context, config *RunConfig) (err error) 
 }
 
 func (pi *PipeInstance) WorkingDirectory(projectDir string, dirtyMode bool) string {
-	return path.Join(WorkingVolumeMountpoint, WorkingVolumeWorkingDir)
+	return path.Join(platform.NewUnix().WorkingVolumeMountpoint(), platform.WorkingVolumeWorkingDir)
 }

--- a/internal/executor/instance/prebuilt_test.go
+++ b/internal/executor/instance/prebuilt_test.go
@@ -49,7 +49,9 @@ func TestCreateArchive(t *testing.T) {
 
 	header, err := archive.Next()
 	require.NoError(t, err)
-	assert.Equal(t, "directory/file-in-a-directory", header.Name)
+
+	adaptedPath := filepath.FromSlash("directory/file-in-a-directory")
+	assert.Equal(t, adaptedPath, header.Name)
 
 	header, err = archive.Next()
 	require.NoError(t, err)

--- a/internal/executor/instance/volume.go
+++ b/internal/executor/instance/volume.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
 	"github.com/google/uuid"
 	"path"
+	"runtime"
 )
 
 var (
@@ -108,9 +109,11 @@ func CreateWorkingVolume(
 			ReadOnly: true,
 		})
 
-		// Disable SELinux confinement for this container, otherwise
-		// the rsync might fail when accessing the project directory
-		input.DisableSELinux = true
+		if runtime.GOOS == "linux" {
+			// Disable SELinux confinement for this container, otherwise
+			// the rsync might fail when accessing the project directory
+			input.DisableSELinux = true
+		}
 	}
 
 	containerName := fmt.Sprintf("cirrus-helper-container-%s", uuid.New().String())

--- a/internal/executor/instance/volume.go
+++ b/internal/executor/instance/volume.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"github.com/google/uuid"
-	"path"
 	"runtime"
 )
 
@@ -15,34 +15,21 @@ var (
 	ErrVolumeCleanupFailed  = errors.New("failed to clean up working volume")
 )
 
-const (
-	// DefaultAgentVersion represents the default version of the https://github.com/cirruslabs/cirrus-ci-agent to use.
-	DefaultAgentVersion = "1.23.1"
-
-	// AgentImageBase is used as a prefix to the agent's version to craft the full agent image name.
-	AgentImageBase = "gcr.io/cirrus-ci-community/cirrus-ci-agent:v"
-
-	// Where working volume is mounted to.
-	WorkingVolumeMountpoint = "/tmp/cirrus-ci"
-
-	// Agent binary relative to the WorkingVolumeMountpoint.
-	WorkingVolumeAgentBinary = "cirrus-ci-agent"
-
-	// Working directory relative to the WorkingVolumeMountpoint.
-	WorkingVolumeWorkingDir = "working-dir"
-)
-
 type Volume struct {
 	name string
 }
 
 // CreateWorkingVolumeFromConfig returns name of the working volume created according to the specification in config.
-func CreateWorkingVolumeFromConfig(ctx context.Context, config *RunConfig) (*Volume, error) {
+func CreateWorkingVolumeFromConfig(
+	ctx context.Context,
+	config *RunConfig,
+	platform platform.Platform,
+) (*Volume, error) {
 	initLogger := config.Logger.Scoped("Preparing execution environment...")
 	initLogger.Infof("Preparing volume to work with...")
 	desiredVolumeName := fmt.Sprintf("cirrus-working-volume-%s", uuid.New().String())
 	v, err := CreateWorkingVolume(ctx, config.ContainerBackend, desiredVolumeName,
-		config.ProjectDir, config.DirtyMode, config.GetAgentVersion())
+		config.ProjectDir, config.DirtyMode, config.GetAgentVersion(), platform)
 	if err != nil {
 		initLogger.Warnf("Failed to create a volume from working directory: %v", err)
 		initLogger.Finish(false)
@@ -60,8 +47,9 @@ func CreateWorkingVolume(
 	projectDir string,
 	dontPopulate bool,
 	agentVersion string,
+	platform platform.Platform,
 ) (vol *Volume, err error) {
-	agentImage := AgentImageBase + agentVersion
+	agentImage := platform.AgentImage(agentVersion)
 
 	// Retrieve the latest agent image
 	if err := backend.ImagePull(ctx, agentImage); err != nil {
@@ -77,26 +65,16 @@ func CreateWorkingVolume(
 		}
 	}()
 
-	// Where we will mount the project directory for further copying into a working volume
-	const projectDirMountpoint = "/project-dir"
-
-	// Create and start a helper container that will copy the agent and project directory
-	// (if not specified otherwise) into the working volume
-	copyCmd := fmt.Sprintf("cp /bin/cirrus-ci-agent %s", path.Join(WorkingVolumeMountpoint, WorkingVolumeAgentBinary))
-
-	if !dontPopulate {
-		copyCmd += fmt.Sprintf(" && rsync -r --filter=':- .gitignore' %s/ %s",
-			projectDirMountpoint, path.Join(WorkingVolumeMountpoint, WorkingVolumeWorkingDir))
-	}
-
+	// Create and start a helper container that will copy the project directory (if needed) and the agent
+	// into the working volume
 	input := &containerbackend.ContainerCreateInput{
 		Image:   agentImage,
-		Command: []string{"/bin/sh", "-c", copyCmd},
+		Command: platform.CopyCommand(!dontPopulate),
 		Mounts: []containerbackend.ContainerMount{
 			{
 				Type:   containerbackend.MountTypeVolume,
 				Source: name,
-				Target: WorkingVolumeMountpoint,
+				Target: platform.WorkingVolumeMountpoint(),
 			},
 		},
 	}
@@ -105,7 +83,7 @@ func CreateWorkingVolume(
 		input.Mounts = append(input.Mounts, containerbackend.ContainerMount{
 			Type:     containerbackend.MountTypeBind,
 			Source:   projectDir,
-			Target:   projectDirMountpoint,
+			Target:   platform.ProjectDirMountpoint(),
 			ReadOnly: true,
 		})
 

--- a/internal/executor/instance/volume.go
+++ b/internal/executor/instance/volume.go
@@ -25,7 +25,7 @@ const (
 	WorkingVolumeMountpoint = "/tmp/cirrus-ci"
 
 	// Agent binary relative to the WorkingVolumeMountpoint.
-	WorkingVolumeAgent = "cirrus-ci-agent"
+	WorkingVolumeAgentBinary = "cirrus-ci-agent"
 
 	// Working directory relative to the WorkingVolumeMountpoint.
 	WorkingVolumeWorkingDir = "working-dir"
@@ -81,7 +81,7 @@ func CreateWorkingVolume(
 
 	// Create and start a helper container that will copy the agent and project directory
 	// (if not specified otherwise) into the working volume
-	copyCmd := fmt.Sprintf("cp /bin/cirrus-ci-agent %s", path.Join(WorkingVolumeMountpoint, WorkingVolumeAgent))
+	copyCmd := fmt.Sprintf("cp /bin/cirrus-ci-agent %s", path.Join(WorkingVolumeMountpoint, WorkingVolumeAgentBinary))
 
 	if !dontPopulate {
 		copyCmd += fmt.Sprintf(" && rsync -r --filter=':- .gitignore' %s/ %s",

--- a/internal/executor/instance/volume_test.go
+++ b/internal/executor/instance/volume_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package instance_test
 
 import (
@@ -6,6 +8,7 @@ import (
 	"fmt"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -25,7 +28,8 @@ func TestWorkingVolumeSmoke(t *testing.T) {
 		desiredVolumeName,
 		dir,
 		false,
-		instance.DefaultAgentVersion,
+		platform.DefaultAgentVersion,
+		platform.NewUnix(),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -48,7 +52,8 @@ func TestCleanupOnFailure(t *testing.T) {
 		desiredVolumeName,
 		"/non-existent",
 		false,
-		instance.DefaultAgentVersion,
+		platform.DefaultAgentVersion,
+		platform.NewUnix(),
 	)
 	require.Error(t, err)
 

--- a/internal/executor/instance/volume_test.go
+++ b/internal/executor/instance/volume_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package instance_test
 
 import (
@@ -29,7 +27,7 @@ func TestWorkingVolumeSmoke(t *testing.T) {
 		dir,
 		false,
 		platform.DefaultAgentVersion,
-		platform.NewUnix(),
+		platform.Auto(),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -53,7 +51,7 @@ func TestCleanupOnFailure(t *testing.T) {
 		"/non-existent",
 		false,
 		platform.DefaultAgentVersion,
-		platform.NewUnix(),
+		platform.Auto(),
 	)
 	require.Error(t, err)
 

--- a/internal/executor/instance/volume_test.go
+++ b/internal/executor/instance/volume_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
 	"github.com/google/uuid"
@@ -23,6 +24,7 @@ func TestWorkingVolumeSmoke(t *testing.T) {
 	volume, err := instance.CreateWorkingVolume(
 		context.Background(),
 		backend,
+		options.ContainerOptions{},
 		desiredVolumeName,
 		dir,
 		false,
@@ -47,6 +49,7 @@ func TestCleanupOnFailure(t *testing.T) {
 	_, err := instance.CreateWorkingVolume(
 		context.Background(),
 		testutil.ContainerBackendFromEnv(t),
+		options.ContainerOptions{},
 		desiredVolumeName,
 		"/non-existent",
 		false,

--- a/internal/executor/platform/auto.go
+++ b/internal/executor/platform/auto.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package platform
+
+func Auto() Platform {
+	return NewUnix()
+}

--- a/internal/executor/platform/auto_windows.go
+++ b/internal/executor/platform/auto_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package platform
+
+func Auto() Platform {
+	return NewWindows("")
+}

--- a/internal/executor/platform/platform.go
+++ b/internal/executor/platform/platform.go
@@ -1,0 +1,29 @@
+package platform
+
+const (
+	// WorkingVolumeWorkingDir is a working directory relative to the WorkingVolumeMountpoint().
+	WorkingVolumeWorkingDir = "working-dir"
+
+	// WorkingVolumeAgentBinary is the name of the agent binary relative to the WorkingVolumeMountpoint().
+	WorkingVolumeAgentBinary = "cirrus-ci-agent"
+
+	// AgentImageBase is used as a prefix to the agent's version to craft the full agent image name.
+	AgentImageBase = "gcr.io/cirrus-ci-community/cirrus-ci-agent:v"
+
+	// DefaultAgentVersion represents the default version of the https://github.com/cirruslabs/cirrus-ci-agent to use.
+	DefaultAgentVersion = "1.24.0"
+)
+
+type Platform interface {
+	// Where we will mount the project directory for further copying into a working volume
+	ProjectDirMountpoint() string
+
+	// Where working volume is mounted to when running Docker containers on Unix-like platforms.
+	WorkingVolumeMountpoint() string
+
+	AgentImage(version string) string
+
+	CopyCommand(populate bool) []string
+
+	AgentBinaryPath() string
+}

--- a/internal/executor/platform/unix.go
+++ b/internal/executor/platform/unix.go
@@ -1,0 +1,41 @@
+package platform
+
+import (
+	"fmt"
+	"path"
+)
+
+type UnixPlatform struct{}
+
+func NewUnix() Platform {
+	return &UnixPlatform{}
+}
+
+func (platform *UnixPlatform) ProjectDirMountpoint() string {
+	return "/project-dir"
+}
+
+func (platform *UnixPlatform) WorkingVolumeMountpoint() string {
+	return "/tmp/cirrus-ci"
+}
+
+func (platform *UnixPlatform) AgentImage(version string) string {
+	return AgentImageBase + version
+}
+
+func (platform *UnixPlatform) CopyCommand(populate bool) []string {
+	copyCmd := fmt.Sprintf("cp /bin/cirrus-ci-agent %s",
+		path.Join(platform.WorkingVolumeMountpoint(), WorkingVolumeAgentBinary))
+
+	if populate {
+		copyCmd += fmt.Sprintf(" && rsync -r --filter=':- .gitignore' %s/ %s",
+			platform.ProjectDirMountpoint(),
+			path.Join(platform.WorkingVolumeMountpoint(), WorkingVolumeWorkingDir))
+	}
+
+	return []string{"/bin/sh", "-c", copyCmd}
+}
+
+func (platform *UnixPlatform) AgentBinaryPath() string {
+	return path.Join(platform.WorkingVolumeMountpoint(), WorkingVolumeAgentBinary)
+}

--- a/internal/executor/platform/windows.go
+++ b/internal/executor/platform/windows.go
@@ -5,10 +5,25 @@ import (
 	"path/filepath"
 )
 
-type WindowsPlatform struct{}
+type WindowsPlatform struct {
+	image string
+}
 
-func NewWindows() Platform {
-	return &WindowsPlatform{}
+func NewWindows(osVersion string) Platform {
+	var image string
+
+	switch osVersion {
+	case "1709":
+		image = "mcr.microsoft.com/windows/servercore:1709"
+	case "1803":
+		image = "mcr.microsoft.com/windows/servercore:1803"
+	default:
+		image = "mcr.microsoft.com/windows/servercore:ltsc2019"
+	}
+
+	return &WindowsPlatform{
+		image: image,
+	}
 }
 
 func (platform *WindowsPlatform) ProjectDirMountpoint() string {
@@ -20,7 +35,7 @@ func (platform *WindowsPlatform) WorkingVolumeMountpoint() string {
 }
 
 func (platform *WindowsPlatform) AgentImage(version string) string {
-	return "mcr.microsoft.com/windows/servercore:ltsc2019"
+	return platform.image
 }
 
 func (platform *WindowsPlatform) CopyCommand(populate bool) []string {

--- a/internal/executor/platform/windows.go
+++ b/internal/executor/platform/windows.go
@@ -1,0 +1,44 @@
+package platform
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+type WindowsPlatform struct{}
+
+func NewWindows() Platform {
+	return &WindowsPlatform{}
+}
+
+func (platform *WindowsPlatform) ProjectDirMountpoint() string {
+	return "C:\\project-dir"
+}
+
+func (platform *WindowsPlatform) WorkingVolumeMountpoint() string {
+	return "C:\\Windows\\Temp"
+}
+
+func (platform *WindowsPlatform) AgentImage(version string) string {
+	return "mcr.microsoft.com/windows/servercore:ltsc2019"
+}
+
+func (platform *WindowsPlatform) CopyCommand(populate bool) []string {
+	windowsAgentURL := fmt.Sprintf("https://github.com/cirruslabs/cirrus-ci-agent/releases/"+
+		"download/v%s/agent-windows-amd64.exe", DefaultAgentVersion)
+
+	copyCmd := fmt.Sprintf("(New-Object System.Net.WebClient).DownloadFile(\"%s\", \"%s\")",
+		windowsAgentURL, platform.AgentBinaryPath())
+
+	if populate {
+		copyCmd += fmt.Sprintf("; echo D | xcopy /Y /E /H %s %s",
+			platform.ProjectDirMountpoint(),
+			filepath.Join(platform.WorkingVolumeMountpoint(), WorkingVolumeWorkingDir))
+	}
+
+	return []string{"powershell", copyCmd}
+}
+
+func (platform *WindowsPlatform) AgentBinaryPath() string {
+	return filepath.Join(platform.WorkingVolumeMountpoint(), WorkingVolumeAgentBinary)
+}

--- a/internal/executor/testdata/dirty-mode-windows/.cirrus.yml
+++ b/internal/executor/testdata/dirty-mode-windows/.cirrus.yml
@@ -1,0 +1,7 @@
+windows_container:
+  image: mcr.microsoft.com/windows/servercore:ltsc2019
+
+task:
+  script:
+    - ps: "!(Test-Path -Path file.txt -PathType leaf)"
+    - type nul > file.txt

--- a/internal/worker/worker_tasks_rpc_test.go
+++ b/internal/worker/worker_tasks_rpc_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package worker_test
 
 import (

--- a/internal/worker/worker_tasks_rpc_test.go
+++ b/internal/worker/worker_tasks_rpc_test.go
@@ -1,11 +1,10 @@
-// +build !windows
-
 package worker_test
 
 import (
 	"context"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"io"
+	"runtime"
 )
 
 type TasksRPC struct {
@@ -18,6 +17,13 @@ func (tasksRPC *TasksRPC) InitialCommands(
 	ctx context.Context,
 	request *api.InitialCommandsRequest,
 ) (*api.CommandsResponse, error) {
+	var checkScript string
+	if runtime.GOOS == "windows" {
+		checkScript = "type go.mod"
+	} else {
+		checkScript = "test -e go.mod"
+	}
+
 	return &api.CommandsResponse{
 		Environment: map[string]string{
 			"CIRRUS_REPO_CLONE_URL": "http://github.com/cirruslabs/cirrus-cli.git",
@@ -34,9 +40,7 @@ func (tasksRPC *TasksRPC) InitialCommands(
 				Name: "check",
 				Instruction: &api.Command_ScriptInstruction{
 					ScriptInstruction: &api.ScriptInstruction{
-						Scripts: []string{
-							"test -e go.mod",
-						},
+						Scripts: []string{checkScript},
 					},
 				},
 			},

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package worker_test
 
 import (

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package worker_test
 
 import (

--- a/internal/worker/worker_workers_rpc_test.go
+++ b/internal/worker/worker_workers_rpc_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package worker_test
 
 import (

--- a/internal/worker/worker_workers_rpc_test.go
+++ b/internal/worker/worker_workers_rpc_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package worker_test
 
 import (

--- a/pkg/larker/fs/github/github.go
+++ b/pkg/larker/fs/github/github.go
@@ -52,7 +52,7 @@ func (gh *GitHub) Get(ctx context.Context, path string) ([]byte, error) {
 
 	// Simulate os.Read() behavior in case the supplied path points to a directory
 	if fileContent == nil {
-		return nil, syscall.EISDIR
+		return nil, fs.ErrNormalizedIsADirectory
 	}
 
 	fileBytes, err := base64.StdEncoding.DecodeString(*fileContent.Content)

--- a/pkg/larker/fs/github/github_test.go
+++ b/pkg/larker/fs/github/github_test.go
@@ -47,7 +47,7 @@ func TestGetDirectory(t *testing.T) {
 	_, err := selfFS().Get(context.Background(), ".")
 
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, syscall.EISDIR))
+	assert.True(t, errors.Is(err, fs.ErrNormalizedIsADirectory))
 }
 
 func TestGetNonExistentFile(t *testing.T) {

--- a/pkg/larker/fs/local/local_test.go
+++ b/pkg/larker/fs/local/local_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/local"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 )
 
@@ -65,7 +65,7 @@ func TestGetDirectory(t *testing.T) {
 	_, err := local.New(dir).Get(context.Background(), ".")
 
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, syscall.EISDIR))
+	assert.True(t, errors.Is(err, fs.ErrNormalizedIsADirectory))
 }
 
 func TestGetNonExistentFile(t *testing.T) {
@@ -86,7 +86,7 @@ func TestPivotNoDotDotBreakout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "/chroot/etc/passwd", pivotedPath)
+	assert.Equal(t, filepath.FromSlash("/chroot/etc/passwd"), pivotedPath)
 }
 
 func TestChdir(t *testing.T) {
@@ -99,5 +99,5 @@ func TestChdir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "/tmp/working-directory", pivotedPath)
+	assert.Equal(t, filepath.FromSlash("/tmp/working-directory"), pivotedPath)
 }

--- a/pkg/larker/fs/normalize.go
+++ b/pkg/larker/fs/normalize.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package fs
+
+import "syscall"
+
+var ErrNormalizedIsADirectory = syscall.EISDIR

--- a/pkg/larker/fs/normalize_windows.go
+++ b/pkg/larker/fs/normalize_windows.go
@@ -1,0 +1,7 @@
+package fs
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+var ErrNormalizedIsADirectory = windows.ERROR_INVALID_HANDLE


### PR DESCRIPTION
Some things that still need to be put in place:

* a few more Windows-specific tests
* pick up container instance's `os_version` and change the base image (`mcr.microsoft.com/windows/servercore:ltsc2019`) used for the service container accordingly

Resolves #38.