### PR TITLE
Don't assume platform by default

### DIFF
--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -205,6 +205,21 @@ proto_task:
 	})
 }
 
+// TestAdditionalInstances ensures that complex dynamically provided instances are respected.
+func TestAdditionalWorkersEmptyInstances(t *testing.T) {
+	yamlConfig := `
+regular_task:
+  persistent_worker: {}
+
+proto_task:
+  proto_persistent_worker: {}
+`
+
+	evaluateTwoTasksIdentical(t, yamlConfig, map[string]string{
+		"proto_persistent_worker": "org.cirruslabs.ci.services.cirruscigrpc.PersistentWorkerInstance",
+	})
+}
+
 func evaluateTwoTasksIdentical(t *testing.T, yamlConfig string, additionalInstancesMapping map[string]string) {
 	response, err := evaluateHelper(t, &api.EvaluateConfigRequest{
 		YamlConfig: yamlConfig,

--- a/pkg/parser/instance/proto.go
+++ b/pkg/parser/instance/proto.go
@@ -323,13 +323,7 @@ func GuessPlatform(anyInstance *anypb.Any, descriptor protoreflect.MessageDescri
 
 	dynamicMessage := dynamicpb.NewMessage(descriptor)
 	_ = proto.Unmarshal(anyInstance.GetValue(), dynamicMessage)
-	platformField := GuessPlatformOfProtoMessage(dynamicMessage, descriptor)
-
-	if platformField != "" {
-		return platformField
-	}
-
-	return "linux"
+	return GuessPlatformOfProtoMessage(dynamicMessage, descriptor)
 }
 
 func GuessPlatformOfProtoMessage(message protoreflect.Message, descriptor protoreflect.MessageDescriptor) string {
@@ -340,6 +334,10 @@ func GuessPlatformOfProtoMessage(message protoreflect.Message, descriptor protor
 		valueDescription := platformField.Enum().Values().Get(int(value.Enum()))
 		enumName := string(valueDescription.Name())
 		return strings.ToLower(enumName)
+	}
+	if platformField != nil {
+		// there is platform field but it's not set so let's return the default
+		return "linux"
 	}
 	for i := 0; i < fields.Len(); i++ {
 		field := fields.Get(i)

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -151,11 +151,14 @@ func NewTask(
 				return err
 			}
 			task.proto.Instance = anyInstance
-			task.proto.Environment = environment.Merge(
-				task.proto.Environment, map[string]string{
-					"CIRRUS_OS": instance.GuessPlatform(anyInstance, scopedDescriptor),
-				},
-			)
+			platform := instance.GuessPlatform(anyInstance, scopedDescriptor)
+			if platform != "" {
+				task.proto.Environment = environment.Merge(
+					task.proto.Environment, map[string]string{
+						"CIRRUS_OS": platform,
+					},
+				)
+			}
 			return nil
 		})
 	}


### PR DESCRIPTION
If proto instance like `persistent_worker` doesn't have `platform` field then don't assume it's `linux` and simply don't set `CIRRUS_OS`.