### PR TITLE
Evaluator: don't append empty YAML configuration from Starlark

### DIFF
--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -121,7 +121,9 @@ func (r *ConfigurationEvaluatorServiceServer) EvaluateConfig(
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 
-		yamlConfigs = append(yamlConfigs, generatedYamlConfig)
+		if generatedYamlConfig != "" {
+			yamlConfigs = append(yamlConfigs, generatedYamlConfig)
+		}
 	}
 
 	additionalInstances, err := TransformAdditionalInstances(request.AdditionalInstancesInfo)


### PR DESCRIPTION
Makes sure we don't emit combined configs with two newlines at the end.