### PR TITLE
Allocate task's local index ID before only_if filtration

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -110,6 +110,7 @@ func (p *Parser) parseTasks(tree *node.Node) ([]task.ParseableTaskLike, error) {
 			}
 
 			taskLike.SetID(p.NextTaskID())
+			taskLike.SetIndexWithinBuild(p.NextTaskLocalIndex())
 
 			// Set task's name if not set in the definition
 			if taskLike.Name() == "" {
@@ -131,8 +132,6 @@ func (p *Parser) parseTasks(tree *node.Node) ([]task.ParseableTaskLike, error) {
 			if !enabled {
 				continue
 			}
-
-			taskLike.SetIndexWithinBuild(p.NextTaskLocalIndex())
 
 			tasks = append(tasks, taskLike)
 		}


### PR DESCRIPTION
Resolves #199.