### PR TITLE
Use main as the default revision

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/cirrus-templates/golang@main", "lint_task")
+load("github.com/cirrus-templates/golang@a4e91ca453a4ade8f41013fca0888536d680f51d", "lint_task")
 
 def main(ctx):
     return [lint_task()]

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/cirrus-templates/golang@a4e91ca453a4ade8f41013fca0888536d680f51d", "lint_task")
+load("github.com/cirrus-templates/golang@main", "lint_task")
 
 def main(ctx):
     return [lint_task()]

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/cirrus-templates/golang", "lint_task")
+load("github.com/cirrus-templates/golang@main", "lint_task")
 
 def main(ctx):
     return [lint_task()]

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -154,7 +154,7 @@ func TestLoadTypoStarVsStart(t *testing.T) {
 
 	// Hint when loading from Git
 	_, err = lrk.Main(context.Background(),
-		"load(\"github.com/cirrus-templates/helpers/dir/lib.start@master\", \"symbol\")\n")
+		"load(\"github.com/cirrus-templates/helpers/dir/lib.start\", \"symbol\")\n")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "instead of the .start?")
 

--- a/pkg/larker/loader/git/git.go
+++ b/pkg/larker/loader/git/git.go
@@ -45,7 +45,7 @@ var regexVariants = []*regexp.Regexp{
 func Parse(module string) *Locator {
 	result := &Locator{
 		Path:     "lib.star",
-		Revision: "master",
+		Revision: "main",
 	}
 
 	for _, regex := range regexVariants {

--- a/pkg/larker/loader/git/git_test.go
+++ b/pkg/larker/loader/git/git_test.go
@@ -17,12 +17,12 @@ func TestParse(t *testing.T) {
 		{"defaults to lib.star", "github.com/some-org/some-repo", &git.Locator{
 			URL:      "https://github.com/some-org/some-repo.git",
 			Path:     "lib.star",
-			Revision: "master",
+			Revision: "main",
 		}},
 		{"parses path", "github.com/some-org/some-repo/dir/some.star", &git.Locator{
 			URL:      "https://github.com/some-org/some-repo.git",
 			Path:     "dir/some.star",
-			Revision: "master",
+			Revision: "main",
 		}},
 		{"parses revision", "github.com/some-org/some-repo@da39a3ee5e6b4b0d3255bfef95601890afd80709", &git.Locator{
 			URL:      "https://github.com/some-org/some-repo.git",
@@ -38,7 +38,7 @@ func TestParse(t *testing.T) {
 		{"parses .git hint", "gitlab.com/some-org/some-repo.git/some.star", &git.Locator{
 			URL:      "https://gitlab.com/some-org/some-repo.git",
 			Path:     "some.star",
-			Revision: "master",
+			Revision: "main",
 		}},
 		// Other Git hosting services (without the ".git" hint)
 		{"fails without .git hint", "gitlab.com/some-org/some-repo", nil},
@@ -62,7 +62,7 @@ func TestRetrieve(t *testing.T) {
 			&git.Locator{
 				URL:      "https://github.com/cirrus-templates/helpers",
 				Path:     "lib.star",
-				Revision: "master",
+				Revision: "main",
 			},
 		},
 		{"non-default branch",


### PR DESCRIPTION
All the new repos has `main` as the default branch. Since the feature is not announced and all the Cirrus Templates will be created with the new defaults it's reasonable to change it here too.