### PR TITLE
Temporarily switch back to remote parser

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -41,7 +41,7 @@ var dockerfileImagePush bool
 var debugNoCleanup bool
 
 // Experimental features flags.
-var experimentalOldParser bool
+var experimentalParser bool
 
 func run(cmd *cobra.Command, args []string) error {
 	// https://github.com/spf13/cobra/issues/340#issuecomment-374617413
@@ -69,7 +69,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Parse
 	var result *parser.Result
-	if !experimentalOldParser {
+	if experimentalParser {
 		p := parser.New(parser.WithEnvironment(userSpecifiedEnvironment))
 		result, err = p.Parse(cmd.Context(), combinedYAML)
 		if err != nil {
@@ -176,8 +176,8 @@ func newRunCmd() *cobra.Command {
 		"don't remove containers and volumes after execution")
 
 	// Experimental features flags
-	cmd.PersistentFlags().BoolVar(&experimentalOldParser, "legacy-remote-parser", false,
-		"use old configuration parser that sends parse requests to the Cirrus Cloud")
+	cmd.PersistentFlags().BoolVar(&experimentalParser, "experimental-parser", false,
+		"use local configuration parser instead of sending parse request to Cirrus Cloud")
 
 	return cmd
 }

--- a/internal/commands/validate/validate.go
+++ b/internal/commands/validate/validate.go
@@ -20,7 +20,7 @@ var validateFile string
 var environment []string
 
 // Experimental features flags.
-var experimentalOldParser bool
+var experimentalParser bool
 
 var yaml bool
 
@@ -64,7 +64,7 @@ func validate(cmd *cobra.Command, args []string) error {
 	// Parse
 	var result *parser.Result
 
-	if !experimentalOldParser {
+	if experimentalParser {
 		p := parser.New(parser.WithEnvironment(userSpecifiedEnvironment))
 		result, err = p.Parse(cmd.Context(), configuration)
 		if err != nil {
@@ -113,8 +113,8 @@ func NewValidateCmd() *cobra.Command {
 		"use file as the configuration file (the path should end with either .yml or ..star)")
 
 	// Experimental features flags
-	cmd.PersistentFlags().BoolVar(&experimentalOldParser, "legacy-remote-parser", false,
-		"use old configuration parser that sends parse requests to the Cirrus Cloud")
+	cmd.PersistentFlags().BoolVar(&experimentalParser, "experimental-parser", false,
+		"use local configuration parser instead of sending parse request to Cirrus Cloud")
 
 	// A hidden flag to dump YAML representation of tasks and aid in generating test
 	// cases for smooth rpcparser → parser transition

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
-	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/local"
-	"github.com/cirruslabs/cirrus-cli/pkg/parser"
+	"github.com/cirruslabs/cirrus-cli/pkg/rpcparser"
 	"github.com/cirruslabs/echelon"
 	"github.com/cirruslabs/echelon/renderers"
 	"github.com/stretchr/testify/assert"
@@ -329,8 +328,8 @@ func filesContentsSingleVariation(t *testing.T, dir, dockerfileContents string) 
 	}
 
 	// Re-parse the configuration
-	p := parser.New(parser.WithFileSystem(local.New(dir)))
-	result, err := p.ParseFromFile(context.Background(), filepath.Join(dir, ".cirrus.yml"))
+	p := rpcparser.Parser{}
+	result, err := p.ParseFromFile(filepath.Join(dir, ".cirrus.yml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutil/executor.go
+++ b/internal/testutil/executor.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-cli/internal/executor"
-	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/local"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser"
+	"github.com/cirruslabs/cirrus-cli/pkg/rpcparser"
 	"github.com/cirruslabs/echelon"
 	"github.com/cirruslabs/echelon/renderers"
 	"github.com/golang/protobuf/ptypes"
@@ -36,8 +36,8 @@ func Execute(t *testing.T, dir string) error {
 }
 
 func ExecuteWithOptions(t *testing.T, dir string, opts ...executor.Option) error {
-	p := parser.New(parser.WithFileSystem(local.New(dir)))
-	result, err := p.ParseFromFile(context.Background(), filepath.Join(dir, ".cirrus.yml"))
+	p := rpcparser.Parser{}
+	result, err := p.ParseFromFile(filepath.Join(dir, ".cirrus.yml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/rpcparser/parser_test.go
+++ b/pkg/rpcparser/parser_test.go
@@ -1,10 +1,8 @@
 package rpcparser_test
 
 import (
-	"context"
 	"errors"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
-	"github.com/cirruslabs/cirrus-cli/pkg/parser"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"log"
@@ -35,8 +33,8 @@ func TestValidConfigs(t *testing.T) {
 	for _, validCase := range validCases {
 		file := validCase
 		t.Run(file, func(t *testing.T) {
-			p := parser.New()
-			result, err := p.ParseFromFile(context.Background(), absolutize(file))
+			p := rpcparser.Parser{}
+			result, err := p.ParseFromFile(absolutize(file))
 
 			require.Nil(t, err)
 			assert.Empty(t, result.Errors)
@@ -48,8 +46,8 @@ func TestInvalidConfigs(t *testing.T) {
 	for _, invalidCase := range invalidCases {
 		file := invalidCase
 		t.Run(file, func(t *testing.T) {
-			p := parser.New()
-			result, err := p.ParseFromFile(context.Background(), absolutize(file))
+			p := rpcparser.Parser{}
+			result, err := p.ParseFromFile(absolutize(file))
 
 			require.Nil(t, err)
 			assert.NotEmpty(t, result.Errors)


### PR DESCRIPTION
There are still some issues with the `gopkg.in/yaml.v2` left.