### PR TITLE
Cloud Build: ensure proper --version is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM goreleaser/goreleaser:latest as builder
 
-ENV GORELEASER_CURRENT_TAG=latest
+ENV GORELEASER_CURRENT_TAG=master
 
 WORKDIR /build
 ADD . /build
 
-RUN goreleaser build --snapshot
+RUN goreleaser build
 
 FROM alpine:latest
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/cirrus-cli/


### PR DESCRIPTION
`--snapshot` currently results in "latest-SNAPSHOT-d3baf27-d3baf27" for 0.42.0.