### PR TITLE
Parser: switch to yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/cirruslabs/cirrus-cli
 
 go 1.14
 
-// https://github.com/go-yaml/yaml/pull/364
-replace gopkg.in/yaml.v2 => github.com/cirruslabs/yaml v0.0.0-20201223192638-1984d0f98f29
-
 require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/PaesslerAG/gval v1.1.0
@@ -75,6 +72,6 @@ require (
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	gotest.tools/v3 v3.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/cirruslabs/echelon v1.4.1 h1:7ij7cANbL1feOyds5sRtYLPBJwycFi3nvLKJI4vC
 github.com/cirruslabs/echelon v1.4.1/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=
 github.com/cirruslabs/podmanapi v0.1.0 h1:JRRVDNKdg2fYooyQaTMEqrCVyPDmEqqPLtLflO8iTDI=
 github.com/cirruslabs/podmanapi v0.1.0/go.mod h1:Wpm7jzVEmeRCw1H2lW++/DCId83DSa4KJ3ZfjUWCdwU=
-github.com/cirruslabs/yaml v0.0.0-20201223192638-1984d0f98f29 h1:Xup+l4/hePD8+OpwiPEyW02lJZR7s7g+mHuvwpW4jDU=
-github.com/cirruslabs/yaml v0.0.0-20201223192638-1984d0f98f29/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -173,6 +171,7 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -915,6 +914,14 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
+gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/parser/modifier/matrix/matrix_test.go
+++ b/pkg/parser/modifier/matrix/matrix_test.go
@@ -5,7 +5,8 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	yamlv2 "gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,8 +23,8 @@ func getDocument(t *testing.T, path string, index int) string {
 	}
 	defer file.Close()
 
