### PR TITLE
No need for gotip anymore

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,29 +74,6 @@ task:
   binaries_artifacts:
     path: "dist/cirrus_*/cirrus*"
 
-apple_silicon: &APPLE_SILICON_BUILD
-  osx_instance:
-    image: catalina-xcode
-  env:
-    GOPATH: $HOME/go
-    PATH: $GOPATH/bin:$PATH
-  install_script:
-    - brew update
-    - brew install go
-  gotip_script:
-    - go get golang.org/dl/gotip
-    - gotip download
-    - gotip version
-  build_script:
-    - CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 gotip build -o cirrus-darwin-arm64 -ldflags "-X github.com/cirruslabs/cirrus-cli/internal/version.Version=$CIRRUS_TAG" cmd/cirrus/main.go
-
-task:
-  name: Release Apple Silicon (Dry Run)
-  only_if: $CIRRUS_TAG == ''
-  << : *APPLE_SILICON_BUILD
-  binary_artifacts:
-    path: cirrus-darwin-arm64
-
 task:
   name: Release
   only_if: $CIRRUS_TAG != ''
@@ -111,17 +88,3 @@ task:
     memory: 12G
   install_script: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
   release_script: ./bin/goreleaser
-
-task:
-  name: Release Apple Silicon
-  only_if: $CIRRUS_RELEASE != ''
-  depends_on: Release
-  env:
-    GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
-  <<: *APPLE_SILICON_BUILD
-  upload_script: |
-    curl -X POST \
-        --data-binary @cirrus-darwin-arm64 \
-        --header "Authorization: token $GITHUB_TOKEN" \
-        --header "Content-Type: application/octet-stream" \
-        https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=cirrus-darwin-arm64


### PR DESCRIPTION
Go 1.16 was just released and GoReleaser introduced darwin/arm64 support [a few hours ago](https://github.com/goreleaser/goreleaser/releases/tag/v0.156.0).