### PR TITLE
Parallels: support Linux as a target platform

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,9 +49,12 @@ task:
       docker: installed
       parallels: installed
   env:
-    CIRRUS_INTERNAL_PARALLELS_VM: big-sur-base
-    CIRRUS_INTERNAL_PARALLELS_SSH_USER: admin
-    CIRRUS_INTERNAL_PARALLELS_SSH_PASSWORD: admin
+    CIRRUS_INTERNAL_PARALLELS_DARWIN_VM: big-sur-base
+    CIRRUS_INTERNAL_PARALLELS_DARWIN_SSH_USER: admin
+    CIRRUS_INTERNAL_PARALLELS_DARWIN_SSH_PASSWORD: admin
+    CIRRUS_INTERNAL_PARALLELS_LINUX_VM: debian
+    CIRRUS_INTERNAL_PARALLELS_LINUX_SSH_USER: parallels
+    CIRRUS_INTERNAL_PARALLELS_LINUX_SSH_PASSWORD: parallels
   test_script:
     - go version
     - go test -p 1 ./...

--- a/internal/executor/agent/agent.go
+++ b/internal/executor/agent/agent.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 var ErrAgentDownloadFailed = errors.New("failed to download agent")
@@ -54,7 +53,7 @@ func RetrieveBinary(
 
 	// Download the agent
 	agentURL := fmt.Sprintf("https://github.com/cirruslabs/cirrus-ci-agent/releases/download/v%s/agent-%s-%s%s",
-		agentVersion, runtime.GOOS, runtime.GOARCH, agentSuffix)
+		agentVersion, agentOS, agentArchitecture, agentSuffix)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", agentURL, http.NoBody)
 	if err != nil {

--- a/internal/executor/instance/persistentworker/isolation/parallels/cli_test.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/cli_test.go
@@ -11,9 +11,9 @@ import (
 func TestPrlctl(t *testing.T) {
 	ctx := context.Background()
 
-	_, imageOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_VM")
-	_, userOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_SSH_USER")
-	_, passwordOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_SSH_PASSWORD")
+	_, imageOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_DARWIN_VM")
+	_, userOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_DARWIN_SSH_USER")
+	_, passwordOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_DARWIN_SSH_PASSWORD")
 	if !imageOk || !userOk || !passwordOk {
 		t.SkipNow()
 	}

--- a/internal/executor/instance/persistentworker/isolation/parallels/clone.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/clone.go
@@ -12,8 +12,7 @@ func cloneFromSuspended(ctx context.Context, vmPathFrom string) (*VM, error) {
 	vm := &VM{
 		uuid: uuid.New().String(),
 
-		shouldRenewDHCP:  true,
-		delayedIsolation: true,
+		clonedFromSuspended: true,
 	}
 
 	serverInfo, err := GetServerInfo(ctx)

--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
@@ -111,10 +111,12 @@ func (parallels *Parallels) Run(ctx context.Context, config *runconfig.RunConfig
 		return fmt.Errorf("%w: failed to start a shell on VM %q: %v", ErrFailed, vm.Ident(), err)
 	}
 
-	// Synchronize time
-	_, err = stdinBuf.Write([]byte(TimeSyncCommand(time.Now().UTC())))
-	if err != nil {
-		return fmt.Errorf("%w: failed to sync time on VM %q: %v", ErrFailed, vm.Ident(), err)
+	// Synchronize time for suspended VMs
+	if vm.ClonedFromSuspended() {
+		_, err = stdinBuf.Write([]byte(TimeSyncCommand(time.Now().UTC())))
+		if err != nil {
+			return fmt.Errorf("%w: failed to sync time on VM %q: %v", ErrFailed, vm.Ident(), err)
+		}
 	}
 
 	command := []string{

--- a/internal/executor/instance/persistentworker/isolation/parallels/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/vm.go
@@ -15,8 +15,7 @@ type VM struct {
 	uuid string
 	name string
 
-	shouldRenewDHCP  bool
-	delayedIsolation bool
+	clonedFromSuspended bool
 }
 
 type NetworkAdapterInfo struct {
@@ -68,7 +67,7 @@ func NewVMClonedFrom(ctx context.Context, vmNameFrom string) (*VM, error) {
 }
 
 func (vm *VM) Start(ctx context.Context) error {
-	if !vm.delayedIsolation {
+	if !vm.clonedFromSuspended {
 		if err := vm.isolate(ctx); err != nil {
 			return err
 		}
@@ -79,13 +78,14 @@ func (vm *VM) Start(ctx context.Context) error {
 		return fmt.Errorf("%w: failed to start VM %q: %v", ErrVMFailed, vm.Ident(), err)
 	}
 
-	if vm.shouldRenewDHCP {
+	if vm.clonedFromSuspended {
 		if err := vm.renewDHCP(ctx); err != nil {
 			return err
 		}
-	}
 
-	if vm.delayedIsolation {
+		// Isolation is delayed for suspended VMs because Parallels
+		// prevents us from modifying this setting before we start
+		// such VM
 		if err := vm.isolate(ctx); err != nil {
 			return err
 		}

--- a/internal/executor/instance/persistentworker/isolation/parallels/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/vm.go
@@ -66,6 +66,10 @@ func NewVMClonedFrom(ctx context.Context, vmNameFrom string) (*VM, error) {
 	return cloneFromDefault(ctx, vmInfoFrom.Name)
 }
 
+func (vm *VM) ClonedFromSuspended() bool {
+	return vm.clonedFromSuspended
+}
+
 func (vm *VM) Start(ctx context.Context) error {
 	if !vm.clonedFromSuspended {
 		if err := vm.isolate(ctx); err != nil {

--- a/internal/executor/instance/persistentworker/persistentworker.go
+++ b/internal/executor/instance/persistentworker/persistentworker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/abstract"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/isolation/none"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/isolation/parallels"
+	"strings"
 )
 
 var ErrInvalidIsolation = errors.New("invalid isolation parameters")
@@ -20,11 +21,12 @@ func New(isolation *api.Isolation) (abstract.Instance, error) {
 	case *api.Isolation_None_:
 		return none.New()
 	case *api.Isolation_Parallels_:
-		if iso.Parallels.Platform != api.Platform_DARWIN {
-			return nil, fmt.Errorf("%w: only Darwin is currently supported", ErrInvalidIsolation)
+		if iso.Parallels.Platform != api.Platform_DARWIN && iso.Parallels.Platform != api.Platform_LINUX {
+			return nil, fmt.Errorf("%w: only Darwin and Linux are currently supported", ErrInvalidIsolation)
 		}
 
-		return parallels.New(iso.Parallels.Image, iso.Parallels.User, iso.Parallels.Password, "darwin")
+		return parallels.New(iso.Parallels.Image, iso.Parallels.User, iso.Parallels.Password,
+			strings.ToLower(iso.Parallels.Platform.String()))
 	default:
 		return nil, fmt.Errorf("%w: unsupported isolation type %T", ErrInvalidIsolation, iso)
 	}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -60,9 +60,9 @@ func TestWorker(t *testing.T) {
 	var isolation *api.Isolation
 
 	// Support Parallels isolation testing configured via environment variables
-	image, imageOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_VM")
-	user, userOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_SSH_USER")
-	password, passwordOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_SSH_PASSWORD")
+	image, imageOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_DARWIN_VM")
+	user, userOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_DARWIN_SSH_USER")
+	password, passwordOk := os.LookupEnv("CIRRUS_INTERNAL_PARALLELS_DARWIN_SSH_PASSWORD")
 	if imageOk && userOk && passwordOk {
 		t.Logf("Using Parallels VM %s for testing...", image)
 		sharedNetworkHostIP, err := parallels.SharedNetworkHostIP(context.Background())


### PR DESCRIPTION
As for the Windows, we could use [github.com/masterzen/winrm](https://github.com/masterzen/winrm) + [github.com/packer-community/winrmcp](https://github.com/packer-community/winrmcp) (a nasty Powershell abomination for copying files), but this requires the user to pre-configure the WinRM in the base image and it's unclear how we are going to test this.

So my proposal here is to simply skip the Windows use-case in favor of the Cirrus Cloud since no-one asked for it.

Resolves #253.