### PR TITLE
Executor: terminate on context.Context cancellation/deadline

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -135,6 +135,9 @@ func (e *Executor) Run(ctx context.Context) error {
 			if firstErr == nil {
 				firstErr = err
 			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
Otherwise it's possible get caught in an endless loop by pressing `Ctrl+C` sometimes.