### PR TITLE
Parser: support persistent_worker isolation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,6 +11,8 @@ docker_builder:
 docker_builder:
   name: Test (Linux with Podman)
   alias: Tests
+  # https://github.com/cirruslabs/cirrus-cli/issues/260
+  skip: true
   install_podman_script:
     - . /etc/os-release
     - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,10 @@ docker_builder:
     - sudo apt-get -y install podman
   run_podman_background_script:
     - podman system service -t 0 unix:///tmp/podman.sock
+  remove_docker_credentials:
+    # This is needed after https://github.com/cirruslabs/vm-images/commit/59d95c79b83559f9ee16dc5e47986248c38968f8
+    # to ensure Podman pulls gcr.io images without credential errors from gcloud credential helper
+    - rm $HOME/.docker/config.json
   test_script:
     - wget --no-verbose -O - https://golang.org/dl/go1.15.linux-amd64.tar.gz | tar -C /usr/local -xz
     - export PATH=$PATH:/usr/local/go/bin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,10 +20,6 @@ docker_builder:
     - sudo apt-get -y install podman
   run_podman_background_script:
     - podman system service -t 0 unix:///tmp/podman.sock
-  remove_docker_credentials:
-    # This is needed after https://github.com/cirruslabs/vm-images/commit/59d95c79b83559f9ee16dc5e47986248c38968f8
-    # to ensure Podman pulls gcr.io images without credential errors from gcloud credential helper
-    - rm $HOME/.docker/config.json
   test_script:
     - wget --no-verbose -O - https://golang.org/dl/go1.15.linux-amd64.tar.gz | tar -C /usr/local -xz
     - export PATH=$PATH:/usr/local/go/bin

