### PR TITLE
Parser: more helpful error message for overridden task names dependents

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -60,42 +60,6 @@ func TestValidConfigs(t *testing.T) {
 	}
 }
 
-func TestIssues(t *testing.T) {
-	issueCases := []struct {
-		File   string
-		Issues []*api.Issue
-	}{
-		{
-			"multiple-name-ambiguity.yml",
-			[]*api.Issue{
-				{
-					Level: api.Issue_WARNING,
-					Message: "consider using 'task:' instead of 'first_name_for_a_task_task:' here since the name field " +
-						"inside of the task already overrides it's name to be \"Second name for a task\"",
-					Path:   ".cirrus.yml",
-					Line:   4,
-					Column: 1,
-				},
-			},
-		},
-		{
-			"no-multiple-name-ambiguity.yml",
-			nil,
-		},
-	}
-
-	for _, issueCase := range issueCases {
-		issueCase := issueCase
-
-		t.Run(issueCase.File, func(t *testing.T) {
-			p := parser.New()
-			result, err := p.ParseFromFile(context.Background(), filepath.Join("testdata", "issues", issueCase.File))
-			require.Nil(t, err)
-			assert.EqualValues(t, issueCase.Issues, result.Issues)
-		})
-	}
-}
-
 func TestInvalidConfigs(t *testing.T) {
 	var invalidCases = []struct {
 		Name  string
@@ -105,6 +69,8 @@ func TestInvalidConfigs(t *testing.T) {
 		{"invalid-upload-caches-nonexistent-cache", "parsing error: 7:3: no cache with name \"mode_nodules\" is defined"},
 		{"invalid-cache-two-fingerprints", "parsing error: 5:3: please either use fingerprint_script: or fingerprint_key, " +
 			"since otherwise there's ambiguity about which one to prefer for cache key calculation"},
+		{"invalid-multiple-name-ambiguity", "parsing error: task 'deploy' depends on task 'rspec_code', which name " +
+			"was overridden by a name: field inside of that task"},
 	}
 
 	for _, invalidCase := range invalidCases {

--- a/pkg/parser/task/dockerbuilder.go
+++ b/pkg/parser/task/dockerbuilder.go
@@ -22,8 +22,9 @@ type DockerBuilder struct {
 	platform  api.Platform
 	osVersion string
 
-	alias     string
-	dependsOn []string
+	fallbackName string
+	alias        string
+	dependsOn    []string
 
 	onlyIfExpression string
 
@@ -139,6 +140,14 @@ func (dbuilder *DockerBuilder) Name() string {
 
 func (dbuilder *DockerBuilder) SetName(name string) {
 	dbuilder.proto.Name = name
+}
+
+func (dbuilder *DockerBuilder) FallbackName() string {
+	return dbuilder.fallbackName
+}
+
+func (dbuilder *DockerBuilder) SetFallbackName(name string) {
+	dbuilder.fallbackName = name
 }
 
 func (dbuilder *DockerBuilder) Alias() string {

--- a/pkg/parser/task/pipe.go
+++ b/pkg/parser/task/pipe.go
@@ -25,8 +25,9 @@ type DockerPipe struct {
 
 	res *PipeResources
 
-	alias     string
-	dependsOn []string
+	fallbackName string
+	alias        string
+	dependsOn    []string
 
 	onlyIfExpression string
 
@@ -191,6 +192,14 @@ func (pipe *DockerPipe) Name() string {
 
 func (pipe *DockerPipe) SetName(name string) {
 	pipe.proto.Name = name
+}
+
+func (pipe *DockerPipe) FallbackName() string {
+	return pipe.fallbackName
+}
+
+func (pipe *DockerPipe) SetFallbackName(name string) {
+	pipe.fallbackName = name
 }
 
 func (pipe *DockerPipe) Alias() string {

--- a/pkg/parser/task/task.go
+++ b/pkg/parser/task/task.go
@@ -21,8 +21,9 @@ import (
 type Task struct {
 	proto api.Task
 
-	alias     string
-	dependsOn []string
+	fallbackName string
+	alias        string
+	dependsOn    []string
 
 	onlyIfExpression string
 
@@ -228,6 +229,14 @@ func (task *Task) Name() string {
 
 func (task *Task) SetName(name string) {
 	task.proto.Name = name
+}
+
+func (task *Task) FallbackName() string {
+	return task.fallbackName
+}
+
+func (task *Task) SetFallbackName(name string) {
+	task.fallbackName = name
 }
 
 func (task *Task) Alias() string {

--- a/pkg/parser/task/tasklike.go
+++ b/pkg/parser/task/tasklike.go
@@ -8,6 +8,8 @@ import (
 type ParseableTaskLike interface {
 	Name() string
 	SetName(name string)
+	FallbackName() string
+	SetFallbackName(name string)
 	Alias() string
 	DependsOnNames() []string
 

--- a/pkg/parser/testdata/invalid-multiple-name-ambiguity.yml
+++ b/pkg/parser/testdata/invalid-multiple-name-ambiguity.yml
@@ -1,0 +1,11 @@
+container:
+  image: ruby:latest
+
+rspec_code_task:
+  matrix:
+    name: Code (shard 1)
+    name: Code (shard 2)
+    name: Code (shard 3)
+
+deploy_task:
+  depends_on: rspec_code

--- a/pkg/parser/testdata/issues/multiple-name-ambiguity.yml
+++ b/pkg/parser/testdata/issues/multiple-name-ambiguity.yml
@@ -1,5 +1,0 @@
-container:
-  image: debian:latest
-
-first_name_for_a_task:
-  name: Second name for a task

--- a/pkg/parser/testdata/issues/no-multiple-name-ambiguity.yml
+++ b/pkg/parser/testdata/issues/no-multiple-name-ambiguity.yml
@@ -1,7 +1,0 @@
-container:
-  image: debian:latest
-
-task:
-  name: First name for a task
-
-first_name_for_a_task_task: {}


### PR DESCRIPTION
This effectively reverts the https://github.com/cirruslabs/cirrus-cli/pull/429 and resolves https://github.com/cirruslabs/cirrus-cli/issues/444 and also resolves https://github.com/cirruslabs/cirrus-ci-docs/issues/887.

Instead of emitting a warning on each override instance (as it turns out overriding names can be useful, see https://github.com/cirruslabs/cirrus-ci-docs/issues/887), emit a more helpful dependency error in cases described https://github.com/cirruslabs/cirrus-cli/issues/427.