### PR TITLE
Parser: fix collectible fields evaluation order

### DIFF
--- a/pkg/parser/parseable/default.go
+++ b/pkg/parser/parseable/default.go
@@ -36,6 +36,15 @@ func (parser *DefaultParser) CollectibleField(name string, schema *schema.Schema
 	})
 }
 
+func (parser *DefaultParser) InstanceCollectibleField(name string, schema *schema.Schema, onFound nodeFunc) {
+	parser.collectibleFields = append(parser.collectibleFields, CollectibleField{
+		Name:            name,
+		onFound:         onFound,
+		Schema:          schema,
+		DefinesInstance: true,
+	})
+}
+
 func (parser *DefaultParser) Collectible() bool {
 	return parser.collectible
 }

--- a/pkg/parser/parseable/parseable.go
+++ b/pkg/parser/parseable/parseable.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/lestrrat-go/jsschema"
 	"regexp"
+	"sort"
 )
 
 type Parseable interface {
@@ -24,13 +25,73 @@ type Field struct {
 }
 
 type CollectibleField struct {
-	Name    string
-	onFound nodeFunc
-	Schema  *schema.Schema
+	Name            string
+	onFound         nodeFunc
+	Schema          *schema.Schema
+	DefinesInstance bool
 }
 
 func (parser *DefaultParser) Parse(node *node.Node) error {
-	for _, field := range parser.collectibleFields {
+	// Rank collectible fields according to their declaration order in the node, e.g.:
+	//
+	// task:
+	//   container:
+	//     ...
+	//   windows_container:
+	//     ...
+	//
+	// ...results in:
+	//
+	// map[string]int{
+	//   {"container": 1},
+	//   {"windows_container": 2},
+	// }
+	//
+	// Note that the first field starts with 1, leaving 0 for the fields that we haven't seen
+	// in the node to prevent collisions.
+	fieldPositions := map[string]int{}
+	for i, child := range node.Children {
+		fieldPositions[child.Name] = i + 1
+	}
+
+	// Sort collectible fields:
+	//
+	// * unspecified fields (fields with rank 0) first
+	// * fields specified in the node that _don't_ describe instances (in the reverse order of declaration)
+	// * fields specified in the node that describe instances (in the reverse order of declaration)
+	//
+	// ...to achieve the (1) deprioritize, (2) overwritten-by-the-user and (2) instances-evaluated-at-the-end properties,
+	// where:
+	//
+	// (1) means that an instance (e.g. container) defined at the task's scope should be preferred
+	//     to the instance defined at the root scope (also container)
+	//
+	// (2) means that if two instances (e.g. container first and the persistent_worker) are defined at the same level,
+	//     the persistent_worker instance overwrites the container instance
+	//
+	// (3) means that collectible fields that don't define instances (e.g. "env") are evaluated first,
+	//     because instances might use environment variables defined in such fields
+	rankedCollectibles := parser.collectibleFields
+
+	sort.Slice(rankedCollectibles, func(i, j int) bool {
+		iField := rankedCollectibles[i]
+		jField := rankedCollectibles[j]
+
+		// Golang docs state that:
+		// >Less reports whether x[i] should be ordered before x[j], as required by the sort Interface.
+
+		// iField should be ordered before jField if it comes first in the node fields
+		// (or wasn't defined at all)
+		if iField.DefinesInstance && jField.DefinesInstance {
+			return fieldPositions[iField.Name] < fieldPositions[jField.Name]
+		}
+
+		// iField should be ordered before jField because if it does not define an instance
+		return !iField.DefinesInstance
+	})
+
+	// Evaluate collectible fields
+	for _, field := range rankedCollectibles {
 		if err := evaluateCollectible(node, field); err != nil {
 			return err
 		}
@@ -38,23 +99,7 @@ func (parser *DefaultParser) Parse(node *node.Node) error {
 
 	// Check required fields
 
-ChildrenLoop:
 	for _, child := range node.Children {
-		// In case this is a collectible field, make an additional evaluation
-		// to guarantee that we follow the declaration order of instances
-		// (and thus their overwrite order)
-		for _, field := range parser.collectibleFields {
-			if field.Name != child.Name {
-				continue
-			}
-
-			if err := evaluateCollectible(node, field); err != nil {
-				return err
-			}
-
-			continue ChildrenLoop
-		}
-
 		// Avoid processing the same node by different field handlers
 		// and possibly generating multiple scripts from a single
 		// script field

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -85,6 +85,28 @@ func TestAdditionalInstanceStability(t *testing.T) {
 	assertExpectedTasks(t, absolutize("additional-instance-stability.json"), result)
 }
 
+func TestCollectiblePropertyOverwrittenByTheUser(t *testing.T) {
+	yamlConfig := `windows_container:
+  image: mcr.microsoft.com/windows/servercore:ltsc2019
+
+task:
+  name: "${CIRRUS_OS}"
+  container:
+    image: debian:latest
+`
+
+	for i := 0; i < 100; i++ {
+		result, err := parser.New().Parse(context.Background(), yamlConfig)
+
+		require.Nil(t, err)
+		require.NotEmpty(t, result.Tasks)
+
+		if result.Tasks[0].Name != "linux" {
+			t.Fatal("CIRRUS_OS should expand to \"linux\"")
+		}
+	}
+}
+
 func TestAdditionalTaskProperties(t *testing.T) {
 	protoName := "custom_bool"
 	protoType := descriptor.FieldDescriptorProto_Type(8)

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -51,7 +51,7 @@ func NewTask(
 	AttachBaseTaskInstructions(&task.DefaultParser, &task.proto, env, boolevator)
 
 	if _, ok := additionalInstances["container"]; !ok {
-		task.CollectibleField("container",
+		task.InstanceCollectibleField("container",
 			instance.NewCommunityContainer(environment.Merge(task.proto.Environment, env), boolevator).Schema(),
 			func(node *node.Node) error {
 				inst := instance.NewCommunityContainer(environment.Merge(task.proto.Environment, env), boolevator)
@@ -76,7 +76,7 @@ func NewTask(
 			})
 	}
 	if _, ok := additionalInstances["windows_container"]; !ok {
-		task.CollectibleField("windows_container",
+		task.InstanceCollectibleField("windows_container",
 			instance.NewWindowsCommunityContainer(environment.Merge(task.proto.Environment, env), boolevator).Schema(),
 			func(node *node.Node) error {
 				inst := instance.NewWindowsCommunityContainer(environment.Merge(task.proto.Environment, env), boolevator)
@@ -101,7 +101,7 @@ func NewTask(
 			})
 	}
 	if _, ok := additionalInstances["persistent_worker"]; !ok {
-		task.CollectibleField("persistent_worker",
+		task.InstanceCollectibleField("persistent_worker",
 			instance.NewPersistentWorker(environment.Merge(task.proto.Environment, env)).Schema(),
 			func(node *node.Node) error {
 				inst := instance.NewPersistentWorker(environment.Merge(task.proto.Environment, env))
@@ -140,7 +140,7 @@ func NewTask(
 		scopedDescriptor := descriptor
 
 		instanceSchema := instance.NewProtoParser(scopedDescriptor, nil, nil).Schema()
-		task.CollectibleField(scopedInstanceName, instanceSchema, func(node *node.Node) error {
+		task.InstanceCollectibleField(scopedInstanceName, instanceSchema, func(node *node.Node) error {
 			parser := instance.NewProtoParser(scopedDescriptor, environment.Merge(task.proto.Environment, env), boolevator)
 			parserInstance, err := parser.Parse(node)
 			if err != nil {

--- a/pkg/parser/testdata/via-rpc/new-collectible-property-deprioritize.json
+++ b/pkg/parser/testdata/via-rpc/new-collectible-property-deprioritize.json
@@ -1,0 +1,29 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "ubuntu:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-collectible-property-deprioritize.yml
+++ b/pkg/parser/testdata/via-rpc/new-collectible-property-deprioritize.yml
@@ -1,0 +1,6 @@
+container:
+  image: debian:latest
+
+task:
+  container:
+    image: ubuntu:latest

--- a/pkg/parser/testdata/via-rpc/new-collectible-property-instances-are-evaluated-at-the-end.json
+++ b/pkg/parser/testdata/via-rpc/new-collectible-property-instances-are-evaluated-at-the-end.json
@@ -1,0 +1,30 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux",
+      "CPU": "5.0"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 5,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-collectible-property-instances-are-evaluated-at-the-end.yml
+++ b/pkg/parser/testdata/via-rpc/new-collectible-property-instances-are-evaluated-at-the-end.yml
@@ -1,0 +1,6 @@
+task:
+  container:
+    image: debian:latest
+    cpu: $CPU
+  env:
+    CPU: 5.0

--- a/pkg/parser/testdata/via-rpc/new-collectible-property-overwritten-by-the-user.json
+++ b/pkg/parser/testdata/via-rpc/new-collectible-property-overwritten-by-the-user.json
@@ -1,0 +1,67 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "windows"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "catalina-xcode",
+      "memory": 4096,
+      "osVersion": "2019",
+      "platform": "WINDOWS"
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "1",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "windows"
+  }
+]

--- a/pkg/parser/testdata/via-rpc/new-collectible-property-overwritten-by-the-user.yml
+++ b/pkg/parser/testdata/via-rpc/new-collectible-property-overwritten-by-the-user.yml
@@ -1,0 +1,10 @@
+container:
+  image: debian:latest
+
+task:
+  script : true
+
+task:
+  name: "${CIRRUS_OS}"
+  windows_container:
+    image: catalina-xcode


### PR DESCRIPTION
They're now ranked by their position in the node (if any) and whether they define an instance or not.