### PR TITLE
GitHub FS: fileInfos cache

### DIFF
--- a/pkg/larker/fs/github/github.go
+++ b/pkg/larker/fs/github/github.go
@@ -39,7 +39,7 @@ func New(owner, repo, reference, token string) (*GitHub, error) {
 	if err != nil {
 		return nil, err
 	}
-	fileInfosCache, err := lru.New(16)
+	fileInfosCache, err := lru.New(1024)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/larker/fs/github/github.go
+++ b/pkg/larker/fs/github/github.go
@@ -23,7 +23,10 @@ type GitHub struct {
 	repo      string
 	reference string
 
-	contentsCache *lru.Cache
+	contentsCache  *lru.Cache
+	fileInfosCache *lru.Cache
+
+	apiCallCount uint64
 }
 
 type Contents struct {
@@ -36,6 +39,10 @@ func New(owner, repo, reference, token string) (*GitHub, error) {
 	if err != nil {
 		return nil, err
 	}
+	fileInfosCache, err := lru.New(16)
+	if err != nil {
+		return nil, err
+	}
 
 	return &GitHub{
 		token:     token,
@@ -43,11 +50,21 @@ func New(owner, repo, reference, token string) (*GitHub, error) {
 		repo:      repo,
 		reference: reference,
 
-		contentsCache: contentsCache,
+		contentsCache:  contentsCache,
+		fileInfosCache: fileInfosCache,
 	}, nil
 }
 
+func (gh *GitHub) APICallCount() uint64 {
+	return gh.apiCallCount
+}
+
 func (gh *GitHub) Stat(ctx context.Context, path string) (*fs.FileInfo, error) {
+	cachedFileInfo, ok := gh.fileInfosCache.Get(path)
+	if ok {
+		return cachedFileInfo.(*fs.FileInfo), nil
+	}
+
 	_, directoryContent, err := gh.getContentsWrapper(ctx, path)
 	if err != nil {
 		return nil, err
@@ -124,6 +141,8 @@ func (gh *GitHub) getContentsWrapper(
 		return contents.(*Contents).File, contents.(*Contents).Directory, nil
 	}
 
+	gh.apiCallCount++
+
 	fileContent, directoryContent, resp, err := gh.client(ctx).Repositories.GetContents(ctx, gh.owner, gh.repo, path,
 		&github.RepositoryContentGetOptions{
 			Ref: gh.reference,
@@ -135,6 +154,28 @@ func (gh *GitHub) getContentsWrapper(
 		}
 
 		return nil, nil, fmt.Errorf("%w: %v", ErrAPI, err)
+	}
+
+	if fileContent != nil {
+		gh.fileInfosCache.ContainsOrAdd(path, &fs.FileInfo{IsDir: false})
+	}
+	for _, directoryEntry := range directoryContent {
+		if directoryEntry.Type == nil || directoryEntry.Path == nil {
+			continue
+		}
+
+		var fileInfo fs.FileInfo
+
+		switch *directoryEntry.Type {
+		case "file":
+			fileInfo.IsDir = false
+		case "dir":
+			fileInfo.IsDir = true
+		default:
+			continue
+		}
+
+		gh.fileInfosCache.ContainsOrAdd(*directoryEntry.Path, &fileInfo)
 	}
 
 	gh.contentsCache.Add(path, &Contents{File: fileContent, Directory: directoryContent})


### PR DESCRIPTION
An alternative implementation of https://github.com/cirruslabs/cirrus-cli/pull/473 that also caches information about directories.