### PR TITLE
Use custom HTTP client in Starlark

### DIFF
--- a/pkg/larker/loader/loader.go
+++ b/pkg/larker/loader/loader.go
@@ -135,7 +135,10 @@ func (loader *Loader) loadCirrusModule() (starlark.StringDict, error) {
 	if err != nil {
 		http.Client = &gohttp.Client{
 			Transport: &gohttp.Transport{
-				TLSClientConfig: &tls.Config{RootCAs: certPool},
+				TLSClientConfig: &tls.Config{
+					RootCAs:    certPool,
+					MinVersion: tls.VersionTLS12,
+				},
 			},
 		}
 	}

--- a/pkg/larker/loader/loader.go
+++ b/pkg/larker/loader/loader.go
@@ -2,8 +2,10 @@ package loader
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"github.com/certifi/gocertifi"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/builtin"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/loader/git"
@@ -16,6 +18,7 @@ import (
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkjson"
 	"go.starlark.net/starlarkstruct"
+	gohttp "net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -126,6 +129,15 @@ func (loader *Loader) loadCirrusModule() (starlark.StringDict, error) {
 	result["fs"] = &starlarkstruct.Module{
 		Name:    "fs",
 		Members: builtin.FS(loader.ctx, loader.fs),
+	}
+
+	certPool, err := gocertifi.CACerts()
+	if err != nil {
+		http.Client = &gohttp.Client{
+			Transport: &gohttp.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: certPool},
+			},
+		}
 	}
 
 	httpModule, err := http.LoadModule()


### PR DESCRIPTION
With certificates installed

Seems right now `http` module fails to execute requests because of that. I'm seeing 

> INVALID_ARGUMENT: exec failed: Get "https://httpbin.org/json": dial tcp 34.231.30.52:443: i/o timeout!

on 

```python
load("cirrus", "http")

def main(ctx):
    resp = http.get("https://httpbin.org/json")
    if resp.status_code != 200 or resp.json().get("slideshow") == None:
        fail("failed to parse JSON")
    print(resp)
    return []
```