### PR TITLE
Starlark: introduce fs.isdir()

### DIFF
--- a/pkg/larker/builtin/fs.go
+++ b/pkg/larker/builtin/fs.go
@@ -13,6 +13,7 @@ func FS(ctx context.Context, fs fs.FileSystem) starlark.StringDict {
 		"exists":  exists(ctx, fs),
 		"read":    read(ctx, fs),
 		"readdir": readdir(ctx, fs),
+		"isdir":   isdir(ctx, fs),
 	}
 }
 
@@ -84,5 +85,27 @@ func readdir(ctx context.Context, fs fs.FileSystem) starlark.Value {
 		}
 
 		return starlark.NewList(starlarkEntries), nil
+	})
+}
+
+func isdir(ctx context.Context, fs fs.FileSystem) starlark.Value {
+	const funcName = "isdir"
+
+	return starlark.NewBuiltin(funcName, func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var path string
+		if err := starlark.UnpackPositionalArgs(funcName, args, kwargs, 1, &path); err != nil {
+			return nil, err
+		}
+
+		fileInfo, err := fs.Stat(ctx, path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return starlark.None, nil
+			}
+
+			return nil, err
+		}
+
+		return starlark.Bool(fileInfo.IsDir), nil
 	})
 }

--- a/pkg/larker/testdata/builtin-fs/.cirrus.star
+++ b/pkg/larker/testdata/builtin-fs/.cirrus.star
@@ -7,6 +7,7 @@ def main(ctx):
     test_exists()
     test_read()
     test_readdir()
+    test_isdir()
 
     return []
 
@@ -35,14 +36,28 @@ def test_read():
 def test_readdir():
     expectedFiles = [
         ".cirrus.star",
+        "dir",
         shouldExist,
         someFile,
     ]
     actualFiles = fs.readdir(".")
 
     if expectedFiles != actualFiles:
-        fail("directory contains %s instead of %s" % (expectedFiles, actualFiles))
+        fail("directory contains %s instead of %s" % (actualFiles, expectedFiles))
 
     shouldNotExist = "readdir-should-not-exist"
     if fs.readdir(shouldNotExist) != None:
         fail("non-existent directory %s should not be readable" % shouldNotExist)
+
+def test_isdir():
+    file = "dir/file"
+    dir = "dir"
+
+    if fs.isdir(file):
+        fail("fs.isdir() reports that the file we've created is a directory")
+
+    if not fs.isdir(dir):
+        fail("fs.isdir() reports that the directory we've created is not a directory")
+
+    if fs.isdir("does-not-exist-really") != None:
+        fail("fs.isdir() should return None on non-existent path")


### PR DESCRIPTION
Works similarly to Python [`os.path`'s `isdir()`](https://docs.python.org/3/library/os.path.html#os.path.isdir).

See https://github.com/cirruslabs/cirrus-ci-docs/issues/938.