-	decoder := yaml.NewDecoder(file)
-	var document yaml.MapSlice
+	decoder := yamlv2.NewDecoder(file)
+	var document yamlv2.MapSlice
 
 	for i := 0; i < index; i++ {
 		if err := decoder.Decode(&document); err != nil {
@@ -31,7 +32,7 @@ func getDocument(t *testing.T, path string, index int) string {
 		}
 	}
 
-	bytes, err := yaml.Marshal(document)
+	bytes, err := yamlv2.Marshal(document)
 	if err != nil {
 		t.Fatalf("%s: %s", newPath, err)
 	}
@@ -40,8 +41,8 @@ func getDocument(t *testing.T, path string, index int) string {
 }
 
 // Unmarshals YAML specified by yamlText to a yaml.MapSlice to simplify comparison.
-func yamlAsStruct(t *testing.T, yamlText string) (result yaml.MapSlice) {
-	if err := yaml.Unmarshal([]byte(yamlText), &result); err != nil {
+func yamlAsStruct(t *testing.T, yamlText string) (result yamlv2.MapSlice) {
+	if err := yamlv2.Unmarshal([]byte(yamlText), &result); err != nil {
 		t.Fatal(err)
 	}
 
@@ -84,13 +85,13 @@ var badCases = []struct {
 }
 
 func runPreprocessor(input string, expand bool) (string, error) {
-	var parsed yaml.MapSlice
-	err := yaml.Unmarshal([]byte(input), &parsed)
+	var parsed yamlv3.Node
+	err := yamlv3.Unmarshal([]byte(input), &parsed)
 	if err != nil {
 		return "", err
 	}
 
-	tree, err := node.NewFromSlice(parsed)
+	tree, err := node.NewFromNode(&parsed)
 	if err != nil {
 		return "", err
 	}
@@ -101,7 +102,7 @@ func runPreprocessor(input string, expand bool) (string, error) {
 		}
 	}
 
-	outputBytes, err := yaml.Marshal(&tree)
+	outputBytes, err := yamlv2.Marshal(tree)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/parser/node/accessor_test.go
+++ b/pkg/parser/node/accessor_test.go
@@ -4,16 +4,23 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 	"testing"
 )
 
-func TestGetExpandedStringValue(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "name", Value: "Batched $VALUE-${I}"},
+func YamlNodeFromString(t *testing.T, yaml string) *yamlv3.Node {
+	var result yamlv3.Node
+
+	if err := yamlv3.Unmarshal([]byte(yaml), &result); err != nil {
+		t.Fatal(err)
 	}
 
-	tree, err := node.NewFromSlice(yamlSlice)
+	return &result
+}
+
+func TestGetExpandedStringValue(t *testing.T) {
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `name: Batched $VALUE-${I}
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,14 +38,10 @@ func TestGetExpandedStringValue(t *testing.T) {
 }
 
 func TestGetStringMapping(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "env", Value: yaml.MapSlice{
-			{Key: "KEY1", Value: "VALUE1"},
-			{Key: "KEY2", Value: "VALUE2"},
-		}},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `env:
+  KEY1: VALUE1
+  KEY2: VALUE2
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,18 +57,13 @@ func TestGetStringMapping(t *testing.T) {
 }
 
 func TestGetSliceOfNonEmptyStrings(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "script_single_scalar", Value: "command1"},
-		{Key: "script_single_list", Value: []interface{}{
-			"command1",
-		}},
-		{Key: "script_multiple_list", Value: []interface{}{
-			"command1",
-			"command2",
-		}},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `script_single_scalar: command1
+script_single_list:
+  - command1
+script_multiple_list:
+  - command1
+  - command2
+`))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/parser/node/finder_test.go
+++ b/pkg/parser/node/finder_test.go
@@ -4,27 +4,20 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 	"testing"
 )
 
 func TestDeepFindChild(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "task", Value: yaml.MapSlice{
-			{Key: "container", Value: yaml.MapSlice{
-				{Key: "matrix", Value: yaml.MapSlice{
-					{Key: "image", Value: "debian:latest"},
-					{Key: "image", Value: "ubuntu:latest"},
-				}},
-			}},
-			{Key: "matrix", Value: yaml.MapSlice{
-				{Key: "name", Value: "First task"},
-				{Key: "name", Value: "Second task"},
-			}},
-		}},
-	}
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `task:
+  container:
+    matrix:
+      image: debian:latest
+      image: ubuntu:latest
 
-	tree, err := node.NewFromSlice(yamlSlice)
+    matrix:
+      name: First task
+      name: Second task
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,20 +29,13 @@ func TestDeepFindChild(t *testing.T) {
 }
 
 func TestDeepFindCollectible(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		// First tree's children
-		{Key: "env", Value: yaml.MapSlice{
-			{Key: "KEY1", Value: "VALUE1"},
-		}},
-		// Second tree's children
-		{Key: "alpha", Value: yaml.MapSlice{
-			{Key: "env", Value: yaml.MapSlice{
-				{Key: "KEY2", Value: "VALUE2"},
-			}},
-		}},
-	}
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `env:
+  KEY1: VALUE1
 
-	tree, err := node.NewFromSlice(yamlSlice)
+alpha:
+  env:
+    KEY2: VALUE2
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,18 +46,12 @@ func TestDeepFindCollectible(t *testing.T) {
 }
 
 func TestDeepFindChildrenSameLevel(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "alpha", Value: yaml.MapSlice{
-			{Key: "env", Value: yaml.MapSlice{
-				{Key: "KEY1", Value: "VALUE1"},
-			}},
-			{Key: "env", Value: yaml.MapSlice{
-				{Key: "KEY2", Value: "VALUE2"},
-			}},
-		}},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `alpha:
+  env:
+    KEY1: VALUE1
+  env:
+    KEY2: VALUE2
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,11 +63,8 @@ func TestDeepFindChildrenSameLevel(t *testing.T) {
 }
 
 func TestHasChildren(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "some name", Value: "some value"},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `some name: some value
