### PR TITLE
Evaluator: fail when cirrus.fs is used but no GitHub FS was initialized

### DIFF
--- a/pkg/larker/fs/failing/failing.go
+++ b/pkg/larker/fs/failing/failing.go
@@ -1,0 +1,28 @@
+package failing
+
+import (
+	"context"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
+)
+
+type Failing struct {
+	err error
+}
+
+func New(err error) *Failing {
+	return &Failing{
+		err: err,
+	}
+}
+
+func (ffs *Failing) Stat(ctx context.Context, path string) (*fs.FileInfo, error) {
+	return nil, ffs.err
+}
+
+func (ffs *Failing) Get(ctx context.Context, path string) ([]byte, error) {
+	return nil, ffs.err
+}
+
+func (ffs *Failing) ReadDir(ctx context.Context, path string) ([]string, error) {
+	return nil, ffs.err
+}


### PR DESCRIPTION
To prevent things like https://github.com/cirruslabs/cirrus-cli/issues/442 in the future.