### PR TITLE
Link virtual node back to tree

### DIFF
--- a/pkg/parser/node/finder.go
+++ b/pkg/parser/node/finder.go
@@ -36,6 +36,8 @@ func (node *Node) DeepFindCollectible(name string) *Node {
 
 	// Simulate Cirrus Cloud parser behavior
 	virtualNode.Deduplicate()
+	// link to the tree so collectible sub-fields will work
+	virtualNode.Parent = node
 
 	return &virtualNode
 }

--- a/pkg/parser/node/finder.go
+++ b/pkg/parser/node/finder.go
@@ -36,7 +36,7 @@ func (node *Node) DeepFindCollectible(name string) *Node {
 
 	// Simulate Cirrus Cloud parser behavior
 	virtualNode.Deduplicate()
-	// link to the tree so collectible sub-fields will work
+	// Link to the tree so collectible sub-fields will know about to the tree
 	virtualNode.Parent = node
 
 	return &virtualNode


### PR DESCRIPTION
Fixes regression after #224 when a collectible field of a collectible filed stopped properly parse from top level.