+`))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/parser/node/matrix.go
+++ b/pkg/parser/node/matrix.go
@@ -104,3 +104,23 @@ func (node *Node) ReplaceWith(with []*Node) {
 
 	node.Parent.Children = newChildren
 }
+
+func (node *Node) MergeMapsOrOverwrite(with *Node) {
+	_, nodeIsMap := node.Value.(*MapValue)
+	_, withIsMap := with.Value.(*MapValue)
+	if nodeIsMap && withIsMap {
+		for _, child := range with.Children {
+			child.Parent = node.Parent
+			node.Children = append(node.Children, child)
+		}
+
+		return
+	}
+
+	node.Value = with.Value
+	node.Children = node.Children[:0]
+	for _, child := range with.Children {
+		child.Parent = node.Parent
+		node.Children = append(node.Children, child)
+	}
+}

--- a/pkg/parser/node/matrix_test.go
+++ b/pkg/parser/node/matrix_test.go
@@ -3,22 +3,15 @@ package node_test
 import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 	"testing"
 )
 
 func TestFindParent(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "a", Value: yaml.MapSlice{
-			{Key: "b", Value: yaml.MapSlice{
-				{Key: "c", Value: 42},
-				{Key: "d", Value: 43},
-			}},
-		},
-		},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `a:
+  b:
+    c: 42
+    d: 43
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,17 +33,11 @@ func TestReversePath(t *testing.T) {
 }
 
 func TestPathUpwardsUpto(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "a", Value: yaml.MapSlice{
-			{Key: "b", Value: yaml.MapSlice{
-				{Key: "c", Value: 42},
-				{Key: "d", Value: 43},
-			}},
-		},
-		},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `a:
+  b:
+    c: 42
+    d: 43
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,17 +47,11 @@ func TestPathUpwardsUpto(t *testing.T) {
 }
 
 func TestGetPath(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "a", Value: yaml.MapSlice{
-			{Key: "b", Value: yaml.MapSlice{
-				{Key: "c", Value: 42},
-				{Key: "d", Value: 43},
-			}},
-		},
-		},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `a:
+  b:
+    c: 42
+    d: 43
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,17 +61,11 @@ func TestGetPath(t *testing.T) {
 }
 
 func TestDeepCopy(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "a", Value: yaml.MapSlice{
-			{Key: "b", Value: yaml.MapSlice{
-				{Key: "c", Value: 42},
-				{Key: "d", Value: 43},
-			}},
-		},
-		},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `a:
+  b:
+    c: 42
+    d: 43
+`))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/parser/node/node.go
+++ b/pkg/parser/node/node.go
@@ -3,7 +3,7 @@ package node
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"reflect"
 	"strings"
 )
@@ -162,68 +162,129 @@ func (node *Node) MergeFrom(other *Node) {
 	}
 }
 
-func NewFromSlice(slice yaml.MapSlice) (*Node, error) {
-	return convert(nil, "root", slice)
+func NewFromNode(yamlNode *yaml.Node) (*Node, error) {
+	// Empty document
+	if yamlNode.Kind == 0 || len(yamlNode.Content) == 0 {
+		return &Node{Name: "root"}, nil
+	}
+
+	if yamlNode.Kind != yaml.DocumentNode {
+		return nil, fmt.Errorf("%w: expected a YAML document, but got %s at %d:%d", ErrNodeConversionFailed,
+			yamlKindToString(yamlNode.Kind), yamlNode.Line, yamlNode.Column)
+	}
+
+	if len(yamlNode.Content) > 1 {
+		extraneous := yamlNode.Content[1]
+
+		return nil, fmt.Errorf("%w: YAML document contains extraneous top-level elements,"+
+			" such as %s at %d:%d", ErrNodeConversionFailed, yamlKindToString(extraneous.Kind),
+			extraneous.Line, extraneous.Column)
+	}
+
+	if yamlNode.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("%w: YAML document should contain a mapping as it top-level element,"+
+			" but found %s at %d:%d", ErrNodeConversionFailed, yamlKindToString(yamlNode.Kind),
+			yamlNode.Line, yamlNode.Column)
+	}
+
+	return convert(nil, "root", yamlNode.Content[0])
 }
 
