### PR TITLE
Parallels: sync time without NTP

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -103,7 +104,9 @@ func (parallels *Parallels) Run(ctx context.Context, config *runconfig.RunConfig
 	if err != nil {
 		return fmt.Errorf("%w: failed to start a shell on VM %q: %v", ErrFailed, vm.Ident(), err)
 	}
-	_, err = stdinBuf.Write([]byte("sudo sntp -sS time.apple.com || true\n"))
+
+	// Synchronize time
+	_, err = stdinBuf.Write([]byte(TimeSyncCommand(time.Now().UTC())))
 	if err != nil {
 		return fmt.Errorf("%w: failed to sync time on VM %q: %v", ErrFailed, vm.Ident(), err)
 	}
@@ -135,4 +138,8 @@ func (parallels *Parallels) Run(ctx context.Context, config *runconfig.RunConfig
 
 func (parallels *Parallels) WorkingDirectory(projectDir string, dirtyMode bool) string {
 	return platform.NewUnix().WorkingVolumeMountpoint() + platform.WorkingVolumeWorkingDir
+}
+
+func TimeSyncCommand(t time.Time) string {
+	return fmt.Sprintf("sudo date %s\n", t.Format("010215042006"))
 }

--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels_test.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels_test.go
@@ -1,0 +1,15 @@
+package parallels_test
+
+import (
+	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/isolation/parallels"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestTimeSyncCommand(t *testing.T) {
+	// https://www.epochconverter.com/?q=1234567890
+	timeFixture := time.Unix(1234567890, 0).UTC()
+
+	assert.Equal(t, "sudo date 021323312009\n", parallels.TimeSyncCommand(timeFixture))
+}


### PR DESCRIPTION
This should improve the robustness in the presence of network errors, but this makes an assumption that time is synchronized properly on the host.

The time format passed to the `date` command is [governed by POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/date.html), so it should work on all other platforms (see #253), except for the Windows.

Should help with cirruslabs/cirrus-ci-docs#772.