### PR TITLE
Fixed parsing of command for additional containers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-test/deep v1.0.1
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-github/v32 v32.1.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/parser/instance/additionalcontainer.go
+++ b/pkg/parser/instance/additionalcontainer.go
@@ -173,14 +173,15 @@ func NewAdditionalContainer(mergedEnv map[string]string, boolevator *boolevator.
 		return nil
 	})
 
-	commandSchema := schema.Script("Container CMD to override.")
+	commandSchema := schema.String("Container CMD to override.")
 	ac.OptionalField(nameable.NewSimpleNameable("command"), commandSchema, func(node *node.Node) error {
-		command, err := node.GetSliceOfNonEmptyStrings()
+		command, err := node.GetExpandedStringValue(mergedEnv)
 		if err != nil {
 			return err
 		}
 
-		ac.proto.Command = command
+		// tokenize the command
+		ac.proto.Command = strings.Fields(command)
 
 		return nil
 	})

--- a/pkg/parser/instance/additionalcontainer.go
+++ b/pkg/parser/instance/additionalcontainer.go
@@ -184,7 +184,7 @@ func NewAdditionalContainer(mergedEnv map[string]string, boolevator *boolevator.
 		// tokenize the command
 		ac.proto.Command, err = shlex.Split(command)
 		if err != nil {
-			return err
+			return node.ParserError("failed to tokenize command: %v", err.Error())
 		}
 
 		return nil

--- a/pkg/parser/instance/additionalcontainer.go
+++ b/pkg/parser/instance/additionalcontainer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/parseable"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/schema"
+	"github.com/google/shlex"
 	jsschema "github.com/lestrrat-go/jsschema"
 	"strconv"
 	"strings"
@@ -181,7 +182,10 @@ func NewAdditionalContainer(mergedEnv map[string]string, boolevator *boolevator.
 		}
 
 		// tokenize the command
-		ac.proto.Command = strings.Fields(command)
+		ac.proto.Command, err = shlex.Split(command)
+		if err != nil {
+			return err
+		}
 
 		return nil
 	})

--- a/pkg/parser/testdata/cirrus.json
+++ b/pkg/parser/testdata/cirrus.json
@@ -2704,20 +2704,8 @@
                   "description": "Additional Container definition.",
                   "properties": {
                     "command": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "items": [
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "type": "array"
-                        }
-                      ],
-                      "description": "Container CMD to override."
+                      "description": "Container CMD to override.",
+                      "type": "string"
                     },
                     "cpu": {
                       "type": "number"
@@ -2911,20 +2899,8 @@
                   "description": "Additional Container definition.",
                   "properties": {
                     "command": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "items": [
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "type": "array"
-                        }
-                      ],
-                      "description": "Container CMD to override."
+                      "description": "Container CMD to override.",
+                      "type": "string"
                     },
                     "cpu": {
                       "type": "number"
@@ -3120,20 +3096,8 @@
                   "description": "Additional Container definition.",
                   "properties": {
                     "command": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "items": [
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "type": "array"
-                        }
-                      ],
-                      "description": "Container CMD to override."
+                      "description": "Container CMD to override.",
+                      "type": "string"
                     },
                     "cpu": {
                       "type": "number"
@@ -3429,20 +3393,8 @@
                   "description": "Additional Container definition.",
                   "properties": {
                     "command": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "items": [
-                            {
-                              "type": "string"
-                            }
-                          ],
-                          "type": "array"
-                        }
-                      ],
-                      "description": "Container CMD to override."
+                      "description": "Container CMD to override.",
+                      "type": "string"
                     },
                     "cpu": {
                       "type": "number"
@@ -4213,20 +4165,8 @@
               "description": "Additional Container definition.",
               "properties": {
                 "command": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "items": [
-                        {
-                          "type": "string"
-                        }
-                      ],
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Container CMD to override."
+                  "description": "Container CMD to override.",
+                  "type": "string"
                 },
                 "cpu": {
                   "type": "number"
@@ -4404,20 +4344,8 @@
               "description": "Additional Container definition.",
               "properties": {
                 "command": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "items": [
-                        {
-                          "type": "string"
-                        }
-                      ],
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Container CMD to override."
+                  "description": "Container CMD to override.",
+                  "type": "string"
                 },
                 "cpu": {
                   "type": "number"
@@ -4593,20 +4521,8 @@
               "description": "Additional Container definition.",
               "properties": {
                 "command": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "items": [
-                        {
-                          "type": "string"
-                        }
-                      ],
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Container CMD to override."
+                  "description": "Container CMD to override.",
+                  "type": "string"
                 },
                 "cpu": {
                   "type": "number"
@@ -4886,20 +4802,8 @@
               "description": "Additional Container definition.",
               "properties": {
                 "command": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "items": [
-                        {
-                          "type": "string"
-                        }
-                      ],
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Container CMD to override."
+                  "description": "Container CMD to override.",
+                  "type": "string"
                 },
                 "cpu": {
                   "type": "number"

--- a/pkg/parser/testdata/via-rpc/simple-additionalContainers.json
+++ b/pkg/parser/testdata/via-rpc/simple-additionalContainers.json
@@ -22,7 +22,8 @@
       "additionalContainers": [
         {
           "command": [
-            "echo $FOO"
+            "memcached",
+            "--version"
           ],
           "cpu": 1.3,
           "environment": {

--- a/pkg/parser/testdata/via-rpc/simple-additionalContainers.yml
+++ b/pkg/parser/testdata/via-rpc/simple-additionalContainers.yml
@@ -6,7 +6,7 @@ container:
       port: 6379
       cpu: 1.3
       memory: 777
-      command: echo $FOO
+      command: memcached --version
       readiness_command: ./health.sh
       environment:
         FOO: Bar


### PR DESCRIPTION
The command should be a string which is tokenized like `CMD` in a Dockerfile.