### PR TITLE
.golangci.yml: use linter whitelist instead of blacklist

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
   enable:
   - asciicheck
   - bodyclose
-  - cyclop
   - deadcode
   - depguard
   - dogsled
@@ -108,6 +107,9 @@ linters:
 
     # Advantages of using t.Helper() are too small to waste developer's cognitive stamina on it.
     - thelper
+
+    # Too restrictive defaults, plus there's already a gocyclo linter in place.
+    - cyclop
 
 issues:
   # Don't hide multiple issues that belong to one class since GitHub annotations can handle them all nicely.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,14 +9,61 @@ linters-settings:
     default-signifies-exhaustive: true
 
 linters:
-  # Selecting all available presets effectively enables all linters.
-  presets:
-    - bugs
-    - complexity
-    - format
-    - performance
-    - style
-    - unused
+  enable:
+  - asciicheck
+  - bodyclose
+  - cyclop
+  - deadcode
+  - depguard
+  - dogsled
+  - dupl
+  - durationcheck
+  - errcheck
+  - exhaustive
+  - exportloopref
+  - gochecknoinits
+  - gocognit
+  - goconst
+  - gocritic
+  - gocyclo
+  - godot
+  - godox
+  - goerr113
+  - gofmt
+  - goheader
+  - golint
+  - gomnd
+  - gomodguard
+  - goprintffuncname
+  - gosec
+  - gosimple
+  - govet
+  - ifshort
+  - ineffassign
+  - interfacer
+  - lll
+  - makezero
+  - misspell
+  - nakedret
+  - nestif
+  - noctx
+  - nolintlint
+  - predeclared
+  - revive
+  - rowserrcheck
+  - scopelint
+  - sqlclosecheck
+  - staticcheck
+  - structcheck
+  - stylecheck
+  - testpackage
+  - tparallel
+  - typecheck
+  - unconvert
+  - unparam
+  - unused
+  - varcheck
+  - whitespace
 
   disable:
     # Messages like "struct of size 104 bytes could be of size 96 bytes" from a package

--- a/internal/executor/instance/container.go
+++ b/internal/executor/instance/container.go
@@ -44,11 +44,7 @@ func (inst *ContainerInstance) Run(ctx context.Context, config *runconfig.RunCon
 		WorkingVolumeName:    workingVolume.Name(),
 	}
 
-	if err := RunContainerizedAgent(ctx, config, params); err != nil {
-		return err
-	}
-
-	return nil
+	return RunContainerizedAgent(ctx, config, params)
 }
 
 func (inst *ContainerInstance) WorkingDirectory(projectDir string, dirtyMode bool) string {

--- a/internal/executor/instance/persistentworker/isolation/none/none.go
+++ b/internal/executor/instance/persistentworker/isolation/none/none.go
@@ -72,11 +72,7 @@ func (pwi *PersistentWorkerInstance) Run(ctx context.Context, config *runconfig.
 	}
 
 	// Run the agent
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Run()
 }
 
 func (pwi *PersistentWorkerInstance) WorkingDirectory(projectDir string, dirtyMode bool) string {

--- a/internal/worker/worker_tasks_rpc_test.go
+++ b/internal/worker/worker_tasks_rpc_test.go
@@ -72,11 +72,7 @@ func (tasksRPC *TasksRPC) StreamLogs(stream api.CirrusCIService_StreamLogsServer
 		}
 	}
 
-	if err := stream.SendAndClose(&api.UploadLogsResponse{}); err != nil {
-		return err
-	}
-
-	return nil
+	return stream.SendAndClose(&api.UploadLogsResponse{})
 }
 
 func (tasksRPC *TasksRPC) Heartbeat(

--- a/pkg/parser/instance/isolation/isolation.go
+++ b/pkg/parser/instance/isolation/isolation.go
@@ -34,11 +34,7 @@ func NewIsolation(mergedEnv map[string]string) *Isolation {
 }
 
 func (isolation *Isolation) Parse(node *node.Node) error {
-	if err := isolation.DefaultParser.Parse(node); err != nil {
-		return err
-	}
-
-	return nil
+	return isolation.DefaultParser.Parse(node)
 }
 
 func (isolation *Isolation) Proto() *api.Isolation {

--- a/pkg/parser/instance/isolation/parallels.go
+++ b/pkg/parser/instance/isolation/parallels.go
@@ -94,11 +94,7 @@ func NewParallels(mergedEnv map[string]string) *Parallels {
 }
 
 func (parallels *Parallels) Parse(node *node.Node) error {
-	if err := parallels.DefaultParser.Parse(node); err != nil {
-		return err
-	}
-
-	return nil
+	return parallels.DefaultParser.Parse(node)
 }
 
 func (parallels *Parallels) Proto() *api.Isolation_Parallels_ {

--- a/pkg/parser/parseable/parseable.go
+++ b/pkg/parser/parseable/parseable.go
@@ -117,9 +117,5 @@ func evaluateCollectible(node *node.Node, field CollectibleField) error {
 		return nil
 	}
 
-	if err := field.onFound(children); err != nil {
-		return err
-	}
-
-	return nil
+	return field.onFound(children)
 }

--- a/pkg/parser/task/behavior.go
+++ b/pkg/parser/task/behavior.go
@@ -81,11 +81,7 @@ func NewBehavior(mergedEnv map[string]string, boolevator *boolevator.Boolevator)
 }
 
 func (b *Behavior) Parse(node *node.Node) error {
-	if err := b.DefaultParser.Parse(node); err != nil {
-		return err
-	}
-
-	return nil
+	return b.DefaultParser.Parse(node)
 }
 
 func (b *Behavior) Proto() []*api.Command {

--- a/pkg/parser/task/piperesources.go
+++ b/pkg/parser/task/piperesources.go
@@ -50,11 +50,7 @@ func NewPipeResources(mergedEnv map[string]string) *PipeResources {
 }
 
 func (res *PipeResources) Parse(node *node.Node) error {
-	if err := res.DefaultParser.Parse(node); err != nil {
-		return err
-	}
-
-	return nil
+	return res.DefaultParser.Parse(node)
 }
 
 func (res *PipeResources) Schema() *jsschema.Schema {


### PR DESCRIPTION
Blacklist is still kept to enable new linter recommendations in the future.