### PR TITLE
[boolevator] properly unquote string literal

### DIFF
--- a/pkg/parser/boolevator/boolevator.go
+++ b/pkg/parser/boolevator/boolevator.go
@@ -32,13 +32,22 @@ func New(opts ...Option) *Boolevator {
 }
 
 func parseString(_ context.Context, parser *gval.Parser) (gval.Evaluable, error) {
-	unquoted, err := strconv.Unquote(parser.TokenText())
-
-	if err != nil {
-		return nil, err
-	}
+	unquoted := trimAllQuotes(parser.TokenText())
 
 	return parser.Const(unquoted), nil
+}
+
+func trimAllQuotes(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	firstCharacter := s[0]
+	lastCharacter := s[len(s)-1]
+	if firstCharacter == lastCharacter && (firstCharacter == '"' || firstCharacter == '\'') {
+		// return recursively to handle double quoted strings
+		return trimAllQuotes(s[1 : len(s)-1])
+	}
+	return s
 }
 
 func (boolevator *Boolevator) Eval(expr string, env map[string]string) (bool, error) {

--- a/pkg/parser/boolevator/boolevator.go
+++ b/pkg/parser/boolevator/boolevator.go
@@ -37,17 +37,18 @@ func parseString(_ context.Context, parser *gval.Parser) (gval.Evaluable, error)
 	return parser.Const(unquoted), nil
 }
 
-func trimAllQuotes(s string) string {
-	if len(s) < 2 {
-		return s
+func trimAllQuotes(text string) string {
+	//nolint:gomnd
+	if len(text) < 2 {
+		return text
 	}
-	firstCharacter := s[0]
-	lastCharacter := s[len(s)-1]
+	firstCharacter := text[0]
+	lastCharacter := text[len(text)-1]
 	if firstCharacter == lastCharacter && (firstCharacter == '"' || firstCharacter == '\'') {
 		// return recursively to handle double quoted strings
-		return trimAllQuotes(s[1 : len(s)-1])
+		return trimAllQuotes(text[1 : len(text)-1])
 	}
-	return s
+	return text
 }
 
 func (boolevator *Boolevator) Eval(expr string, env map[string]string) (bool, error) {

--- a/pkg/parser/boolevator/boolevator.go
+++ b/pkg/parser/boolevator/boolevator.go
@@ -7,7 +7,6 @@ import (
 	"github.com/PaesslerAG/gval"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/expander"
 	"strconv"
-	"strings"
 	"text/scanner"
 )
 
@@ -32,8 +31,12 @@ func New(opts ...Option) *Boolevator {
 	return boolevator
 }
 
-func parseString(ctx context.Context, parser *gval.Parser) (gval.Evaluable, error) {
-	unquoted := strings.Trim(parser.TokenText(), "'\"")
+func parseString(_ context.Context, parser *gval.Parser) (gval.Evaluable, error) {
+	unquoted, err := strconv.Unquote(parser.TokenText())
+
+	if err != nil {
+		return nil, err
+	}
 
 	return parser.Const(unquoted), nil
 }

--- a/pkg/parser/boolevator/boolevator_test.go
+++ b/pkg/parser/boolevator/boolevator_test.go
@@ -73,8 +73,9 @@ func TestRegExMultiline(t *testing.T) {
 }
 
 func TestQuotes(t *testing.T) {
-	assert.True(t, evalHelper(t, "$CIRRUS_CHANGE_MESSAGE == \"test 'foo'\"", map[string]string{"CIRRUS_CHANGE_MESSAGE": "test 'foo'"}))
-	assert.True(t, evalHelper(t, "$CIRRUS_CHANGE_MESSAGE =~ \".*test 'foo'.*\"", map[string]string{"CIRRUS_CHANGE_MESSAGE": "test 'foo'"}))
+	env := map[string]string{"CIRRUS_CHANGE_MESSAGE": "test 'foo'"}
+	assert.True(t, evalHelper(t, "$CIRRUS_CHANGE_MESSAGE == \"test 'foo'\"", env))
+	assert.True(t, evalHelper(t, "$CIRRUS_CHANGE_MESSAGE =~ \".*test 'foo'.*\"", env))
 }
 
 func TestPrRegEx(t *testing.T) {

--- a/pkg/parser/boolevator/boolevator_test.go
+++ b/pkg/parser/boolevator/boolevator_test.go
@@ -72,6 +72,11 @@ func TestRegExMultiline(t *testing.T) {
 		map[string]string{"CHANGELOG": changelog}))
 }
 
+func TestQuotes(t *testing.T) {
+	assert.True(t, evalHelper(t, "$CIRRUS_CHANGE_MESSAGE == \"test 'foo'\"", map[string]string{"CIRRUS_CHANGE_MESSAGE": "test 'foo'"}))
+	assert.True(t, evalHelper(t, "$CIRRUS_CHANGE_MESSAGE =~ \".*test 'foo'.*\"", map[string]string{"CIRRUS_CHANGE_MESSAGE": "test 'foo'"}))
+}
+
 func TestPrRegEx(t *testing.T) {
 	assert.True(t, evalHelper(t, "'pull/.*' =~ 'pull/123'", nil))
 	assert.True(t, evalHelper(t, "'pull/123' =~ 'pull/.*'", nil))


### PR DESCRIPTION
`strings.Trim` removes all leading or trailing character so string like `"foo 'foo'"` will get both `'` and `"` trimmed from the end.