### PR TITLE
Parallels: kill prl_vm_app processes before running new VMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/lestrrat-go/pdebug v0.0.0-20200204225717-4d6bd78da58d // indirect
 	github.com/lestrrat-go/structinfo v0.0.0-20190212233437-acd51874663b // indirect
 	github.com/magiconair/properties v1.8.4 // indirect
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/mitchellh/mapstructure v1.4.0 // indirect
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/onsi/ginkgo v1.14.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,8 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=

--- a/internal/executor/instance/persistentworker/isolation/parallels/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/vm.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/mitchellh/go-ps"
 	"strings"
+	"syscall"
 )
 
 var ErrVMFailed = errors.New("Parallels VM operation failed")
@@ -33,6 +35,10 @@ type VirtualMachineInfo struct {
 }
 
 func NewVMClonedFrom(ctx context.Context, vmNameFrom string) (*VM, error) {
+	if err := ensureNoVMsRunning(); err != nil {
+		return nil, fmt.Errorf("%w: failed to cleanup already running VMs: %v", ErrVMFailed, err)
+	}
+
 	// We use different cloning strategy depending on the source VM's state
 	vmInfoFrom, err := retrieveInfo(ctx, vmNameFrom)
 	if err != nil {
@@ -159,4 +165,28 @@ func firstNonEmptyLine(lines string) string {
 	}
 
 	return ""
+}
+
+// Sometimes issuing the prlctl stop --kill command isn't enough, and we're not
+// supposed to be running other VMs anyway, so clean them up by killing processes,
+// according to the hint in the unofficial documentation[1].
+//
+// [1]: https://virtuozzosupport.force.com/s/article/000014272
+func ensureNoVMsRunning() error {
+	processes, err := ps.Processes()
+	if err != nil {
+		return err
+	}
+
+	for _, process := range processes {
+		if process.Executable() != "prl_vm_app" {
+			continue
+		}
+
+		if err := syscall.Kill(process.Pid(), syscall.SIGKILL); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/executor/instance/persistentworker/isolation/parallels/vmkiller.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/vmkiller.go
@@ -1,0 +1,5 @@
+package parallels
+
+import "errors"
+
+var ErrVMKiller = errors.New("failed to kill running VM processes")

--- a/internal/executor/instance/persistentworker/isolation/parallels/vmkiller_darwin.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/vmkiller_darwin.go
@@ -1,0 +1,33 @@
+package parallels
+
+import (
+	"fmt"
+	"github.com/mitchellh/go-ps"
+	"syscall"
+)
+
+const vmProcessName = "prl_vm_app"
+
+// Sometimes issuing the prlctl stop --kill command isn't enough, and we're not
+// supposed to be running other VMs anyway, so clean them up by killing processes,
+// according to the hint in the unofficial documentation[1].
+//
+// [1]: https://virtuozzosupport.force.com/s/article/000014272
+func ensureNoVMsRunning() error {
+	processes, err := ps.Processes()
+	if err != nil {
+		return fmt.Errorf("%w: failed to retrieve a list of processes: %v", ErrVMKiller, err)
+	}
+
+	for _, process := range processes {
+		if process.Executable() != vmProcessName {
+			continue
+		}
+
+		if err := syscall.Kill(process.Pid(), syscall.SIGKILL); err != nil {
+			return fmt.Errorf("%w: failed to kill %s process: %v", ErrVMKiller, vmProcessName, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/executor/instance/persistentworker/isolation/parallels/vmkiller_unsupported.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/vmkiller_unsupported.go
@@ -1,0 +1,12 @@
+// +build !darwin
+
+package parallels
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func ensureNoVMsRunning() error {
+	return fmt.Errorf("%w: unsupported platform: %s", ErrVMKiller, runtime.GOOS)
+}


### PR DESCRIPTION
Should help with the problems observed in #248.