### PR TITLE
Bump agent's version

### DIFF
--- a/internal/executor/platform/platform.go
+++ b/internal/executor/platform/platform.go
@@ -11,7 +11,7 @@ const (
 	AgentImageBase = "gcr.io/cirrus-ci-community/cirrus-ci-agent:v"
 
 	// DefaultAgentVersion represents the default version of the https://github.com/cirruslabs/cirrus-ci-agent to use.
-	DefaultAgentVersion = "1.26.0"
+	DefaultAgentVersion = "1.28.0"
 )
 
 type Platform interface {


### PR DESCRIPTION
To include https://github.com/cirruslabs/cirrus-ci-agent/pull/98 fix.