### PR TITLE
cirrus {run,validate}: provide context lines for *parsererror.Rich

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/taskfilter"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parsererror"
 	"github.com/cirruslabs/cirrus-cli/pkg/rpcparser"
 	"github.com/spf13/cobra"
 	"os"
@@ -70,10 +71,15 @@ func run(cmd *cobra.Command, args []string) error {
 	// Parse
 	var tasks []*api.Task
 
+	// nolint:nestif // this will be a no-issue once we switch to Go parser
 	if experimentalParser {
 		p := parser.New(parser.WithEnvironment(userSpecifiedEnvironment))
 		result, err := p.Parse(cmd.Context(), combinedYAML)
 		if err != nil {
+			if re, ok := err.(*parsererror.Rich); ok {
+				fmt.Print(re.ContextLines())
+			}
+
 			return err
 		}
 		tasks = result.Tasks

--- a/internal/commands/validate/validate.go
+++ b/internal/commands/validate/validate.go
@@ -8,6 +8,7 @@ import (
 	eenvironment "github.com/cirruslabs/cirrus-cli/internal/executor/environment"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parsererror"
 	"github.com/cirruslabs/cirrus-cli/pkg/rpcparser"
 	"github.com/spf13/cobra"
 	"strings"
@@ -64,10 +65,15 @@ func validate(cmd *cobra.Command, args []string) error {
 	// Parse
 	var tasks []*api.Task
 
+	// nolint:nestif // this will be a no-issue once we switch to Go parser
 	if experimentalParser {
 		p := parser.New(parser.WithEnvironment(userSpecifiedEnvironment))
 		result, err := p.Parse(cmd.Context(), configuration)
 		if err != nil {
+			if re, ok := err.(*parsererror.Rich); ok {
+				fmt.Print(re.ContextLines())
+			}
+
 			return err
 		}
 		tasks = result.Tasks

--- a/pkg/parser/parsererror/parsererror.go
+++ b/pkg/parser/parsererror/parsererror.go
@@ -3,6 +3,7 @@ package parsererror
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var (
@@ -47,4 +48,31 @@ func (rich *Rich) Line() int {
 
 func (rich *Rich) Column() int {
 	return rich.column
+}
+
+func (rich *Rich) ContextLines() string {
+	var result string
+
+	const contextLines = 5
+
+	zeroBasedLine := rich.line - 1
+	zeroBasedColumn := rich.column - 1
+
+	for i, line := range strings.Split(rich.config, "\n") {
+		// Skip lines that are out of context
+		if i < (zeroBasedLine-contextLines) || i > (zeroBasedLine+contextLines) {
+			continue
+		}
+
+		// Insert line-numbered config line
+		lineNumber := fmt.Sprintf("%d: ", i+1)
+		result += lineNumber + line + "\n"
+
+		// Insert a column indicator if this was a line with error
+		if i == zeroBasedLine {
+			result += strings.Repeat(" ", len(lineNumber)+zeroBasedColumn) + "^\n"
+		}
+	}
+
+	return result
 }

--- a/pkg/parser/parsererror/parsererror_test.go
+++ b/pkg/parser/parsererror/parsererror_test.go
@@ -1,0 +1,44 @@
+package parsererror_test
+
+import (
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/parsererror"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMultiLineMessageWithContext(t *testing.T) {
+	pe := parsererror.NewRich(8, 3, "unacceptable condition")
+	pe.Enrich(`first_task:
+  container:
+    image: debian:latest
+
+  script: echo "I'm a first task!"
+
+second_task:
+  containers:
+
+  script: true
+
+third_task:
+  container:
+    image: debian:latest
+
+  script: echo "I'm a third task!"
+`)
+
+	expected := `3:     image: debian:latest
+4: 
+5:   script: echo "I'm a first task!"
+6: 
+7: second_task:
+8:   containers:
+     ^
+9: 
+10:   script: true
+11: 
+12: third_task:
+13:   container:
+`
+
+	assert.Equal(t, expected, pe.ContextLines())
+}


### PR DESCRIPTION
Looks like this:

```
% ~/cirrus run --experimental-parser 
3:     image: debian:latest
4: 
5:   script: echo "I'm a first task!"
6: 
7: second_task:
8:   containers:
     ^
9: 
10:   script: true
11: 
12: third_task:
13:   container:
Error: parsing error: 8:3: task has no instance attached
2021/02/08 21:53:58 parsing error: 8:3: task has no instance attached
```