### PR TITLE
Parallels: check if the context was cancelled before handling the actual sess.Wait()'s error

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
@@ -180,6 +180,11 @@ func (parallels *Parallels) Run(ctx context.Context, config *runconfig.RunConfig
 	}
 	err = sess.Wait()
 	if err != nil {
+		// Work around x/crypto/ssh not being context.Context-friendly (e.g. https://github.com/golang/go/issues/20288)
+		if err := monitorCtx.Err(); err != nil {
+			return err
+		}
+
 		return fmt.Errorf("%w: failed to run agent on VM %q: %v", ErrFailed, vm.Ident(), err)
 	}
 


### PR DESCRIPTION
And don't treat the context cancellation in persistent worker as an error.

Resolves #373.