### PR TITLE
Larker: opportunistically convert incoming float values to integers

### DIFF
--- a/pkg/larker/converthook.go
+++ b/pkg/larker/converthook.go
@@ -80,9 +80,9 @@ func interfaceAsStarlarkValue(value interface{}) (starlark.Value, error) {
 	case uint64:
 		return starlark.MakeUint64(v), nil
 	case float32:
-		return starlark.Float(v), nil
+		return tryIntegerOrFloat(float64(v))
 	case float64:
-		return starlark.Float(v), nil
+		return tryIntegerOrFloat(v)
 	case string:
 		return starlark.String(v), nil
 	case []interface{}:
@@ -118,4 +118,12 @@ func interfaceAsStarlarkValue(value interface{}) (starlark.Value, error) {
 	default:
 		return nil, fmt.Errorf("%w: unsupported type %T", ErrStarlarkConversion, value)
 	}
+}
+
+func tryIntegerOrFloat(floatValue float64) (starlark.Value, error) {
+	if integerValue := int64(floatValue); floatValue == float64(integerValue) {
+		return starlark.MakeInt64(integerValue), nil
+	}
+
+	return starlark.Float(floatValue), nil
 }


### PR DESCRIPTION
So that we don't have to do things like `int(ctx.payload.data.build.id)`.