### PR TITLE
[worker] force time sync for Parallels VMs

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
@@ -83,6 +83,10 @@ func (parallels *Parallels) Run(ctx context.Context, config *runconfig.RunConfig
 	if err != nil {
 		return fmt.Errorf("%w: failed to start a shell on VM %q: %v", ErrFailed, vm.Ident(), err)
 	}
+	_, err = stdinBuf.Write([]byte("sudo sntp -sS time.apple.com || true\n"))
+	if err != nil {
+		return fmt.Errorf("%w: failed to sync time on VM %q: %v", ErrFailed, vm.Ident(), err)
+	}
 
 	command := []string{
 		remoteAgentPath,


### PR DESCRIPTION
Suspended VMs don't pick time right away