### PR TITLE
windows_container instance support in parser

### DIFF
--- a/pkg/parser/instance/windowscontainer.go
+++ b/pkg/parser/instance/windowscontainer.go
@@ -1,0 +1,133 @@
+package instance
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/boolevator"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/nameable"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parseable"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/schema"
+	jsschema "github.com/lestrrat-go/jsschema"
+	"strconv"
+)
+
+const (
+	defaultWindowsCPU    = 1.0
+	defaultWindowsMemory = 1024
+)
+
+type WindowsContainer struct {
+	proto *api.ContainerInstance
+
+	parseable.DefaultParser
+}
+
+func NewWindowsCommunityContainer(mergedEnv map[string]string, boolevator *boolevator.Boolevator) *WindowsContainer {
+	container := &WindowsContainer{
+		proto: &api.ContainerInstance{
+			Platform: api.Platform_WINDOWS,
+		},
+	}
+
+	imageSchema := schema.String("Docker Image to use.")
+	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
+		image, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+		container.proto.Image = image
+		return nil
+	})
+
+	dockerfileSchema := schema.String("Relative path to Dockerfile to build container from.")
+	container.OptionalField(nameable.NewSimpleNameable("dockerfile"), dockerfileSchema, func(node *node.Node) error {
+		dockerfile, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+		container.proto.Dockerfile = dockerfile
+		return nil
+	})
+
+	dockerArgumentsNameable := nameable.NewSimpleNameable("docker_arguments")
+	dockerArgumentsSchema := schema.Map("Arguments for Docker build")
+	container.OptionalField(dockerArgumentsNameable, dockerArgumentsSchema, func(node *node.Node) error {
+		dockerArguments, err := node.GetStringMapping()
+		if err != nil {
+			return err
+		}
+		container.proto.DockerArguments = dockerArguments
+		return nil
+	})
+
+	osVersionSchema := schema.Enum([]interface{}{"2019", "1709", "1803"}, "Windows version of container.")
+	container.OptionalField(nameable.NewSimpleNameable("os_version"), osVersionSchema, func(node *node.Node) error {
+		osVersion, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+
+		container.proto.OsVersion = osVersion
+
+		return nil
+	})
+
+	container.OptionalField(nameable.NewSimpleNameable("cpu"), schema.Number(""), func(node *node.Node) error {
+		cpu, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+		cpuFloat, err := strconv.ParseFloat(cpu, 32)
+		if err != nil {
+			return err
+		}
+		container.proto.Cpu = float32(cpuFloat)
+		return nil
+	})
+
+	container.OptionalField(nameable.NewSimpleNameable("memory"), schema.Memory(), func(node *node.Node) error {
+		memory, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+		memoryParsed, err := ParseMegaBytes(memory)
+		if err != nil {
+			return err
+		}
+		container.proto.Memory = uint32(memoryParsed)
+		return nil
+	})
+
+	// no-op
+	sipSchema := schema.Condition("")
+	container.OptionalField(nameable.NewSimpleNameable("use_static_ip"), sipSchema, func(node *node.Node) error {
+		return nil
+	})
+
+	return container
+}
+
+func (container *WindowsContainer) Parse(node *node.Node) (*api.ContainerInstance, error) {
+	if err := container.DefaultParser.Parse(node); err != nil {
+		return nil, err
+	}
+
+	// Resource defaults
+	if container.proto.Cpu == 0 {
+		container.proto.Cpu = defaultWindowsCPU
+	}
+	if container.proto.Memory == 0 {
+		container.proto.Memory = defaultWindowsMemory
+	}
+
+	return container.proto, nil
+}
+
+func (container *WindowsContainer) Schema() *jsschema.Schema {
+	modifiedSchema := container.DefaultParser.Schema()
+
+	modifiedSchema.Type = jsschema.PrimitiveTypes{jsschema.ObjectType}
+	modifiedSchema.Description = "Windows Container definition for Community Cluster."
+
+	return modifiedSchema
+}

--- a/pkg/parser/instance/windowscontainer.go
+++ b/pkg/parser/instance/windowscontainer.go
@@ -11,11 +11,6 @@ import (
 	"strconv"
 )
 
-const (
-	defaultWindowsCPU    = 1.0
-	defaultWindowsMemory = 1024
-)
-
 type WindowsContainer struct {
 	proto *api.ContainerInstance
 
@@ -114,10 +109,10 @@ func (container *WindowsContainer) Parse(node *node.Node) (*api.ContainerInstanc
 
 	// Resource defaults
 	if container.proto.Cpu == 0 {
-		container.proto.Cpu = defaultWindowsCPU
+		container.proto.Cpu = defaultCPU
 	}
 	if container.proto.Memory == 0 {
-		container.proto.Memory = defaultWindowsMemory
+		container.proto.Memory = defaultMemory
 	}
 
 	return container.proto, nil

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -338,7 +338,6 @@ func TestSchema(t *testing.T) {
 		"gcp_credentials",
 		"gke_container",
 		"osx_instance",
-		"windows_container",
 	}
 
 	for _, ignoredInstance := range ignoredInstances {

--- a/pkg/parser/testdata/via-rpc/container_build-osVersion.json
+++ b/pkg/parser/testdata/via-rpc/container_build-osVersion.json
@@ -1,0 +1,90 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "./test1.sh",
+            "./test2.sh"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "windows"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "dockerfile": "ci/Dockerfile.windows",
+      "image": "gcr.io/cirrus-ci-community/d41d8cd98f00b204e9800998ecf8427e:latest",
+      "memory": 4096,
+      "osVersion": "1803",
+      "platform": "WINDOWS"
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "task1",
+    "requiredGroups": [
+      "1"
+    ]
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "build",
+        "scriptInstruction": {
+          "scripts": [
+            "docker build --tag gcr.io/cirrus-ci-community/d41d8cd98f00b204e9800998ecf8427e:latest --file ci/Dockerfile.windows ."
+          ]
+        }
+      },
+      {
+        "name": "push",
+        "scriptInstruction": {
+          "scripts": [
+            "gcloud docker -- push gcr.io/cirrus-ci-community/d41d8cd98f00b204e9800998ecf8427e:latest"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "windows"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PrebuiltImageInstance",
+      "dockerfile": "ci/Dockerfile.windows",
+      "platform": "WINDOWS",
+      "reference": "latest",
+      "repository": "cirrus-ci-community/d41d8cd98f00b204e9800998ecf8427e"
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "1",
+        "skip_notifications": "true",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "Prebuild ci/Dockerfile.windows"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/container_build-osVersion.yml
+++ b/pkg/parser/testdata/via-rpc/container_build-osVersion.yml
@@ -1,0 +1,9 @@
+windows_container:
+  dockerfile: ci/Dockerfile.windows
+  os_version: 1803
+
+task:
+  name: task1
+  script:
+    - ./test1.sh
+    - ./test2.sh


### PR DESCRIPTION
Needed to run with `--experimental-parser` on Windows when using Windows Containers introduced in #188.