### PR TITLE
Use GWDG's mirror instead of broken openSUSE traffic director

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,8 +14,8 @@ docker_builder:
   install_podman_script:
     - sudo rm /root/.docker/config.json || true
     - . /etc/os-release
-    - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-    - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+    - echo "deb https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    - curl -L https://ftp.gwdg.de/pub/opensuse/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
     - sudo apt-get update
     - sudo apt-get -y upgrade
     - sudo apt-get -y install podman


### PR DESCRIPTION
Should help with Podman installation failing.