### PR TITLE
Move GitHub FS back to it's package and fix last linter error

### DIFF
--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/larker"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/failing"
-	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/git"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/github"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/memory"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/parsererror"
@@ -101,7 +101,7 @@ func fsFromEnvironment(env map[string]string) (fs fs.FileSystem, err error) {
 		return
 	}
 
-	return git.NewGitHub(owner, repo, reference, token)
+	return github.New(owner, repo, reference, token)
 }
 
 func (r *ConfigurationEvaluatorServiceServer) EvaluateConfig(

--- a/pkg/larker/fs/git/git.go
+++ b/pkg/larker/fs/git/git.go
@@ -27,7 +27,7 @@ type Git struct {
 	worktree *git.Worktree
 }
 
-func NewGit(ctx context.Context, url string, revision string) (*Git, error) {
+func New(ctx context.Context, url string, revision string) (*Git, error) {
 	const (
 		cacheBytes = 1 * units.MiB
 

--- a/pkg/larker/fs/git/git_test.go
+++ b/pkg/larker/fs/git/git_test.go
@@ -18,7 +18,7 @@ func fileSystemsToTest(t *testing.T) map[string]fs.FileSystem {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gitFS, err := git.NewGit(context.Background(), "https://github.com/cirruslabs/cirrus-cli", "master")
+	gitFS, err := git.New(context.Background(), "https://github.com/cirruslabs/cirrus-cli", "master")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/larker/fs/git/git_test.go
+++ b/pkg/larker/fs/git/git_test.go
@@ -2,152 +2,16 @@ package git_test
 
 import (
 	"context"
-	"errors"
-	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/git"
-	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/github"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"os"
-	"syscall"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/githubfixture"
 	"testing"
 )
 
-func fileSystemsToTest(t *testing.T) map[string]fs.FileSystem {
-	ghFS, err := github.New("cirruslabs", "cirrus-cli", "master", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	gitFS, err := git.New(context.Background(), "https://github.com/cirruslabs/cirrus-cli", "master")
+func TestGitHubFixture(t *testing.T) {
+	gitFS, err := git.New(context.Background(), githubfixture.URL, githubfixture.Reference)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return map[string]fs.FileSystem{"github": ghFS, "git": gitFS}
-}
-
-func possiblySkip(t *testing.T) {
-	if _, ok := os.LookupEnv("CIRRUS_INTERNAL_NO_GITHUB_API_TESTS"); ok {
-		t.SkipNow()
-	}
-}
-
-func TestStatFile(t *testing.T) {
-	possiblySkip(t)
-
-	for name, currentFS := range fileSystemsToTest(t) {
-		fileSystem := currentFS
-		t.Run(name, func(t *testing.T) {
-			stat, err := fileSystem.Stat(context.Background(), "go.mod")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			assert.False(t, stat.IsDir)
-		})
-	}
-}
-
-func TestStatDirectory(t *testing.T) {
-	possiblySkip(t)
-
-	for name, currentFS := range fileSystemsToTest(t) {
-		fileSystem := currentFS
-		t.Run(name, func(t *testing.T) {
-			stat, err := fileSystem.Stat(context.Background(), ".")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			assert.True(t, stat.IsDir)
-		})
-	}
-}
-
-func TestGetFile(t *testing.T) {
-	possiblySkip(t)
-
-	for name, currentFS := range fileSystemsToTest(t) {
-		fileSystem := currentFS
-		t.Run(name, func(t *testing.T) {
-			fileBytes, err := fileSystem.Get(context.Background(), "go.mod")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			assert.Contains(t, string(fileBytes), "module github.com/cirruslabs/cirrus-cli")
-		})
-	}
-}
-
-func TestGetDirectory(t *testing.T) {
-	possiblySkip(t)
-
-	for name, currentFS := range fileSystemsToTest(t) {
-		fileSystem := currentFS
-		t.Run(name, func(t *testing.T) {
-			_, err := fileSystem.Get(context.Background(), ".")
-
-			require.Error(t, err)
-			assert.True(t, errors.Is(err, fs.ErrNormalizedIsADirectory))
-		})
-	}
-}
-
-func TestGetNonExistentFile(t *testing.T) {
-	possiblySkip(t)
-
-	for name, currentFS := range fileSystemsToTest(t) {
-		fileSystem := currentFS
-		t.Run(name, func(t *testing.T) {
-			_, err := fileSystem.Get(context.Background(), "the-file-that-should-not-exist.txt")
-
-			require.Error(t, err)
-			assert.True(t, errors.Is(err, os.ErrNotExist))
-		})
-	}
-}
-
-func TestReadDirFile(t *testing.T) {
-	possiblySkip(t)
-
-	for name, currentFS := range fileSystemsToTest(t) {
-		fileSystem := currentFS
-		t.Run(name, func(t *testing.T) {
-			_, err := fileSystem.ReadDir(context.Background(), "go.mod")
-
-			require.Error(t, err)
-			assert.True(t, errors.Is(err, syscall.ENOTDIR))
-		})
-	}
-}
-
-func TestReadDirDirectory(t *testing.T) {
-	possiblySkip(t)
-
-	for name, currentFS := range fileSystemsToTest(t) {
-		fileSystem := currentFS
-		t.Run(name, func(t *testing.T) {
-			entries, err := fileSystem.ReadDir(context.Background(), ".")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			assert.Contains(t, entries, "go.mod", "go.sum")
-		})
-	}
-}
-
-func TestReadDirNonExistentDirectory(t *testing.T) {
-	possiblySkip(t)
-
-	for name, currentFS := range fileSystemsToTest(t) {
-		fileSystem := currentFS
-		t.Run(name, func(t *testing.T) {
-			_, err := fileSystem.ReadDir(context.Background(), "the-directory-that-should-not-exist")
-
-			require.Error(t, err)
-			assert.True(t, errors.Is(err, os.ErrNotExist))
-		})
-	}
+	githubfixture.Run(t, gitFS)
 }

--- a/pkg/larker/fs/git/git_test.go
+++ b/pkg/larker/fs/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/git"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -13,7 +14,7 @@ import (
 )
 
 func fileSystemsToTest(t *testing.T) map[string]fs.FileSystem {
-	ghFS, err := git.NewGitHub("cirruslabs", "cirrus-cli", "master", "")
+	ghFS, err := github.New("cirruslabs", "cirrus-cli", "master", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/larker/fs/github/github.go
+++ b/pkg/larker/fs/github/github.go
@@ -1,4 +1,4 @@
-package git
+package github
 
 import (
 	"context"
@@ -17,9 +17,6 @@ import (
 
 var ErrAPI = errors.New("failed to communicate with the GitHub API")
 
-// Work around golint's false positive:
-// "type name will be used as git.GitHub by other packages, and that stutters; consider calling this Hub"
-// nolint:golint
 type GitHub struct {
 	token     string
 	owner     string
@@ -37,7 +34,7 @@ type Contents struct {
 	Directory []*github.RepositoryContent
 }
 
-func NewGitHub(owner, repo, reference, token string) (*GitHub, error) {
+func New(owner, repo, reference, token string) (*GitHub, error) {
 	contentsCache, err := lru.New(16)
 	if err != nil {
 		return nil, err

--- a/pkg/larker/fs/github/github_test.go
+++ b/pkg/larker/fs/github/github_test.go
@@ -1,8 +1,8 @@
-package git_test
+package github_test
 
 import (
 	"context"
-	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/git"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/github"
 	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
@@ -13,7 +13,7 @@ func TestStatUsesFileInfosCache(t *testing.T) {
 		t.SkipNow()
 	}
 
-	fileSystem, err := git.NewGitHub("cirruslabs", "cirrus-cli", "master", "")
+	fileSystem, err := github.New("cirruslabs", "cirrus-cli", "master", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/larker/fs/github/github_test.go
+++ b/pkg/larker/fs/github/github_test.go
@@ -3,15 +3,31 @@ package github_test
 import (
 	"context"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/github"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/githubfixture"
 	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
 )
 
-func TestStatUsesFileInfosCache(t *testing.T) {
+func possiblySkip(t *testing.T) {
 	if _, ok := os.LookupEnv("CIRRUS_INTERNAL_NO_GITHUB_API_TESTS"); ok {
 		t.SkipNow()
 	}
+}
+
+func TestGitHubFixture(t *testing.T) {
+	possiblySkip(t)
+
+	ghFS, err := github.New(githubfixture.Owner, githubfixture.Repo, githubfixture.Reference, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	githubfixture.Run(t, ghFS)
+}
+
+func TestStatUsesFileInfosCache(t *testing.T) {
+	possiblySkip(t)
 
 	fileSystem, err := github.New("cirruslabs", "cirrus-cli", "master", "")
 	if err != nil {

--- a/pkg/larker/fs/githubfixture/githubfixture.go
+++ b/pkg/larker/fs/githubfixture/githubfixture.go
@@ -1,0 +1,87 @@
+package githubfixture
+
+import (
+	"context"
+	"errors"
+	fspkg "github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"syscall"
+	"testing"
+)
+
+const (
+	URL       = "https://github.com/cirruslabs/cirrus-cli"
+	Owner     = "cirruslabs"
+	Repo      = "cirrus-cli"
+	Reference = "master"
+)
+
+func Run(t *testing.T, fs fspkg.FileSystem) {
+	ctx := context.Background()
+
+	t.Run("TestStatFile", func(t *testing.T) {
+		stat, err := fs.Stat(ctx, "go.mod")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.False(t, stat.IsDir)
+	})
+
+	t.Run("TestStatDirectory", func(t *testing.T) {
+		stat, err := fs.Stat(ctx, ".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.True(t, stat.IsDir)
+	})
+
+	t.Run("TestGetFile", func(t *testing.T) {
+		fileBytes, err := fs.Get(ctx, "go.mod")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Contains(t, string(fileBytes), "module github.com/cirruslabs/cirrus-cli")
+	})
+
+	t.Run("TestGetDirectory", func(t *testing.T) {
+		_, err := fs.Get(ctx, ".")
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fspkg.ErrNormalizedIsADirectory))
+	})
+
+	t.Run("TestGetNonExistentFile", func(t *testing.T) {
+		_, err := fs.Get(ctx, "the-file-that-should-not-exist.txt")
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, os.ErrNotExist))
+	})
+
+	t.Run("TestReadDirFile", func(t *testing.T) {
+		_, err := fs.ReadDir(ctx, "go.mod")
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, syscall.ENOTDIR))
+	})
+
+	t.Run("TestReadDirDirectory", func(t *testing.T) {
+		entries, err := fs.ReadDir(ctx, ".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Contains(t, entries, "go.mod", "go.sum")
+	})
+
+	t.Run("TestReadDirNonExistentDirectory", func(t *testing.T) {
+		_, err := fs.ReadDir(ctx, "the-directory-that-should-not-exist")
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, os.ErrNotExist))
+	})
+}

--- a/pkg/larker/loader/module_fs.go
+++ b/pkg/larker/loader/module_fs.go
@@ -110,7 +110,7 @@ func findLocatorFS(
 ) (fs.FileSystem, string, error) {
 	switch l := location.(type) {
 	case gitHubLocation:
-		token, _ := env["CIRRUS_REPO_CLONE_TOKEN"]
+		token := env["CIRRUS_REPO_CLONE_TOKEN"]
 
 		ghFS, err := github.New(l.Owner, l.Name, l.Revision, token)
 		if err != nil {

--- a/pkg/larker/loader/module_fs.go
+++ b/pkg/larker/loader/module_fs.go
@@ -118,7 +118,7 @@ func findLocatorFS(
 		}
 		return ghFS, l.Path, nil
 	case gitLocation:
-		gitFS, err := git.NewGit(ctx, l.URL, l.Revision)
+		gitFS, err := git.New(ctx, l.URL, l.Revision)
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/larker/loader/module_fs.go
+++ b/pkg/larker/loader/module_fs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/git"
+	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs/github"
 	"regexp"
 )
 
@@ -111,7 +112,7 @@ func findLocatorFS(
 	case gitHubLocation:
 		token, _ := env["CIRRUS_REPO_CLONE_TOKEN"]
 
-		ghFS, err := git.NewGitHub(l.Owner, l.Name, l.Revision, token)
+		ghFS, err := github.New(l.Owner, l.Name, l.Revision, token)
 		if err != nil {
 			return nil, "", err
 		}


### PR DESCRIPTION
Also there's now a helper package named `githubfixture` that can be used to test various FS implementations that can access GitHub repositories against it.