### PR TITLE
Parser: properly deep-copy the virtual node used for collectible fields

### DIFF
--- a/pkg/parser/node/finder.go
+++ b/pkg/parser/node/finder.go
@@ -23,11 +23,10 @@ func (node *Node) DeepFindCollectible(name string) *Node {
 	for i := len(traverseChain) - 1; i >= 0; i-- {
 		child := traverseChain[i]
 
+		virtualNode.MergeFrom(child)
+
 		if !fulfilledAtLeastOnce {
-			virtualNode = *child
 			fulfilledAtLeastOnce = true
-		} else {
-			virtualNode.MergeFrom(child)
 		}
 	}
 

--- a/pkg/parser/testdata/via-rpc/new-virtual-node-is-deepcopied.json
+++ b/pkg/parser/testdata/via-rpc/new-virtual-node-is-deepcopied.json
@@ -1,0 +1,81 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux",
+      "KEK": "WRONG"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      },
+      "uniqueLabels": [
+        "KEK:WRONG"
+      ]
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux",
+      "KEK": "RIGHT"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "1",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      },
+      "uniqueLabels": [
+        "KEK:RIGHT"
+      ]
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-virtual-node-is-deepcopied.yml
+++ b/pkg/parser/testdata/via-rpc/new-virtual-node-is-deepcopied.yml
@@ -1,0 +1,13 @@
+container:
+  image: debian:latest
+
+env:
+  KEK: RIGHT
+
+task:
+  env:
+    KEK: WRONG
+  script: true
+
+task:
+  script: true


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/cirruslabs/cirrus-cli/pull/209.