### PR TITLE
Persistent worker: prefer static temporary directory over dynamic one when possible

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/none/none.go
+++ b/internal/executor/instance/persistentworker/isolation/none/none.go
@@ -26,12 +26,12 @@ type PersistentWorkerInstance struct {
 
 func staticTempDirWithDynamicFallback() (string, error) {
 	// Prefer static directory for non-Cirrus CI caches efficiency (e.g. ccache)
-	staticTempDir := filepath.Join(os.TempDir(), "cirrus-cli-build")
+	staticTempDir := filepath.Join(os.TempDir(), "cirrus-build")
 	if err := os.Mkdir(staticTempDir, 0700); err == nil {
 		return staticTempDir, nil
 	}
 
-	return ioutil.TempDir("", "cirrus-cli-build-")
+	return ioutil.TempDir("", "cirrus-build-")
 }
 
 func New() (*PersistentWorkerInstance, error) {

--- a/internal/executor/instance/persistentworker/isolation/none/none.go
+++ b/internal/executor/instance/persistentworker/isolation/none/none.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 )
@@ -23,9 +24,19 @@ type PersistentWorkerInstance struct {
 	cleanup func() error
 }
 
+func staticTempDirWithDynamicFallback() (string, error) {
+	// Prefer static directory for non-Cirrus CI caches efficiency (e.g. ccache)
+	staticTempDir := filepath.Join(os.TempDir(), "cirrus-cli-build")
+	if err := os.Mkdir(staticTempDir, 0700); err == nil {
+		return staticTempDir, nil
+	}
+
+	return ioutil.TempDir("", "cirrus-cli-build-")
+}
+
 func New() (*PersistentWorkerInstance, error) {
 	// Create a working directory that will be used if no dirty mode is requested in Run()
-	tempDir, err := ioutil.TempDir("", "cirrus-build-")
+	tempDir, err := staticTempDirWithDynamicFallback()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To improve caching, see https://github.com/cirruslabs/cirrus-cli/issues/357#issuecomment-814250111.