### PR TITLE
Evaluator: populate tasks_count_before_filtering field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
-	github.com/cirruslabs/cirrus-ci-agent v1.25.1
+	github.com/cirruslabs/cirrus-ci-agent v1.27.0
 	github.com/cirruslabs/echelon v1.4.1
 	github.com/cirruslabs/podmanapi v0.1.0
 	github.com/containerd/containerd v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200507155900-a9f01edf17e3/go.mod h1:XT+cAw5wfvsodedcijoh1l9cf7v1x9FlFB/3VmF/O8s=
-github.com/cirruslabs/cirrus-ci-agent v1.25.1 h1:9dg5s1JTA2KC5kvpbGzna4s/ESe16thiH/CbuZy7/6s=
-github.com/cirruslabs/cirrus-ci-agent v1.25.1/go.mod h1:ga2zCGBfC+/+tnlHWa5cHwEuBPnhFuaf1PgTpWPGJWo=
+github.com/cirruslabs/cirrus-ci-agent v1.27.0 h1:1S24EB3IprOwSbdPparqzPyfofwJ3bN6HrutpbRIWhQ=
+github.com/cirruslabs/cirrus-ci-agent v1.27.0/go.mod h1:ga2zCGBfC+/+tnlHWa5cHwEuBPnhFuaf1PgTpWPGJWo=
 github.com/cirruslabs/cirrus-ci-annotations v0.0.0-20200908203753-b813f63941d7/go.mod h1:98qD7HLlBx5aNqWiCH80OTTqTTsbXT69wxnlnrnoL0E=
 github.com/cirruslabs/echelon v1.4.1 h1:7ij7cANbL1feOyds5sRtYLPBJwycFi3nvLKJI4vCOPs=
 github.com/cirruslabs/echelon v1.4.1/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -124,7 +124,10 @@ func (r *ConfigurationEvaluatorServiceServer) EvaluateConfig(
 		return nil, status.Error(codes.InvalidArgument, result.Errors[0])
 	}
 
-	return &api.EvaluateConfigResponse{Tasks: result.Tasks}, nil
+	return &api.EvaluateConfigResponse{
+		Tasks:                     result.Tasks,
+		TasksCountBeforeFiltering: result.TasksCountBeforeFiltering,
+	}, nil
 }
 
 func (r *ConfigurationEvaluatorServiceServer) JSONSchema(

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -50,11 +50,15 @@ type Parser struct {
 	idNumbering         int64
 	indexNumbering      int64
 	additionalInstances map[string]protoreflect.MessageDescriptor
+
+	tasksCountBeforeFiltering int64
 }
 
 type Result struct {
 	Errors []string
 	Tasks  []*api.Task
+
+	TasksCountBeforeFiltering int64
 }
 
 func New(opts ...Option) *Parser {
@@ -122,6 +126,8 @@ func (p *Parser) parseTasks(tree *node.Node) ([]task.ParseableTaskLike, error) {
 			taskSpecificEnv := map[string]string{
 				"CIRRUS_TASK_NAME": taskLike.Name(),
 			}
+
+			p.tasksCountBeforeFiltering++
 
 			enabled, err := taskLike.Enabled(environment.Merge(taskSpecificEnv, p.environment), p.boolevator)
 			if err != nil {
@@ -225,7 +231,8 @@ func (p *Parser) Parse(ctx context.Context, config string) (*Result, error) {
 	})
 
 	return &Result{
-		Tasks: protoTasks,
+		Tasks:                     protoTasks,
+		TasksCountBeforeFiltering: p.tasksCountBeforeFiltering,
 	}, nil
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -378,3 +378,14 @@ func TestSchema(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestTasksCountBeforeFiltering(t *testing.T) {
+	p := parser.New()
+	result, err := p.ParseFromFile(context.Background(), "testdata/tasks-count-before-filtering.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Empty(t, result.Errors)
+	assert.EqualValues(t, 2, result.TasksCountBeforeFiltering)
+}

--- a/pkg/parser/testdata/tasks-count-before-filtering.yml
+++ b/pkg/parser/testdata/tasks-count-before-filtering.yml
@@ -1,0 +1,9 @@
+container:
+  image: debian:latest
+
+foo_task:
+  container:
+    dockerfile: Dockerfile.ci
+
+bar_task:
+  only_if: false


### PR DESCRIPTION
Support the helper field to aid in remote use of the Go parser.