### PR TITLE
Parser: emit warnings on tasks named task_*

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054
-	github.com/cirruslabs/cirrus-ci-agent v1.39.0
+	github.com/cirruslabs/cirrus-ci-agent v1.43.0
 	github.com/cirruslabs/echelon v1.4.1
 	github.com/cirruslabs/go-java-glob v0.1.0
 	github.com/cirruslabs/podmanapi v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -86,9 +86,9 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200507155900-a9f01edf17e3/go.mod h1:XT+cAw5wfvsodedcijoh1l9cf7v1x9FlFB/3VmF/O8s=
-github.com/cirruslabs/cirrus-ci-agent v1.39.0 h1:0ekH81DiZVBiZi5Ju8jlnMTm4bRIFk0ZuC8bQ236g7Q=
-github.com/cirruslabs/cirrus-ci-agent v1.39.0/go.mod h1:T3amh8kB54wkmpWrQ/VXVl9osHXdt3ILS0cH5ZaYGF4=
-github.com/cirruslabs/cirrus-ci-annotations v0.1.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
+github.com/cirruslabs/cirrus-ci-agent v1.43.0 h1:hAEBmZa0rrI3px/bdp448Z359SDQ85IezGBkw/FmtxM=
+github.com/cirruslabs/cirrus-ci-agent v1.43.0/go.mod h1:OmeCZ7+GrwvTMaHAnfLlJqVCBPv+Hug9hXEkflkzFF0=
+github.com/cirruslabs/cirrus-ci-annotations v0.2.1/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/echelon v1.4.1 h1:7ij7cANbL1feOyds5sRtYLPBJwycFi3nvLKJI4vCOPs=
 github.com/cirruslabs/echelon v1.4.1/go.mod h1:1jFBACMy3tzodXyTtNNLN9bw6UUU7Xpq9tYMRydehtY=
 github.com/cirruslabs/go-java-glob v0.1.0 h1:qC4Fzrq2sXKTLLsBb7ih7BNdCjCR6ZJAAK4nOZ6d/Ak=
@@ -298,7 +298,7 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/joshdk/go-junit v0.0.0-20200312181801-e5d93c0f31a8/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
-github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
+github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -150,20 +150,23 @@ func (r *ConfigurationEvaluatorServiceServer) EvaluateConfig(
 	parseResult, err := p.Parse(ctx, result.ProcessedConfig)
 	if err != nil {
 		if re, ok := err.(*parsererror.Rich); ok {
-			return &api.EvaluateConfigResponse{
-				Error: &api.RichError{
-					Message:         re.Message(),
-					ProcessedConfig: re.Config(),
-					Line:            uint64(re.Line()),
-					Column:          uint64(re.Column()),
+			result.Issues = []*api.Issue{
+				{
+					Level:   api.Issue_ERROR,
+					Message: re.Message(),
+					Line:    uint64(re.Line()),
+					Column:  uint64(re.Column()),
 				},
-			}, nil
+			}
+
+			return result, nil
 		}
 
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	result.Tasks = parseResult.Tasks
+	result.Issues = parseResult.Issues
 	result.TasksCountBeforeFiltering = parseResult.TasksCountBeforeFiltering
 
 	return result, nil

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -307,12 +307,14 @@ task:
 
 	response, err := evaluateConfigHelper(t, &api.EvaluateConfigRequest{YamlConfig: yamlConfig})
 	require.NoError(t, err)
-	require.NotNil(t, response.Error)
+	require.NotNil(t, response.Issues)
 
-	assert.EqualValues(t, response.Error.Message, "not a scalar value")
-	assert.NotEmpty(t, response.Error.ProcessedConfig)
-	assert.EqualValues(t, response.Error.Line, 3)
-	assert.EqualValues(t, response.Error.Column, 5)
+	firstIssue := response.Issues[0]
+	assert.NotEmpty(t, response.ProcessedConfig)
+	assert.EqualValues(t, api.Issue_ERROR, firstIssue.Level)
+	assert.EqualValues(t, firstIssue.Message, "not a scalar value")
+	assert.EqualValues(t, firstIssue.Line, 3)
+	assert.EqualValues(t, firstIssue.Column, 5)
 }
 
 func TestHook(t *testing.T) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -75,6 +75,29 @@ func TestInvalidConfigs(t *testing.T) {
 	}
 }
 
+func TestProblematicConfigs(t *testing.T) {
+	var problematicCases = []struct {
+		Name           string
+		ExpectedIssues []*api.Issue
+	}{
+		{"problematic-potentially-missed-task", []*api.Issue{
+			{Level: api.Issue_WARNING, Message: "you've probably meant foo_task", Line: 5, Column: 3},
+		}},
+	}
+
+	for _, problematicCase := range problematicCases {
+		problematicCase := problematicCase
+
+		t.Run(problematicCase.Name, func(t *testing.T) {
+			p := parser.New()
+			result, err := p.ParseFromFile(context.Background(), absolutize(problematicCase.Name+".yml"))
+
+			require.NoError(t, err)
+			assert.EqualValues(t, problematicCase.ExpectedIssues, result.Issues)
+		})
+	}
+}
+
 func TestAdditionalInstances(t *testing.T) {
 	containerInstanceReflect := (&api.ContainerInstance{}).ProtoReflect()
 	p := parser.New(parser.WithAdditionalInstances(map[string]protoreflect.MessageDescriptor{

--- a/pkg/parser/testdata/problematic-potentially-missed-task.yml
+++ b/pkg/parser/testdata/problematic-potentially-missed-task.yml
@@ -1,0 +1,5 @@
+container:
+  image: debian:latest
+
+task_foo:
+  script: uname -a


### PR DESCRIPTION
And also route these warnings through an evaluator.

Resolves #329.