### PR TITLE
Parser: properly treat task aliases

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -300,7 +300,7 @@ func resolveDependenciesShallow(tasks []task.ParseableTaskLike) {
 		var dependsOnIDs []int64
 		for _, dependsOnName := range task.DependsOnNames() {
 			for _, subTask := range tasks {
-				if subTask.Name() == dependsOnName {
+				if subTask.Name() == dependsOnName || subTask.Alias() == dependsOnName {
 					dependsOnIDs = append(dependsOnIDs, subTask.ID())
 				}
 			}

--- a/pkg/parser/task/dockerbuilder.go
+++ b/pkg/parser/task/dockerbuilder.go
@@ -125,15 +125,15 @@ func (dbuilder *DockerBuilder) Parse(node *node.Node) error {
 }
 
 func (dbuilder *DockerBuilder) Name() string {
-	if dbuilder.alias != "" {
-		return dbuilder.alias
-	}
-
 	return dbuilder.proto.Name
 }
 
 func (dbuilder *DockerBuilder) SetName(name string) {
 	dbuilder.proto.Name = name
+}
+
+func (dbuilder *DockerBuilder) Alias() string {
+	return dbuilder.alias
 }
 
 func (dbuilder *DockerBuilder) DependsOnNames() []string {

--- a/pkg/parser/task/pipe.go
+++ b/pkg/parser/task/pipe.go
@@ -263,15 +263,15 @@ func (pipe *DockerPipe) Parse(node *node.Node) error {
 }
 
 func (pipe *DockerPipe) Name() string {
-	if pipe.alias != "" {
-		return pipe.alias
-	}
-
 	return pipe.proto.Name
 }
 
 func (pipe *DockerPipe) SetName(name string) {
 	pipe.proto.Name = name
+}
+
+func (pipe *DockerPipe) Alias() string {
+	return pipe.alias
 }
 
 func (pipe *DockerPipe) DependsOnNames() []string {

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -206,15 +206,15 @@ func (task *Task) Parse(node *node.Node) error {
 }
 
 func (task *Task) Name() string {
-	if task.alias != "" {
-		return task.alias
-	}
-
 	return task.proto.Name
 }
 
 func (task *Task) SetName(name string) {
 	task.proto.Name = name
+}
+
+func (task *Task) Alias() string {
+	return task.alias
 }
 
 func (task *Task) DependsOnNames() []string {

--- a/pkg/parser/task/tasklike.go
+++ b/pkg/parser/task/tasklike.go
@@ -8,6 +8,7 @@ import (
 type ParseableTaskLike interface {
 	Name() string
 	SetName(name string)
+	Alias() string
 	DependsOnNames() []string
 
 	ID() int64

--- a/pkg/parser/testdata/via-rpc/new-alias-reuse.json
+++ b/pkg/parser/testdata/via-rpc/new-alias-reuse.json
@@ -1,0 +1,113 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "test something 1"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "test1"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "test something 2"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "1",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "test2"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "release stuff"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "2",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "2",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "release",
+    "requiredGroups": [
+      "0",
+      "1"
+    ]
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-alias-reuse.yml
+++ b/pkg/parser/testdata/via-rpc/new-alias-reuse.yml
@@ -1,0 +1,14 @@
+container:
+  image: debian:latest
+
+test1_task:
+  alias: Tests
+  script: test something 1
+
+test2_task:
+  alias: Tests
+  script: test something 2
+
+release_task:
+  depends_on: Tests
+  script: release stuff

--- a/pkg/parser/testdata/via-rpc/new-duplicate-task-names-are-kept.json
+++ b/pkg/parser/testdata/via-rpc/new-duplicate-task-names-are-kept.json
@@ -1,0 +1,73 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 1"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "Test"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 2"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "1",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "Test"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-duplicate-task-names-are-kept.yml
+++ b/pkg/parser/testdata/via-rpc/new-duplicate-task-names-are-kept.yml
@@ -1,0 +1,10 @@
+# Ensures that we treat task aliases separately from their names.
+
+container:
+  image: debian:latest
+
+Test_task:
+  alias: Tests
+  matrix:
+    script: echo 1
+    script: echo 2


### PR DESCRIPTION
They are not a substitute for names.