### PR TITLE
Parallels: fix and simplify Prlctl/Prlsrvctl handling

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/parallels/cli.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/cli.go
@@ -27,6 +27,12 @@ func runParallelsCommand(ctx context.Context, commandName string, args ...string
 			return "", "", fmt.Errorf("%w: %q not found in PATH, make sure Parallels is installed",
 				ErrParallelsCommandNotFound, commandName)
 		}
+
+		// We need to weed out other errors like context.Canceled
+		// to only handle exec.ExitError's below
+		if _, ok := err.(*exec.ExitError); !ok {
+			return "", "", err
+		}
 	}
 
 	return stdout.String(), stderr.String(), fmt.Errorf("%w: %q", ErrParallelsCommandNonZero,

--- a/internal/executor/instance/persistentworker/isolation/parallels/cli.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/cli.go
@@ -28,15 +28,14 @@ func runParallelsCommand(ctx context.Context, commandName string, args ...string
 				ErrParallelsCommandNotFound, commandName)
 		}
 
-		// We need to weed out other errors like context.Canceled
-		// to only handle exec.ExitError's below
-		if _, ok := err.(*exec.ExitError); !ok {
-			return "", "", err
+		if _, ok := err.(*exec.ExitError); ok {
+			// Parallels command failed, redefine the error
+			// to be the Parallels-specific output
+			err = fmt.Errorf("%w: %q", ErrParallelsCommandNonZero, firstNonEmptyLine(stderr.String(), stdout.String()))
 		}
 	}
 
-	return stdout.String(), stderr.String(), fmt.Errorf("%w: %q", ErrParallelsCommandNonZero,
-		firstNonEmptyLine(stderr.String(), stdout.String()))
+	return stdout.String(), stderr.String(), err
 }
 
 func Prlctl(ctx context.Context, args ...string) (string, string, error) {

--- a/internal/executor/instance/persistentworker/isolation/parallels/cli_test.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/cli_test.go
@@ -1,0 +1,32 @@
+package parallels_test
+
+import (
+	"context"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/isolation/parallels"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestPrlctl(t *testing.T) {
+	ctx := context.Background()
+
+	_, imageOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_VM")
+	_, userOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_SSH_USER")
+	_, passwordOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_SSH_PASSWORD")
+	if !imageOk || !userOk || !passwordOk {
+		t.SkipNow()
+	}
+
+	// Working example
+	_, _, err := parallels.Prlctl(ctx, "list")
+	assert.NoError(t, err)
+
+	// Non-working example
+	expectedErrorMessage := `Parallels command returned non-zero exit code: "Failed to get VM config: The virtual` +
+		` machine could not be found. The virtual machine is not registered in the virtual machine directory on your Mac."`
+
+	_, _, err = parallels.Prlctl(ctx, "list", "non-existent-vm")
+	assert.Error(t, err)
+	assert.Equal(t, expectedErrorMessage, err.Error())
+}

--- a/internal/executor/instance/persistentworker/isolation/parallels/clone.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/clone.go
@@ -27,13 +27,12 @@ func cloneFromSuspended(ctx context.Context, vmPathFrom string) (*VM, error) {
 		return nil, fmt.Errorf("%w: failed to copy VM from %q to %q: %v", ErrVMFailed, vmPathFrom, newHome, err)
 	}
 
-	stdout, stderr, err := Prlctl(ctx, "register", newHome, "--uuid", vm.uuid)
+	_, _, err = Prlctl(ctx, "register", newHome, "--uuid", vm.uuid)
 	if err != nil {
 		// Cleanup
 		_ = os.RemoveAll(newHome)
 
-		return nil, fmt.Errorf("%w: failed to import VM from %q: %q", ErrVMFailed, newHome,
-			firstNonEmptyLine(stderr, stdout))
+		return nil, fmt.Errorf("%w: failed to import VM from %q: %v", ErrVMFailed, newHome, err)
 	}
 
 	return vm, nil
@@ -44,10 +43,9 @@ func cloneFromDefault(ctx context.Context, vmNameFrom string) (*VM, error) {
 		name: fmt.Sprintf("cirrus-%s", uuid.New().String()),
 	}
 
-	stdout, stderr, err := Prlctl(ctx, "clone", vmNameFrom, "--name", vm.Ident())
+	_, _, err := Prlctl(ctx, "clone", vmNameFrom, "--name", vm.Ident())
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to clone VM %q: %q", ErrVMFailed, vm.Ident(),
-			firstNonEmptyLine(stderr, stdout))
+		return nil, fmt.Errorf("%w: failed to clone VM %q: %v", ErrVMFailed, vm.Ident(), err)
 	}
 
 	return vm, nil

--- a/internal/executor/instance/persistentworker/isolation/parallels/server.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/server.go
@@ -11,10 +11,9 @@ type ServerInfo struct {
 }
 
 func GetServerInfo(ctx context.Context) (*ServerInfo, error) {
-	stdout, stderr, err := Prlsrvctl(ctx, "info", "--json")
+	stdout, _, err := Prlsrvctl(ctx, "info", "--json")
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to retrieve Parallels server info: %q",
-			ErrVMFailed, firstNonEmptyLine(stderr, stdout))
+		return nil, fmt.Errorf("%w: failed to retrieve Parallels server info: %v", ErrVMFailed, err)
 	}
 
 	var serverInfo ServerInfo


### PR DESCRIPTION
This also fixes `stdout` reuse error in `VM.Close()`:

https://github.com/cirruslabs/cirrus-cli/blob/680cf039a36de18524e5c5a9028d352f7785ed48/internal/executor/instance/persistentworker/isolation/parallels/vm.go#L141-L145