### PR TITLE
Boolevator: ensure we match the whole string

### DIFF
--- a/pkg/parser/boolevator/operator.go
+++ b/pkg/parser/boolevator/operator.go
@@ -83,12 +83,12 @@ func opRegexEquals(a, b interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	equalsOneWay, err := regexp.MatchString(EnsureFullMatch(a.(string)), b.(string))
+	equalsOneWay, err := regexp.MatchString(EnsureFullMultilineMatch(a.(string)), b.(string))
 	if err != nil {
 		return false, err
 	}
 
-	equalsOtherWay, err := regexp.MatchString(EnsureFullMatch(b.(string)), a.(string))
+	equalsOtherWay, err := regexp.MatchString(EnsureFullMultilineMatch(b.(string)), a.(string))
 	if err != nil {
 		return false, err
 	}
@@ -121,7 +121,7 @@ func handleError(arguments ...interface{}) error {
 	return nil
 }
 
-func EnsureFullMatch(r string) string {
+func EnsureFullMultilineMatch(r string) string {
 	var newPrefix, newSuffix string
 
 	alreadyFullyPrefixed := strings.HasPrefix(r, "^(?s)") || strings.HasPrefix(r, "(?s)^")

--- a/pkg/parser/boolevator/operator.go
+++ b/pkg/parser/boolevator/operator.go
@@ -83,12 +83,12 @@ func opRegexEquals(a, b interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	equalsOneWay, err := regexp.MatchString(a.(string), b.(string))
+	equalsOneWay, err := regexp.MatchString(EnsureFullMatch(a.(string)), b.(string))
 	if err != nil {
 		return false, err
 	}
 
-	equalsOtherWay, err := regexp.MatchString(b.(string), a.(string))
+	equalsOtherWay, err := regexp.MatchString(EnsureFullMatch(b.(string)), a.(string))
 	if err != nil {
 		return false, err
 	}
@@ -119,4 +119,28 @@ func handleError(arguments ...interface{}) error {
 	}
 
 	return nil
+}
+
+func EnsureFullMatch(r string) string {
+	var newPrefix, newSuffix string
+
+	alreadyFullyPrefixed := strings.HasPrefix(r, "^(?s)") || strings.HasPrefix(r, "(?s)^")
+
+	// Enable Pattern.DOTALL[1] alternative in Go because otherwise simply adding ^ and $ will be too restricting,
+	// since we actually support multi-line matches.
+	//
+	// [1]: https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#DOTALL
+	if !alreadyFullyPrefixed && !strings.HasPrefix(r, "(?s)") {
+		newPrefix += "(?s)"
+	}
+
+	if !alreadyFullyPrefixed && !strings.HasPrefix(r, "^") {
+		newPrefix += "^"
+	}
+
+	if !strings.HasSuffix(r, "$") {
+		newSuffix += "$"
+	}
+
+	return newPrefix + r + newSuffix
 }

--- a/pkg/parser/boolevator/operator_test.go
+++ b/pkg/parser/boolevator/operator_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 )
 
-// TestEnsureFullMatch ensures that a regular expression passed to EnsureFullMatch()
+// TestEnsureFullMultilineMatch ensures that a regular expression passed to EnsureFullMultilineMatch()
 // will be forced to match the whole string instead of only a part of it.
-func TestEnsureFullMatch(t *testing.T) {
-	match, err := regexp.MatchString(boolevator.EnsureFullMatch("s"), "something")
+func TestEnsureFullMultilineMatch(t *testing.T) {
+	match, err := regexp.MatchString(boolevator.EnsureFullMultilineMatch("s"), "something")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/parser/boolevator/operator_test.go
+++ b/pkg/parser/boolevator/operator_test.go
@@ -1,0 +1,19 @@
+package boolevator_test
+
+import (
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/boolevator"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+// TestEnsureFullMatch ensures that a regular expression passed to EnsureFullMatch()
+// will be forced to match the whole string instead of only a part of it.
+func TestEnsureFullMatch(t *testing.T) {
+	match, err := regexp.MatchString(boolevator.EnsureFullMatch("s"), "something")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.False(t, match)
+}

--- a/pkg/parser/testdata/via-rpc/new-only-if-with-nonexistent-env-var.json
+++ b/pkg/parser/testdata/via-rpc/new-only-if-with-nonexistent-env-var.json
@@ -1,0 +1,37 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "date"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "dummy"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-only-if-with-nonexistent-env-var.yml
+++ b/pkg/parser/testdata/via-rpc/new-only-if-with-nonexistent-env-var.yml
@@ -1,0 +1,9 @@
+container:
+  image: debian:latest
+
+dummy_task:
+  script: date
+
+actual_task:
+  only_if: $CIRRUS_TAG =~ 'v.*'
+  script: date


### PR DESCRIPTION
Otherwise the boolevator will give false-positives for non-existent environment variables that are expanded to `""`.