### PR TITLE
Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+update_configs:
+  - package_manager: "go:modules"
+    directory: "/"
+    update_schedule: daily
+    allowed_updates:
+      - match:
+          update_type: security
+      - match:
+          dependency_name: "github.com/certifi/gocertifi"


### PR DESCRIPTION
Only check for security updates and updates for https://github.com/certifi/gocertifi (since it provides periodically changing X.509 certificates) for now.