### PR TITLE
Evaluator: properly treat cases where entrypoint is not found

### DIFF
--- a/internal/executor/executor_darwin_test.go
+++ b/internal/executor/executor_darwin_test.go
@@ -19,6 +19,8 @@ func TestExecutorParallels(t *testing.T) {
 	testutil.TempChdir(t)
 
 	for _, platform := range []string{"darwin", "linux"} {
+		platform := platform
+
 		t.Run(platform, func(t *testing.T) {
 			commonPrefix := fmt.Sprintf("CIRRUS_INTERNAL_PARALLELS_%s_", strings.ToUpper(platform))
 

--- a/pkg/larker/larker.go
+++ b/pkg/larker/larker.go
@@ -17,6 +17,7 @@ import (
 var (
 	ErrLoadFailed           = errors.New("load failed")
 	ErrExecFailed           = errors.New("exec failed")
+	ErrNotFound             = errors.New("entrypoint not found")
 	ErrMainFailed           = errors.New("failed to call main")
 	ErrHookFailed           = errors.New("failed to call hook")
 	ErrMainUnexpectedResult = errors.New("main returned unexpected result")
@@ -84,7 +85,7 @@ func (larker *Larker) Main(ctx context.Context, source string) (*MainResult, err
 		// Retrieve main()
 		main, ok := globals["main"]
 		if !ok {
-			errCh <- fmt.Errorf("%w: main() not found", ErrMainFailed)
+			errCh <- fmt.Errorf("%w: main()", ErrNotFound)
 			return
 		}
 
@@ -172,7 +173,7 @@ func (larker *Larker) Hook(
 		// Retrieve hook
 		hook, ok := globals[name]
 		if !ok {
-			errCh <- fmt.Errorf("%w: %s() not found", ErrHookFailed, name)
+			errCh <- fmt.Errorf("%w: %s()", ErrNotFound, name)
 			return
 		}
 


### PR DESCRIPTION
* it's OK to have a Starlark configuration with no `main()` defined — a common use-case for this is using hooks
* use a separate gRPC error code to differentiate between cases when:
  * hook wasn't defined
  * all other cases (e.g. hook failed to execute or wasn't a function)