-func convert(parent *Node, name string, obj interface{}) (*Node, error) {
-	var result *Node
+// nolint:gocognit // splitting this into multiple functions would probably make this even less comprehensible
+func convert(parent *Node, name string, yamlNode *yaml.Node) (*Node, error) {
+	result := &Node{
+		Name:   name,
+		Parent: parent,
+	}
 
-	switch typedObj := obj.(type) {
-	case []interface{}:
-		result = &Node{
-			Name:   name,
-			Value:  &ListValue{},
-			Parent: parent,
-		}
+	switch yamlNode.Kind {
+	case yaml.SequenceNode:
+		result.Value = &ListValue{}
 
-		for _, arrayItem := range typedObj {
+		for _, item := range yamlNode.Content {
 			// Ignore null[1] array elements for backwards compatibility
 			//
 			// [1]: https://yaml.org/type/null.html
-			if arrayItem == nil {
+			if item.Tag == "!!null" {
 				continue
 			}
 
-			listSubtree, err := convert(result, "", arrayItem)
+			listSubtree, err := convert(result, "", item)
 			if err != nil {
 				return nil, err
 			}
 
 			result.Children = append(result.Children, listSubtree)
 		}
-	case yaml.MapSlice:
-		result = &Node{
-			Name:   name,
-			Value:  &MapValue{},
-			Parent: parent,
+	case yaml.MappingNode:
+		result.Value = &MapValue{}
+
+		if !isEven(len(yamlNode.Content)) {
+			return nil, fmt.Errorf("%w: unbalanced map at %d:%d", ErrNodeConversionFailed,
+				yamlNode.Line, yamlNode.Column)
 		}
 
-		for _, sliceItem := range typedObj {
+		for i := 0; i < len(yamlNode.Content); i += 2 {
+			// Handle "<<" keys
+			if yamlNode.Content[i].Tag == "!!merge" {
+				aliasValue, err := convert(result, "", yamlNode.Content[i+1])
+				if err != nil {
+					return nil, err
+				}
+
+				result.MergeMapsOrOverwrite(aliasValue)
+
+				continue
+			}
+
 			// Apparently this is possible, so do the sanity check
-			key, ok := sliceItem.Key.(string)
-			if !ok {
+			if yamlNode.Content[i].Tag != "!!str" {
 				return nil, fmt.Errorf("%w: map key is not a string", ErrNodeConversionFailed)
 			}
 
-			mapSubtree, err := convert(result, key, sliceItem.Value)
+			mapSubtree, err := convert(result, yamlNode.Content[i].Value, yamlNode.Content[i+1])
 			if err != nil {
 				return nil, err
 			}
 
 			result.Children = append(result.Children, mapSubtree)
 		}
+	case yaml.ScalarNode:
+		result.Value = &ScalarValue{Value: yamlNode.Value}
+	case yaml.AliasNode:
+		resolvedAlias, err := convert(parent, name, yamlNode.Alias)
+		if err != nil {
+			return nil, err
+		}
+
+		return resolvedAlias, nil
 	default:
-		scalar := &ScalarValue{}
-		if typedObj != nil {
-			scalar.Value = fmt.Sprintf("%v", typedObj)
-		}
-		result = &Node{
-			Name:   name,
-			Value:  scalar,
-			Parent: parent,
-		}
+		return nil, fmt.Errorf("%w: unexpected %s at %d:%d", ErrNodeConversionFailed,
+			yamlKindToString(yamlNode.Kind), yamlNode.Line, yamlNode.Column)
 	}
 
 	return result, nil
+}
+
+func yamlKindToString(kind yaml.Kind) string {
+	switch kind {
+	case yaml.DocumentNode:
+		return "document"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.AliasNode:
+		return "alias"
+	default:
+		return fmt.Sprintf("element of kind %d", kind)
+	}
+}
+
+func isEven(number int) bool {
+	const divisor = 2
+
+	return (number % divisor) == 0
 }

--- a/pkg/parser/node/node_test.go
+++ b/pkg/parser/node/node_test.go
@@ -3,22 +3,16 @@ package node_test
 import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
 	"testing"
 )
 
 func TestScalarToString(t *testing.T) {
-	yamlSlice := yaml.MapSlice{
-		{Key: "boolTrue", Value: true},
-		{Key: "boolFalse", Value: false},
-		{Key: "string", Value: "some value"},
-		{Key: "int", Value: 42},
-		{Key: "uint", Value: uint(42)},
-		{Key: "float32", Value: float32(3.14159)},
-		{Key: "float64", Value: float64(3.14159)},
-	}
-
-	tree, err := node.NewFromSlice(yamlSlice)
+	tree, err := node.NewFromNode(YamlNodeFromString(t, `boolTrue: true
+boolFalse: false
+string: "some value"
+integer: 42
+float: 3.14159
+`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,8 +22,6 @@ func TestScalarToString(t *testing.T) {
 		"false",
 		"some value",
 		"42",
-		"42",
-		"3.14159",
 		"3.14159",
 	}
 

--- a/pkg/parser/node/yaml.go
+++ b/pkg/parser/node/yaml.go
@@ -3,7 +3,7 @@ package node
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
+	yamlv2 "gopkg.in/yaml.v2"
 )
 
 var ErrFailedToMarshal = errors.New("failed to marshal to YAML")
@@ -11,7 +11,7 @@ var ErrFailedToMarshal = errors.New("failed to marshal to YAML")
 func (node *Node) MarshalYAML() (interface{}, error) {
 	switch obj := node.Value.(type) {
 	case *MapValue:
-		var result yaml.MapSlice
+		var result yamlv2.MapSlice
 
 		for _, child := range node.Children {
 			marshalledItem, err := child.MarshalYAML()
@@ -19,7 +19,7 @@ func (node *Node) MarshalYAML() (interface{}, error) {
 				return nil, err
 			}
 
-			result = append(result, yaml.MapItem{
+			result = append(result, yamlv2.MapItem{
 				Key:   child.Name,
 				Value: marshalledItem,
 			})

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -20,7 +20,7 @@ import (
 	"github.com/lestrrat-go/jsschema"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -158,7 +158,7 @@ func (p *Parser) parseTasks(tree *node.Node) ([]task.ParseableTaskLike, error) {
 }
 
 func (p *Parser) Parse(ctx context.Context, config string) (*Result, error) {
-	var parsed yaml.MapSlice
+	var parsed yaml.Node
 
 	// Unmarshal YAML
 	if err := yaml.Unmarshal([]byte(config), &parsed); err != nil {
@@ -167,7 +167,7 @@ func (p *Parser) Parse(ctx context.Context, config string) (*Result, error) {
 
 	// Convert the parsed and nested YAML structure into a tree
 	// to get the ability to walk parents
-	tree, err := node.NewFromSlice(parsed)
+	tree, err := node.NewFromNode(&parsed)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
 	"google.golang.org/protobuf/reflect/protoreflect"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/pkg/parser/testdata/via-rpc/new-floats-are-picked-up-as-is.json
+++ b/pkg/parser/testdata/via-rpc/new-floats-are-picked-up-as-is.json
@@ -1,0 +1,30 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux",
+      "VERSION": "1.0"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-floats-are-picked-up-as-is.yml
+++ b/pkg/parser/testdata/via-rpc/new-floats-are-picked-up-as-is.yml
@@ -1,0 +1,6 @@
+container:
+  image: debian:latest
+
+task:
+  env:
+    VERSION: 1.0

--- a/pkg/parser/testdata/via-rpc/new-non-standard-list-merging.json
+++ b/pkg/parser/testdata/via-rpc/new-non-standard-list-merging.json
@@ -1,0 +1,81 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 123"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux",
+      "DEVICE": "iPhone"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      },
+      "uniqueLabels": [
+        "DEVICE:iPhone"
+      ]
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "echo 123"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux",
+      "DEVICE": "Android"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "1",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      },
+      "uniqueLabels": [
+        "DEVICE:Android"
+      ]
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-non-standard-list-merging.yml
+++ b/pkg/parser/testdata/via-rpc/new-non-standard-list-merging.yml
@@ -1,0 +1,13 @@
+container:
+  image: debian:latest
+
+template: &TEMPLATE
+  - env:
+      DEVICE: iPhone
+  - env:
+      DEVICE: Android
+
+task:
+  matrix:
+    << : *TEMPLATE
+  script: echo 123


### PR DESCRIPTION
This improves Go parser compatibility with the Cloud parser, mainly:

* floats and other non-trivial types are treated as is (see `new-floats-are-picked-up-as-is.yml`)
* non-standard alias merging of lists when using `<<` map keys (see `new-non-standard-list-merging.yml`)

As a side-effect we can now easily save the line and a column from `yaml.Node` in `node.Node` and emit more useful parser error messages.