### PR TITLE
Parser: support to-be-deprecated port fields

### DIFF
--- a/pkg/parser/instance/additionalcontainer.go
+++ b/pkg/parser/instance/additionalcontainer.go
@@ -123,6 +123,10 @@ func NewAdditionalContainer(mergedEnv map[string]string, boolevator *boolevator.
 			return node.ParserError("failed to parse port: %v", err)
 		}
 
+		// Support old port fields until they're deprecated
+		ac.proto.ContainerPort = portMapping.ContainerPort
+		ac.proto.HostPort = portMapping.HostPort
+
 		ac.proto.Ports = append(ac.proto.Ports, portMapping)
 
 		return nil

--- a/pkg/parser/testdata/example-mysql.json
+++ b/pkg/parser/testdata/example-mysql.json
@@ -32,7 +32,8 @@
             {
               "containerPort": 3306
             }
-          ]
+          ],
+          "containerPort": 3306
         }
       ],
       "cpu": 2,

--- a/pkg/parser/testdata/proto-instance.json
+++ b/pkg/parser/testdata/proto-instance.json
@@ -24,7 +24,8 @@
             {
               "containerPort": 3306
             }
-          ]
+          ],
+          "containerPort": 3306
         }
       ],
       "cpu": 2.5,
@@ -67,7 +68,8 @@
             {
               "containerPort": 3306
             }
-          ]
+          ],
+          "containerPort": 3306
         }
       ],
       "cpu": 2.5,

--- a/pkg/parser/testdata/via-rpc/new-deduplicator-same-type.json
+++ b/pkg/parser/testdata/via-rpc/new-deduplicator-same-type.json
@@ -29,7 +29,8 @@
             {
               "containerPort": 80
             }
-          ]
+          ],
+          "containerPort": 80
         }
       ],
       "cpu": 2,

--- a/pkg/parser/testdata/via-rpc/simple-additionalContainers.json
+++ b/pkg/parser/testdata/via-rpc/simple-additionalContainers.json
@@ -38,7 +38,8 @@
             {
               "containerPort": 6379
             }
-          ]
+          ],
+          "containerPort": 6379
         },
         {
           "cpu": 0.5,
@@ -50,7 +51,9 @@
               "containerPort": 6379,
               "hostPort": 7777
             }
-          ]
+          ],
+          "containerPort": 6379,
+          "hostPort": 7777
         },
         {
           "cpu": 0.5,
@@ -62,7 +65,8 @@
             {
               "containerPort": 2375
             }
-          ]
+          ],
+          "containerPort": 2375
         }
       ],
       "cpu": 2,


### PR DESCRIPTION
To aid in transition.

We can later just revert this once `container_port` and `host_port` fields are deprecated.