### PR TITLE
Podman backend: properly treat SELinux disable flag

### DIFF
--- a/internal/executor/instance/containerbackend/podman_linux.go
+++ b/internal/executor/instance/containerbackend/podman_linux.go
@@ -370,7 +370,7 @@ func (backend *Podman) ContainerCreate(
 	}
 
 	if input.DisableSELinux {
-		specGen.Annotations = map[string]string{"io.podman.annotations.label": "disable"}
+		specGen.SelinuxOpts = []string{"disable"}
 	}
 
 	// nolint:bodyclose // already closed by Swagger-generated code

--- a/internal/executor/instance/containerbackend/podman_linux.go
+++ b/internal/executor/instance/containerbackend/podman_linux.go
@@ -369,6 +369,10 @@ func (backend *Podman) ContainerCreate(
 		}
 	}
 
+	if input.DisableSELinux {
+		specGen.Annotations = map[string]string{"io.podman.annotations.label": "disable"}
+	}
+
 	// nolint:bodyclose // already closed by Swagger-generated code
 	cont, _, err := backend.cli.ContainersApi.LibpodCreateContainer(ctx, &swagger.ContainersApiLibpodCreateContainerOpts{
 		Body: optional.NewInterface(&specGen),


### PR DESCRIPTION
This results in `podman inspect` output similar to one can get when running with `--security-opt label=disable`.

However, for some reason the container process gets a label like `system_u:system_r:container_t:s0:c283,c879` instead of `unconfined_u:system_r:spc_t:s0`.

Resolves #192.