### PR TITLE
Parser: provide stable iteration order for additional instances

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
@@ -14,9 +14,10 @@ import (
 	"time"
 )
 
+const AttemptsToRetrieveIP = 60 // each attempt every second
+
 var (
-	ErrFailed            = errors.New("Parallels isolation failed")
-	AttemptsToRetrieveIP = uint(60) // each attempt every second
+	ErrFailed = errors.New("Parallels isolation failed")
 )
 
 type Parallels struct {

--- a/pkg/parser/labels.go
+++ b/pkg/parser/labels.go
@@ -34,11 +34,20 @@ func instanceLabels(
 	taskInstance *anypb.Any,
 	additionalInstances map[string]protoreflect.MessageDescriptor,
 ) ([]string, error) {
-	for instanceName, descriptor := range additionalInstances {
+	// Provide stable iteration order
+	var sortedInstanceKeys []string
+	for key := range additionalInstances {
+		sortedInstanceKeys = append(sortedInstanceKeys, key)
+	}
+	sort.Strings(sortedInstanceKeys)
+
+	for _, instanceName := range sortedInstanceKeys {
+		descriptor := additionalInstances[instanceName]
 		if strings.HasSuffix(taskInstance.GetTypeUrl(), string(descriptor.FullName())) {
 			return extractProtoInstanceLabels(taskInstance, instanceName, descriptor)
 		}
 	}
+
 	// Instance-specific labels
 	var labels []string
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -72,6 +72,25 @@ func TestAdditionalInstances(t *testing.T) {
 	assertExpectedTasks(t, absolutize("proto-instance.json"), result)
 }
 
+func TestAdditionalInstanceStability(t *testing.T) {
+	containerInstanceReflect := (&api.ContainerInstance{}).ProtoReflect()
+	p := parser.New(parser.WithAdditionalInstances(map[string]protoreflect.MessageDescriptor{
+		"red_instance":    containerInstanceReflect.Descriptor(),
+		"orange_instance": containerInstanceReflect.Descriptor(),
+		"yellow_instance": containerInstanceReflect.Descriptor(),
+		"green_instance":  containerInstanceReflect.Descriptor(),
+		"blue_instance":   containerInstanceReflect.Descriptor(),
+		"purple_instance": containerInstanceReflect.Descriptor(),
+	}))
+	result, err := p.ParseFromFile(context.Background(), absolutize("additional-instance-stability.yml"))
+
+	require.Nil(t, err)
+	require.Empty(t, result.Errors)
+	require.NotEmpty(t, result.Tasks)
+
+	assertExpectedTasks(t, absolutize("additional-instance-stability.json"), result)
+}
+
 func TestAdditionalTaskProperties(t *testing.T) {
 	protoName := "custom_bool"
 	protoType := descriptor.FieldDescriptorProto_Type(8)

--- a/pkg/parser/testdata/additional-instance-stability.json
+++ b/pkg/parser/testdata/additional-instance-stability.json
@@ -1,0 +1,289 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 1"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 2"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "1",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 3"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "2",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "2",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 4"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "3",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "3",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 5"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "4",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "4",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 6"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "5",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "5",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 7"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "6",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "6",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 8"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "7",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "7",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/additional-instance-stability.yml
+++ b/pkg/parser/testdata/additional-instance-stability.yml
@@ -1,0 +1,13 @@
+container:
+  image: debian:latest
+
+task:
+  matrix:
+    script: echo 1
+    script: echo 2
+    script: echo 3
+    script: echo 4
+    script: echo 5
+    script: echo 6
+    script: echo 7
+    script: echo 8


### PR DESCRIPTION
This ensures that things like osx_instance and macos_instance won't get randomized, resulting in incorrect unique labels set.

Also fix a linter error that somehow made it to the master.