### PR TITLE
Speed-up image build by using goreleaser's --single-target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM goreleaser/goreleaser:latest as builder
 WORKDIR /build
 ADD . /build
 
-RUN goreleaser build
+RUN goreleaser build --single-target
 
 FROM alpine:latest
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/cirrus-cli/


### PR DESCRIPTION
This flag was introduced recently in https://github.com/goreleaser/goreleaser/pull/2179.