### PR TITLE
Starlark: new is_test cirrus builtin

### DIFF
--- a/STARLARK.md
+++ b/STARLARK.md
@@ -158,7 +158,7 @@ def main(ctx):
 
 ### `is_test`
 
-While not technically a builtin, `is_test` is a [`bool`](https://github.com/bazelbuild/starlark/blob/master/spec.md#booleans) that allows Starlark code to determine whether it's running in`cirrus internal test`.
+While not technically a builtin, `is_test` is a [`bool`](https://github.com/bazelbuild/starlark/blob/master/spec.md#booleans) that allows Starlark code to determine whether it's running in `cirrus internal test`.
 
 This can be useful for limiting the test complexity, e.g. by not making a real HTTP request and mocking/skipping it instead.
 

--- a/STARLARK.md
+++ b/STARLARK.md
@@ -156,6 +156,12 @@ def main(ctx):
     return tasks
 ```
 
+### `is_test`
+
+While not technically a builtin, `is_test` is a [`bool`](https://github.com/bazelbuild/starlark/blob/master/spec.md#booleans) that allows Starlark code to determine whether it's running in`cirrus internal test`.
+
+This can be useful for limiting the test complexity, e.g. by not making a real HTTP request and mocking/skipping it instead.
+
 ### `env`
 
 While not technically a builtin, `env` is dict that contains environment variables passed via `cirrus run --environment`.

--- a/internal/commands/internal/test/test.go
+++ b/internal/commands/internal/test/test.go
@@ -56,7 +56,7 @@ func test(cmd *cobra.Command, args []string) error {
 		}
 
 		// Create Starlark executor and run .cirrus.star to generate the configuration
-		var larkerOpts []larker.Option
+		larkerOpts := []larker.Option{larker.WithTestMode()}
 
 		fs := local.New(".")
 		fs.Chdir(testDir)

--- a/pkg/larker/larker.go
+++ b/pkg/larker/larker.go
@@ -27,6 +27,7 @@ type Larker struct {
 	fs            fs.FileSystem
 	env           map[string]string
 	affectedFiles []string
+	isTest        bool
 }
 
 type HookResult struct {
@@ -66,7 +67,7 @@ func (larker *Larker) Main(ctx context.Context, source string) (*MainResult, err
 	}
 
 	thread := &starlark.Thread{
-		Load:  loader.NewLoader(ctx, larker.fs, larker.env, larker.affectedFiles).LoadFunc(),
+		Load:  loader.NewLoader(ctx, larker.fs, larker.env, larker.affectedFiles, larker.isTest).LoadFunc(),
 		Print: capture,
 	}
 
@@ -154,7 +155,7 @@ func (larker *Larker) Hook(
 	}
 
 	thread := &starlark.Thread{
-		Load:  loader.NewLoader(ctx, larker.fs, larker.env, []string{}).LoadFunc(),
+		Load:  loader.NewLoader(ctx, larker.fs, larker.env, []string{}, larker.isTest).LoadFunc(),
 		Print: capture,
 	}
 

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -266,3 +266,25 @@ func TestBuiltinStarlib(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTestMode(t *testing.T) {
+	dir := testutil.TempDirPopulatedWith(t, "testdata/test-mode")
+
+	// Read the source code
+	source, err := ioutil.ReadFile(filepath.Join(dir, ".cirrus.star"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the source code with testing mode disabled
+	lrk := larker.New(larker.WithFileSystem(local.New(dir)))
+	result, err := lrk.Main(context.Background(), string(source))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.OutputLogs), "testing mode disabled")
+
+	// Run the source code with testing mode enabled
+	lrk = larker.New(larker.WithFileSystem(local.New(dir)), larker.WithTestMode())
+	result, err = lrk.Main(context.Background(), string(source))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.OutputLogs), "testing mode enabled")
+}

--- a/pkg/larker/loader/loader.go
+++ b/pkg/larker/loader/loader.go
@@ -40,15 +40,23 @@ type Loader struct {
 	fs            fs.FileSystem
 	env           map[string]string
 	affectedFiles []string
+	isTest        bool
 }
 
-func NewLoader(ctx context.Context, fs fs.FileSystem, env map[string]string, affectedFiles []string) *Loader {
+func NewLoader(
+	ctx context.Context,
+	fs fs.FileSystem,
+	env map[string]string,
+	affectedFiles []string,
+	isTest bool,
+) *Loader {
 	return &Loader{
 		ctx:           ctx,
 		cache:         make(map[string]*CacheEntry),
 		fs:            fs,
 		env:           env,
 		affectedFiles: affectedFiles,
+		isTest:        isTest,
 	}
 }
 
@@ -123,6 +131,8 @@ func (loader *Loader) loadCirrusModule() (starlark.StringDict, error) {
 		}
 	}
 	result["env"] = starlarkEnv
+
+	result["is_test"] = starlark.Bool(loader.isTest)
 
 	result["changes_include"] = generateChangesIncludeBuiltin(loader.affectedFiles)
 

--- a/pkg/larker/options.go
+++ b/pkg/larker/options.go
@@ -23,3 +23,9 @@ func WithAffectedFiles(affectedFiles []string) Option {
 		e.affectedFiles = affectedFiles
 	}
 }
+
+func WithTestMode() Option {
+	return func(e *Larker) {
+		e.isTest = true
+	}
+}

--- a/pkg/larker/testdata/test-mode/.cirrus.star
+++ b/pkg/larker/testdata/test-mode/.cirrus.star
@@ -1,0 +1,9 @@
+load("cirrus", "is_test")
+
+def main(ctx):
+    if is_test:
+        print("testing mode enabled")
+    else:
+        print("testing mode disabled")
+
+    return []


### PR DESCRIPTION
To simplify writing complex tests.

Related to #354 and #381.