### PR TITLE
Add --print option to validate

### DIFF
--- a/internal/commands/validate/validate.go
+++ b/internal/commands/validate/validate.go
@@ -19,6 +19,7 @@ var ErrValidate = errors.New("validate failed")
 // General flags.
 var validateFile string
 var environment []string
+var shouldPrint bool
 
 func additionalInstancesOption(stderr io.Writer) parser.Option {
 	// Try to retrieve additional instances from the Cirrus Cloud
@@ -89,6 +90,10 @@ func validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if shouldPrint {
+		fmt.Fprint(cmd.OutOrStdout(), configuration)
+	}
+
 	return nil
 }
 
@@ -104,6 +109,8 @@ func NewValidateCmd() *cobra.Command {
 		"set (-e A=B) or pass-through (-e A) an environment variable to the Starlark interpreter")
 	cmd.PersistentFlags().StringVarP(&validateFile, "file", "f", "",
 		"use file as the configuration file (the path should end with either .yml or ..star)")
+	cmd.PersistentFlags().BoolVarP(&shouldPrint, "print", "p", false,
+		"print the configuration as YAML (useful for debugging Starlak files)")
 
 	return cmd
 }

--- a/internal/commands/validate/validate.go
+++ b/internal/commands/validate/validate.go
@@ -110,7 +110,7 @@ func NewValidateCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&validateFile, "file", "f", "",
 		"use file as the configuration file (the path should end with either .yml or ..star)")
 	cmd.PersistentFlags().BoolVarP(&shouldPrint, "print", "p", false,
-		"print the configuration as YAML (useful for debugging Starlak files)")
+		"print the configuration as YAML (useful for debugging Starlark files)")
 
 	return cmd
 }

--- a/internal/commands/validate/validate.go
+++ b/internal/commands/validate/validate.go
@@ -79,6 +79,10 @@ func validate(cmd *cobra.Command, args []string) error {
 		return ErrValidate
 	}
 
+	if shouldPrint {
+		fmt.Fprint(cmd.OutOrStdout(), configuration)
+	}
+
 	// Parse
 	p := parser.New(parser.WithEnvironment(userSpecifiedEnvironment), additionalInstancesOption(cmd.ErrOrStderr()))
 	_, err = p.Parse(cmd.Context(), configuration)
@@ -88,10 +92,6 @@ func validate(cmd *cobra.Command, args []string) error {
 		}
 
 		return err
-	}
-
-	if shouldPrint {
-		fmt.Fprint(cmd.OutOrStdout(), configuration)
 	}
 
 	return nil

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -11,7 +11,13 @@ import (
 
 // A simplest possible, but valid configuration.
 var validConfig = []byte("container:\n  image: debian:latest\ntask:\n  script: true\n")
-var validStarlark = []byte("def main():\n    return {'container': {'image': 'debian:latest'}, 'task': {'script': True}}")
+var validStarlark = []byte(`
+def main():
+	return {
+		'container': {'image': 'debian:latest'},
+		'task': {'script': True}
+	}
+`)
 
 func TestValidateNoArgsNoFile(t *testing.T) {
 	testutil.TempChdir(t)

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -11,7 +11,7 @@ import (
 
 // A simplest possible, but valid configuration.
 var validConfig = []byte("container:\n  image: debian:latest\ntask:\n  script: true\n")
-var validStarlak = []byte("def main():\n    return {'container': {'image': 'debian:latest'}, 'task': {'script': True}}")
+var validStarlark = []byte("def main():\n    return {'container': {'image': 'debian:latest'}, 'task': {'script': True}}")
 
 func TestValidateNoArgsNoFile(t *testing.T) {
 	testutil.TempChdir(t)
@@ -69,7 +69,7 @@ func TestValidateNoArgsHasFileWithNonStandardExtension(t *testing.T) {
 func TestValidatePrintFlag(t *testing.T) {
 	testutil.TempChdir(t)
 
-	if err := ioutil.WriteFile(".cirrus.star", validStarlak, 0600); err != nil {
+	if err := ioutil.WriteFile(".cirrus.star", validStarlark, 0600); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Hi guys, thank you very much again for the awesome tools. I am really excited with the new Starlak builds.

With this PR I propose adding adding a `--print` flag to the `validate` command of Cirrus CLI. This idea is to allow users to inspect what they are creating in Starlak (some small quality of life improvement). What do you think about this idea?

I am not very experience with Go, but I gave it a try, hopefully I didn't do anything wrong.

I did manage to run `go test -v internal/commands/validate_test.go` and check the unit test I have added, but I am still trying to find a way of compiling the project locally into a single file executable...