### PR TITLE
Evaluator: send output_logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
-	github.com/cirruslabs/cirrus-ci-agent v1.32.0
+	github.com/cirruslabs/cirrus-ci-agent v1.32.1-0.20210310142043-f3ddc9ee3fbe
 	github.com/cirruslabs/echelon v1.4.1
 	github.com/cirruslabs/go-java-glob v0.1.0
 	github.com/cirruslabs/podmanapi v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
-	github.com/cirruslabs/cirrus-ci-agent v1.32.1-0.20210310142043-f3ddc9ee3fbe
+	github.com/cirruslabs/cirrus-ci-agent v1.33.0
 	github.com/cirruslabs/echelon v1.4.1
 	github.com/cirruslabs/go-java-glob v0.1.0
 	github.com/cirruslabs/podmanapi v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200507155900-a9f01edf17e3/go.mod h1:XT+cAw5wfvsodedcijoh1l9cf7v1x9FlFB/3VmF/O8s=
-github.com/cirruslabs/cirrus-ci-agent v1.32.1-0.20210310142043-f3ddc9ee3fbe h1:9ZO/juK3di8o5QiiBnPD5wkqiMmgNgClwDr9p2+NwgQ=
-github.com/cirruslabs/cirrus-ci-agent v1.32.1-0.20210310142043-f3ddc9ee3fbe/go.mod h1:T3amh8kB54wkmpWrQ/VXVl9osHXdt3ILS0cH5ZaYGF4=
+github.com/cirruslabs/cirrus-ci-agent v1.33.0 h1:6qbhUCO2QaUXjzLkz0l97HGqUCZr4P5cshPwnVLPZX0=
+github.com/cirruslabs/cirrus-ci-agent v1.33.0/go.mod h1:T3amh8kB54wkmpWrQ/VXVl9osHXdt3ILS0cH5ZaYGF4=
 github.com/cirruslabs/cirrus-ci-annotations v0.1.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/echelon v1.4.1 h1:7ij7cANbL1feOyds5sRtYLPBJwycFi3nvLKJI4vCOPs=
 github.com/cirruslabs/echelon v1.4.1/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200507155900-a9f01edf17e3/go.mod h1:XT+cAw5wfvsodedcijoh1l9cf7v1x9FlFB/3VmF/O8s=
-github.com/cirruslabs/cirrus-ci-agent v1.32.0 h1:WOCyP/Oe2GY3NpArHHFk3m1WU4OAe+1eLXTB9VTcsas=
-github.com/cirruslabs/cirrus-ci-agent v1.32.0/go.mod h1:T3amh8kB54wkmpWrQ/VXVl9osHXdt3ILS0cH5ZaYGF4=
+github.com/cirruslabs/cirrus-ci-agent v1.32.1-0.20210310142043-f3ddc9ee3fbe h1:9ZO/juK3di8o5QiiBnPD5wkqiMmgNgClwDr9p2+NwgQ=
+github.com/cirruslabs/cirrus-ci-agent v1.32.1-0.20210310142043-f3ddc9ee3fbe/go.mod h1:T3amh8kB54wkmpWrQ/VXVl9osHXdt3ILS0cH5ZaYGF4=
 github.com/cirruslabs/cirrus-ci-annotations v0.1.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/echelon v1.4.1 h1:7ij7cANbL1feOyds5sRtYLPBJwycFi3nvLKJI4vCOPs=
 github.com/cirruslabs/echelon v1.4.1/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=

--- a/internal/commands/helpers/helpers.go
+++ b/internal/commands/helpers/helpers.go
@@ -79,7 +79,13 @@ func EvaluateStarlarkConfig(ctx context.Context, path string, env map[string]str
 	}
 
 	lrk := larker.New(larker.WithFileSystem(local.New(".")), larker.WithEnvironment(env))
-	return lrk.Main(ctx, string(starlarkSource))
+
+	result, err := lrk.Main(ctx, string(starlarkSource))
+	if err != nil {
+		return "", err
+	}
+
+	return result.YAMLConfig, nil
 }
 
 func ReadCombinedConfig(ctx context.Context, env map[string]string) (string, error) {

--- a/internal/commands/internal/test/test.go
+++ b/internal/commands/internal/test/test.go
@@ -78,7 +78,7 @@ func test(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("%w: %v", ErrTest, err)
 		}
 
-		generatedConfigString, err := lrk.Main(cmd.Context(), string(sourceBytes))
+		result, err := lrk.Main(cmd.Context(), string(sourceBytes))
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrTest, err)
 		}
@@ -91,7 +91,7 @@ func test(cmd *cobra.Command, args []string) error {
 		}
 
 		var generatedConfig yaml.Node
-		err = yaml.Unmarshal([]byte(generatedConfigString), &generatedConfig)
+		err = yaml.Unmarshal([]byte(result.YAMLConfig), &generatedConfig)
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrTest, err)
 		}

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -363,3 +363,16 @@ func TestHook(t *testing.T) {
 
 	assert.Equal(t, expectedStructpb, res.Result, "hook should return a list of build and task IDs")
 }
+
+func TestStarlarkOutputLogs(t *testing.T) {
+	starlarkConfig := `def main(ctx):
+    print("Foo")
+    print("Bar")
+
+    return []
+`
+
+	response, err := evaluateConfigHelper(t, &api.EvaluateConfigRequest{StarlarkConfig: starlarkConfig})
+	require.NoError(t, err)
+	require.Equal(t, "Foo\nBar\n", string(response.OutputLogs))
+}

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -43,7 +43,7 @@ func validateExpected(t *testing.T, testDir string) {
 
 	// Run the source code to produce a YAML configuration
 	lrk := larker.New(larker.WithFileSystem(local.New(dir)))
-	configuration, err := lrk.Main(context.Background(), string(source))
+	result, err := lrk.Main(context.Background(), string(source))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func validateExpected(t *testing.T, testDir string) {
 		t.Fatal(err)
 	}
 
-	assert.YAMLEq(t, string(expectedConfiguration), configuration)
+	assert.YAMLEq(t, string(expectedConfiguration), result.YAMLConfig)
 }
 
 // TestLoadFileSystemLocal ensures that modules can be loaded from the local file system.
@@ -137,7 +137,7 @@ func TestLoadGitHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.YAMLEq(t, string(expected), result)
+	assert.YAMLEq(t, string(expected), result.YAMLConfig)
 }
 
 // TestLoadTypoStarVsStart ensures that we return a user-friendly hint when loading of the module


### PR DESCRIPTION
`github.com/cirruslabs/cirrus-ci-agent`'s version can be changed to a proper one after https://github.com/cirruslabs/cirrus-ci-agent/pull/111 gets merged.