--- a/internal/commands/logs/foldable.go
+++ b/internal/commands/logs/foldable.go
@@ -30,8 +30,7 @@ func (r FoldableLogsRenderer) RenderMessage(entry *echelon.LogEntryMessage) {
 }
 
 func (r FoldableLogsRenderer) printFoldMessage(scopes []string, template string) {
-	scopesCount := len(scopes)
-	if scopesCount > 0 {
+	if scopesCount := len(scopes); scopesCount > 0 {
 		lastScope := scopes[scopesCount-1]
 
 		if r.escapeFunc != nil {

--- a/internal/executor/cache/cache_test.go
+++ b/internal/executor/cache/cache_test.go
@@ -84,8 +84,7 @@ func TestMultipleGetAndPut(t *testing.T) {
 func getRandomBlob(t *testing.T, size int) []byte {
 	buf := make([]byte, size)
 
-	_, err := rand.Read(buf)
-	if err != nil {
+	if _, err := rand.Read(buf); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/parser/instance/isolation/isolation.go
+++ b/pkg/parser/instance/isolation/isolation.go
@@ -1,0 +1,55 @@
+package isolation
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/nameable"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parseable"
+	jsschema "github.com/lestrrat-go/jsschema"
+)
+
+type Isolation struct {
+	proto api.Isolation
+
+	parseable.DefaultParser
+}
+
+func NewIsolation(mergedEnv map[string]string) *Isolation {
+	isolation := &Isolation{}
+
+	parallelsSchema := NewParallels(mergedEnv).Schema()
+	isolation.OptionalField(nameable.NewSimpleNameable("parallels"), parallelsSchema, func(node *node.Node) error {
+		parallels := NewParallels(mergedEnv)
+
+		if err := parallels.Parse(node); err != nil {
+			return err
+		}
+
+		isolation.proto.Type = parallels.Proto()
+
+		return nil
+	})
+
+	return isolation
+}
+
+func (isolation *Isolation) Parse(node *node.Node) error {
+	if err := isolation.DefaultParser.Parse(node); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (isolation *Isolation) Proto() *api.Isolation {
+	return &isolation.proto
+}
+
+func (isolation *Isolation) Schema() *jsschema.Schema {
+	modifiedSchema := isolation.DefaultParser.Schema()
+
+	modifiedSchema.Type = jsschema.PrimitiveTypes{jsschema.ObjectType}
+	modifiedSchema.Description = "Persistent Worker isolation."
+
+	return modifiedSchema
+}

--- a/pkg/parser/instance/isolation/parallels.go
+++ b/pkg/parser/instance/isolation/parallels.go
@@ -1,0 +1,117 @@
+package isolation
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/nameable"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parseable"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parsererror"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/schema"
+	jsschema "github.com/lestrrat-go/jsschema"
+	"sort"
+	"strings"
+)
+
+type Parallels struct {
+	proto *api.Isolation_Parallels_
+
+	parseable.DefaultParser
+}
+
+func NewParallels(mergedEnv map[string]string) *Parallels {
+	parallels := &Parallels{
+		proto: &api.Isolation_Parallels_{
+			Parallels: &api.Isolation_Parallels{},
+		},
+	}
+
+	imageSchema := schema.String("Image name.")
+	parallels.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
+		image, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+
+		parallels.proto.Parallels.Image = image
+
+		return nil
+	})
+
+	userSchema := schema.String("SSH username")
+	parallels.OptionalField(nameable.NewSimpleNameable("user"), userSchema, func(node *node.Node) error {
+		user, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+
+		parallels.proto.Parallels.User = user
+
+		return nil
+	})
+
+	passwordSchema := schema.String("SSH password")
+	parallels.OptionalField(nameable.NewSimpleNameable("password"), passwordSchema, func(node *node.Node) error {
+		password, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+
+		parallels.proto.Parallels.Password = password
+
+		return nil
+	})
+
+	// Prepare a list of platforms
+	var platformsLowercased []string
+	for _, platformName := range api.Platform_name {
+		platformsLowercased = append(platformsLowercased, strings.ToLower(platformName))
+	}
+
+	sort.Strings(platformsLowercased)
+
+	var platformsInterfaced []interface{}
+	for _, lowercasePlatform := range platformsLowercased {
+		platformsInterfaced = append(platformsInterfaced, lowercasePlatform)
+	}
+
+	platformSchema := schema.Enum(platformsInterfaced, "Image Platform.")
+	parallels.OptionalField(nameable.NewSimpleNameable("platform"), platformSchema, func(node *node.Node) error {
+		platform, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+
+		resolvedPlatform, ok := api.Platform_value[strings.ToUpper(platform)]
+		if !ok {
+			return fmt.Errorf("%w: unsupported platform name: %q", parsererror.ErrParsing, platform)
+		}
+
+		parallels.proto.Parallels.Platform = api.Platform(resolvedPlatform)
+
+		return nil
+	})
+
+	return parallels
+}
+
+func (parallels *Parallels) Parse(node *node.Node) error {
+	if err := parallels.DefaultParser.Parse(node); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (parallels *Parallels) Proto() *api.Isolation_Parallels_ {
+	return parallels.proto
+}
+
+func (parallels *Parallels) Schema() *jsschema.Schema {
+	modifiedSchema := parallels.DefaultParser.Schema()
+
+	modifiedSchema.Type = jsschema.PrimitiveTypes{jsschema.ObjectType}
+	modifiedSchema.Description = "Parallels VM isolation."
+
+	return modifiedSchema
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -379,7 +379,6 @@ func TestSchema(t *testing.T) {
 		"gke_container",
 		"osx_instance",
 		"macos_instance",
-		"persistent_worker",
 		// cloud task properties
 		"auto_cancellation",
 		"execution_lock",
@@ -405,12 +404,6 @@ func TestSchema(t *testing.T) {
 	}
 
 	delete(referenceObject, "fileMatch")
-
-	// Remove persistent_worker instance from our schema since it's not present in the reference schema
-	delete(ourObject["properties"].(map[string]interface{}), "persistent_worker")
-
-	patternedTask := ourObject["patternProperties"].(map[string]interface{})["^(.*)task$"]
-	delete(patternedTask.(map[string]interface{})["properties"].(map[string]interface{}), "persistent_worker")
 
 	// Compare two schemas
 	differ := gojsondiff.New()

--- a/pkg/parser/testdata/cirrus.json
+++ b/pkg/parser/testdata/cirrus.json
@@ -3588,10 +3588,9 @@
                     "platform": {
                       "description": "Image Platform.",
                       "enum": [
-                        "freebsd",
+                        "darwin",
                         "linux",
-                        "windows",
-                        "solaris"
+                        "windows"
                       ]
                     },
                     "user": {
@@ -4663,10 +4662,9 @@
                 "platform": {
                   "description": "Image Platform.",
                   "enum": [
-                    "freebsd",
+                    "darwin",
                     "linux",
-                    "windows",
-                    "solaris"
+                    "windows"
                   ]
                 },
                 "user": {

--- a/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-none.json
+++ b/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-none.json
@@ -1,0 +1,37 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "./ci/integration-tests.sh"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PersistentWorkerInstance",
+      "labels": {
+        "device": "iPhone12ProMax"
+      }
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-none.json
+++ b/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-none.json
@@ -14,9 +14,6 @@
         }
       }
     ],
-    "environment": {
-      "CIRRUS_OS": "linux"
-    },
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PersistentWorkerInstance",
       "labels": {

--- a/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-none.yml
+++ b/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-none.yml
@@ -1,0 +1,5 @@
+task:
+  persistent_worker:
+    labels:
+      device: iPhone12ProMax
+  script: ./ci/integration-tests.sh

--- a/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-parallels.json
+++ b/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-parallels.json
@@ -15,7 +15,7 @@
       }
     ],
     "environment": {
-      "CIRRUS_OS": "linux"
+      "CIRRUS_OS": "darwin"
     },
     "instance": {
       "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PersistentWorkerInstance",

--- a/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-parallels.json
+++ b/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-parallels.json
@@ -1,0 +1,46 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.PersistentWorkerInstance",
+      "isolation": {
+        "parallels": {
+          "image": "big-sur-base",
+          "password": "secret",
+          "platform": "DARWIN",
+          "user": "admin"
+        }
+      },
+      "labels": {
+        "A": "B",
+        "C": "D"
+      }
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-parallels.yml
+++ b/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-parallels.yml
@@ -1,0 +1,13 @@
+persistent_worker:
+  isolation:
+    parallels:
+      image: big-sur-base
+      user: admin
+      password: secret
+      platform: darwin
+  labels:
+    A: B
+    C: D
+
+task:
+  script: true


### PR DESCRIPTION
The tests will pass (with a little nudge) once corresponding changes to the cloud parser will be rolled out.

Resolves #252.