### PR TITLE
Allow starlark main to return a list of tuples

### DIFF
--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -89,32 +89,3 @@ func TestValidatePrintFlag(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, buf.String(), string(validConfig))
 }
-
-var repeatedKeysStarlark = `
-def task(name, script):
-		return {'name': name, 'script': script}
-
-def main():
-		return [
-			('container', {'image': 'debian:latest'}),
-			('task', {'name': 'task1', 'script': True}),
-			task('task2', True),
-			('task', {'name': 'task3', 'script': True}),
-			task('task4', True)
-		]
-`
-
-func TestValidateStarlarkWithRepeatedKeys(t *testing.T) {
-	testutil.TempChdir(t)
-
-	config := []byte(repeatedKeysStarlark)
-	if err := ioutil.WriteFile(".cirrus.star", config, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	command := commands.NewRootCmd()
-	command.SetArgs([]string{"validate", ""})
-	err := command.Execute()
-
-	assert.Nil(t, err)
-}

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -90,28 +90,6 @@ func TestValidatePrintFlag(t *testing.T) {
 	assert.Contains(t, buf.String(), string(validConfig))
 }
 
-var repeatedKeysYAML = `
-container: {image: 'debian:latest'}
-task: {name: task1, script: true}
-task: {name: task2, script: true}
-task: {name: task3, script: true}
-`
-
-func TestValidateYAMLWithRepeatedKeys(t *testing.T) {
-	testutil.TempChdir(t)
-
-	config := []byte(repeatedKeysYAML)
-	if err := ioutil.WriteFile(".cirrus.yml", config, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	command := commands.NewRootCmd()
-	command.SetArgs([]string{"validate", ""})
-	err := command.Execute()
-
-	assert.Nil(t, err)
-}
-
 var repeatedKeysStarlark = `
 def task(name, script):
 		return {'name': name, 'script': script}

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -89,3 +89,54 @@ func TestValidatePrintFlag(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, buf.String(), string(validConfig))
 }
+
+var repeatedKeysYAML = `
+container: {image: 'debian:latest'}
+task: {name: task1, script: true}
+task: {name: task2, script: true}
+task: {name: task3, script: true}
+`
+
+func TestValidateYAMLWithRepeatedKeys(t *testing.T) {
+	testutil.TempChdir(t)
+
+	config := []byte(repeatedKeysYAML)
+	if err := ioutil.WriteFile(".cirrus.yml", config, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := commands.NewRootCmd()
+	command.SetArgs([]string{"validate", ""})
+	err := command.Execute()
+
+	assert.Nil(t, err)
+}
+
+var repeatedKeysStarlark = `
+def task(name, script):
+		return {'name': name, 'script': script}
+
+def main():
+		return [
+			('container', {'image': 'debian:latest'}),
+			('task', {'name': 'task1', 'script': True}),
+			task('task2', True),
+			('task', {'name': 'task3', 'script': True}),
+			task('task4', True)
+		]
+`
+
+func TestValidateStarlarkWithRepeatedKeys(t *testing.T) {
+	testutil.TempChdir(t)
+
+	config := []byte(repeatedKeysStarlark)
+	if err := ioutil.WriteFile(".cirrus.star", config, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := commands.NewRootCmd()
+	command.SetArgs([]string{"validate", ""})
+	err := command.Execute()
+
+	assert.Nil(t, err)
+}

--- a/pkg/larker/convertmain.go
+++ b/pkg/larker/convertmain.go
@@ -25,8 +25,8 @@ func convertInstructions(instructions *starlark.List) *yaml.Node {
 		if ok && pair.Len() == 2 {
 			// Cirrus accepts repeated keys in a YAML Mapping, but that is not
 			// allowed in Starlark. The closest we can have is a list of tuples: [(key, value)]
-			keyObject := pair.Index(0).(starlark.String)
-			key = keyObject.GoString()
+			keyWrapper := pair.Index(0).(starlark.String)
+			key = keyWrapper.GoString()
 			item = convertValue(pair.Index(1))
 		} else {
 			key = "task"

--- a/pkg/larker/convertmain.go
+++ b/pkg/larker/convertmain.go
@@ -21,13 +21,14 @@ func convertInstructions(instructions *starlark.List) *yaml.Node {
 	var item *yaml.Node
 
 	for iter.Next(&listValue) {
-		switch value := listValue.(type) {
-		case starlark.Tuple:
+		pair, ok := listValue.(starlark.Tuple)
+		if ok && pair.Len() == 2 {
 			// Cirrus accepts repeated keys in a YAML Mapping, but that is not
 			// allowed in Starlark. The closest we can have is a list of tuples: [(key, value)]
-			key = strings.Trim(value.Index(0).String(), "'\"")
-			item = convertValue(value.Index(1))
-		default:
+			keyObject := pair.Index(0).(starlark.String)
+			key = keyObject.GoString()
+			item = convertValue(pair.Index(1))
+		} else {
 			key = "task"
 			item = convertValue(listValue)
 		}

--- a/pkg/larker/larker.go
+++ b/pkg/larker/larker.go
@@ -148,7 +148,7 @@ func (larker *Larker) Main(ctx context.Context, source string) (*MainResult, err
 	// main() should return a list of tasks or a dict resembling a Cirrus YAML configuration
 	switch typedMainResult := mainResult.(type) {
 	case *starlark.List:
-		tasksNode = convertTasks(typedMainResult)
+		tasksNode = convertInstructions(typedMainResult)
 		if tasksNode == nil {
 			return &MainResult{OutputLogs: outputLogsBuffer.Bytes()}, nil
 		}

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -64,6 +64,17 @@ func TestMainReturnsTupleList(t *testing.T) {
 	assert.Equal(t, expectedConfig, resultConfig)
 }
 
+// With the introduction of lists of tuples, people can also try to mix
+// tuples and dicts, for example:
+// [('container', 'debian:latest'), task(...), task(...)
+func TestMainReturnsMixedListTuplesAndDicts(t *testing.T) {
+	dir := testutil.TempDirPopulatedWith(t, "testdata/mixed-list")
+	// Avoid validateExpect (will try to parse YAML without accepting repeated keys)
+	resultConfig := loadStarlarkConfig(t, dir)
+	expectedConfig := loadExpectedConfig(t, dir)
+	assert.Equal(t, expectedConfig, resultConfig)
+}
+
 func TestNoCtxHook(t *testing.T) {
 	dir := testutil.TempDirPopulatedWith(t, "testdata/no-ctx")
 

--- a/pkg/larker/larker_test.go
+++ b/pkg/larker/larker_test.go
@@ -41,6 +41,29 @@ func TestMainReturnsDict(t *testing.T) {
 	validateExpected(t, "testdata/main-returns-dict")
 }
 
+// TestMainReturnsList ensures that we support list of tasks
+// lists of tasks will produce repeated keys in the resulting YAML.
+func TestMainReturnsList(t *testing.T) {
+	dir := testutil.TempDirPopulatedWith(t, "testdata/main-returns-list")
+	// Avoid validateExpect (will try to parse YAML without accepting repeated keys)
+	resultConfig := loadStarlarkConfig(t, dir)
+	expectedConfig := loadExpectedConfig(t, dir)
+	assert.Equal(t, expectedConfig, resultConfig)
+}
+
+// For feature parity between Cirrus YAML and Starlark configs,
+// accepting repeated keys is required (not the default behaviour of YAML).
+// A solution for that is to accept a list of tuples from `main`
+// which should be equivalent to a dictionary as output of
+// `main` with the advantage that repeated keys can be used.
+func TestMainReturnsTupleList(t *testing.T) {
+	dir := testutil.TempDirPopulatedWith(t, "testdata/main-returns-tuple-list")
+	// Avoid validateExpect (will try to parse YAML without accepting repeated keys)
+	resultConfig := loadStarlarkConfig(t, dir)
+	expectedConfig := loadExpectedConfig(t, dir)
+	assert.Equal(t, expectedConfig, resultConfig)
+}
+
 func TestNoCtxHook(t *testing.T) {
 	dir := testutil.TempDirPopulatedWith(t, "testdata/no-ctx")
 
@@ -57,9 +80,7 @@ func TestNoCtxHook(t *testing.T) {
 	assert.Contains(t, string(result.OutputLogs), "it works fine without ctx argument!")
 }
 
-func validateExpected(t *testing.T, testDir string) {
-	dir := testutil.TempDirPopulatedWith(t, testDir)
-
+func loadStarlarkConfig(t *testing.T, dir string) string {
 	// Read the source code
 	source, err := ioutil.ReadFile(filepath.Join(dir, ".cirrus.star"))
 	if err != nil {
@@ -73,12 +94,23 @@ func validateExpected(t *testing.T, testDir string) {
 		t.Fatal(err)
 	}
 
+	return result.YAMLConfig
+}
+
+func loadExpectedConfig(t *testing.T, dir string) string {
 	expectedConfiguration, err := ioutil.ReadFile(filepath.Join(dir, "expected.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.YAMLEq(t, string(expectedConfiguration), result.YAMLConfig)
+	return string(expectedConfiguration)
+}
+
+func validateExpected(t *testing.T, testDir string) {
+	dir := testutil.TempDirPopulatedWith(t, testDir)
+	resultConfig := loadStarlarkConfig(t, dir)
+	expectedConfig := loadExpectedConfig(t, dir)
+	assert.YAMLEq(t, expectedConfig, resultConfig)
 }
 
 // TestLoadFileSystemLocal ensures that modules can be loaded from the local file system.

--- a/pkg/larker/testdata/main-returns-list/.cirrus.star
+++ b/pkg/larker/testdata/main-returns-list/.cirrus.star
@@ -1,0 +1,13 @@
+def main():
+    return [
+        {
+            "name": "task 1",
+            "container": {"image": "debian:latest"},
+            "script": "printenv",
+        },
+        {
+            "name": "task 2",
+            "container": {"image": "debian:latest"},
+            "script": "echo 'hello'",
+        }
+    ]

--- a/pkg/larker/testdata/main-returns-list/expected.yaml
+++ b/pkg/larker/testdata/main-returns-list/expected.yaml
@@ -1,0 +1,10 @@
+task:
+  name: task 1
+  container:
+    image: debian:latest
+  script: printenv
+task:
+  name: task 2
+  container:
+    image: debian:latest
+  script: echo 'hello'

--- a/pkg/larker/testdata/main-returns-tuple-list/.cirrus.star
+++ b/pkg/larker/testdata/main-returns-tuple-list/.cirrus.star
@@ -1,0 +1,7 @@
+def main():
+    return [
+        ("container", {"image": "debian:latest"}),
+        ("env", {"VARIABLE_NAME": "VARIABLE_VALUE"}),
+        ("task", {"name": "task 1", "script": ["printenv"]}),
+        ("task", {"name": "task 2", "script": ['echo "task"']})
+    ]

--- a/pkg/larker/testdata/main-returns-tuple-list/expected.yaml
+++ b/pkg/larker/testdata/main-returns-tuple-list/expected.yaml
@@ -1,0 +1,12 @@
+container:
+  image: debian:latest
+env:
+  VARIABLE_NAME: VARIABLE_VALUE
+task:
+  name: task 1
+  script:
+    - printenv
+task:
+  name: task 2
+  script:
+    - echo "task"

--- a/pkg/larker/testdata/mixed-list/.cirrus.star
+++ b/pkg/larker/testdata/mixed-list/.cirrus.star
@@ -1,0 +1,11 @@
+def main():
+    return [
+        ('container', {'image': 'debian:latest'}),
+        ('task', {'name': 'task1', 'script': True}),
+        task('task2', True),
+        ('task', {'name': 'task3', 'script': True}),
+        task('task4', True)
+    ]
+
+def task(name, script):
+    return {'name': name, 'script': script}

--- a/pkg/larker/testdata/mixed-list/expected.yaml
+++ b/pkg/larker/testdata/mixed-list/expected.yaml
@@ -1,0 +1,14 @@
+container:
+  image: debian:latest
+task:
+  name: task1
+  script: true
+task:
+  name: task2
+  script: true
+task:
+  name: task3
+  script: true
+task:
+  name: task4
+  script: true

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -509,3 +509,20 @@ func TestWithMissingInstancesAllowed(t *testing.T) {
 	assert.Len(t, result.Tasks, 1)
 	assert.Nil(t, result.Tasks[0].Instance)
 }
+
+var repeatedKeysYAML = `
+container: {image: 'debian:latest'}
+task: {name: task1, script: true}
+task: {name: task2, script: true}
+task: {name: task3, script: true}
+`
+
+func TestRepeatedKeys(t *testing.T) {
+	p := parser.New()
+	result, err := p.Parse(context.Background(), repeatedKeysYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, result.Tasks, 3)
+}


### PR DESCRIPTION
Cirrus interpretation of the YAML file allows repeated keys.
While standard YAML (that forbids repeated keys) maps very nicely to Starlak, this feature cannot be achieved if users are constrained to return either a dict or a list of task (dict) objects.

This PR proposes allowing a list of tuples `[(key, value)]` as an equivalent to returning a dict from `main` in a Starlark script, to circumvent this limitation.

*Motivation*: until recently, Cirrus web interface was displaying warning for some scenarios where repetition was not being used (https://github.com/cirruslabs/cirrus-ci-docs/issues/887). I also don't know if some instructions can be prefixed (e.g. `docker_builder`, it is not clear on the [docs](https://cirrus-ci.org/guide/docker-builder-vm/))

Returning dicts (or equivalent) is important when the users want to have shared env vars/container definition, and other top level instructions such as `pipe`, `docker_builder`, etc. An example of repeated top level keys can be found in the very own `.cirrus.yml` file of this repository (3 `docker_builder` and 3 `task` instructions).

---
A little disclaimer: I am not an experienced Go programmer (in fact pretty much using it for the first time in the PRs to cirrus-cli), so any feedback/suggestions/guidance is very welcome.

---
Quick question: does the CirrusCI executor uses the `larker` package in this repository to parse/run the starlarker scripts, so changing it here means things automatically change in Cirrus CI, or that is a completely different codebase that would require unrelated changes?