### PR TITLE
Starlark's main(): allow returning dict in addition to list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
   - gofmt
   - goheader
   - golint
-  - gomnd
   - gomodguard
   - goprintffuncname
   - gosec
@@ -117,6 +116,9 @@ linters:
     # No way to disable the "exported" check for the whole project[1]
     # [1]: https://github.com/mgechev/revive/issues/244#issuecomment-560512162
     - revive
+
+    # Unfortunately too much false-positives, e.g. for a 0700 umask or number 10 when using strconv.FormatInt()
+    - gomnd
 
 issues:
   # Don't hide multiple issues that belong to one class since GitHub annotations can handle them all nicely.

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -36,6 +36,11 @@ func TestNoCtxMain(t *testing.T) {
 	validateExpected(t, "testdata/no-ctx")
 }
 
+// TestMainReturnsDict ensures that we support <>.
+func TestMainReturnsDict(t *testing.T) {
+	validateExpected(t, "testdata/main-returns-dict")
+}
+
 func TestNoCtxHook(t *testing.T) {
 	dir := testutil.TempDirPopulatedWith(t, "testdata/no-ctx")
 

--- a/pkg/larker/testdata/main-returns-dict/.cirrus.star
+++ b/pkg/larker/testdata/main-returns-dict/.cirrus.star
@@ -1,0 +1,14 @@
+def main():
+    return {
+        "container": {
+          "image": "debian:latest",
+        },
+        "env": {
+          "VARIABLE_NAME": "VARIABLE_VALUE",
+        },
+        "task": {
+            "script": [
+                "printenv",
+            ],
+        },
+    }

--- a/pkg/larker/testdata/main-returns-dict/expected.yaml
+++ b/pkg/larker/testdata/main-returns-dict/expected.yaml
@@ -1,0 +1,9 @@
+container:
+  image: debian:latest
+
+env:
+  VARIABLE_NAME: VARIABLE_VALUE
+
+task:
+  script:
+    - printenv


### PR DESCRIPTION
Note that it's not possible to [construct a dictonary with duplicate keys](https://docs.bazel.build/versions/2.1.0/skylark/lib/dict.html) in Starlark, so this approach is somewhat limited and forces the user to name the tasks differently, and not just `task:`

Resolves https://github.com/cirruslabs/cirrus-cli/issues/398.