### PR TITLE
Parser: fix map merging when using aliases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,8 @@ docker_builder:
     - sudo apt-get -y install podman
   configure_podman_script:
     - echo 'unqualified-search-registries=["docker.io"]' > /etc/containers/registries.conf.d/docker.conf
+  work_around_gcloud_credential_helper_script:
+    - rm /root/.docker/config.json
   run_podman_background_script:
     - podman system service -t 0 unix:///tmp/podman.sock
   test_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ docker_builder:
   platform: windows
   os_version: 2019
   test_script:
-    - choco install -y golang
+    - choco install -y golang git
     - refreshenv
     - md C:\Windows\system32\config\systemprofile\AppData\Local\Temp
     - go test -v ./...

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,8 @@ docker_builder:
   alias: Tests
   install_podman_script:
     - sudo apt-get -y install podman
+  configure_podman_script:
+    - echo 'unqualified-search-registries=["docker.io"]' > /etc/containers/registries.conf.d/docker.conf
   run_podman_background_script:
     - podman system service -t 0 unix:///tmp/podman.sock
   test_script:

--- a/internal/executor/instance/volume/volume.go
+++ b/internal/executor/instance/volume/volume.go
@@ -64,7 +64,8 @@ func CreateWorkingVolume(
 	agentImage := platform.ContainerAgentImage(agentVersion)
 
 	if err := pullhelper.PullHelper(ctx, agentImage, backend, containerOptions, nil); err != nil {
-		return nil, nil, fmt.Errorf("%w: when pulling agent image: %v", ErrVolumeCreationFailed, err)
+		return nil, nil, fmt.Errorf("%w: when pulling agent image %s: %v",
+			ErrVolumeCreationFailed, agentImage, err)
 	}
 
 	if err := backend.VolumeCreate(ctx, agentVolumeName); err != nil {

--- a/pkg/parser/modifier/merger/merger.go
+++ b/pkg/parser/modifier/merger/merger.go
@@ -1,0 +1,47 @@
+package merger
+
+import (
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
+)
+
+func merge(tree *node.Node) {
+	switch tree.Value.(type) {
+	case *node.MapValue:
+		indexesToOmit := map[int]struct{}{}
+		prevNameToIndex := map[string]int{}
+
+		for i, child := range tree.Children {
+			merge(child)
+
+			prevIndex, hasPrevName := prevNameToIndex[child.Name]
+
+			if hasPrevName && tree.Children[prevIndex].Merged {
+				indexesToOmit[prevIndex] = struct{}{}
+			}
+
+			prevNameToIndex[child.Name] = i
+		}
+
+		var newChildren []*node.Node
+
+		for i, child := range tree.Children {
+			_, shouldOmit := indexesToOmit[i]
+
+			if !shouldOmit {
+				newChildren = append(newChildren, child)
+			}
+		}
+
+		tree.Children = newChildren
+	case *node.ListValue:
+		for _, listItem := range tree.Children {
+			merge(listItem)
+		}
+	}
+}
+
+func MergeMapEntries(tree *node.Node) error {
+	merge(tree)
+
+	return nil
+}

--- a/pkg/parser/node/matrix.go
+++ b/pkg/parser/node/matrix.go
@@ -106,11 +106,20 @@ func (node *Node) ReplaceWith(with []*Node) {
 }
 
 func (node *Node) MergeMapsOrOverwrite(with *Node) {
-	_, nodeIsMap := node.Value.(*MapValue)
-	_, withIsMap := with.Value.(*MapValue)
-	if nodeIsMap && withIsMap {
+	// If the value associated with the key is a single mapping node,
+	// each of its key/value pairs is inserted into the current mapping,
+	// unless the key already exists in it.
+	//
+	// https://yaml.org/type/merge.html
+	if node.IsMap() && with.IsMap() {
 		for _, child := range with.Children {
+			// Skip merging the key if it already exists in node.
+			if node.FindChild(child.Name) != nil {
+				continue
+			}
+
 			child.Parent = node
+			child.Merged = true
 			node.Children = append(node.Children, child)
 		}
 

--- a/pkg/parser/node/node.go
+++ b/pkg/parser/node/node.go
@@ -11,6 +11,7 @@ type Node struct {
 	Value    interface{}
 	Parent   *Node
 	Children []*Node
+	Merged   bool
 
 	Line   int
 	Column int
@@ -44,6 +45,12 @@ func (node *Node) ValueIsEmpty() bool {
 	default:
 		return false
 	}
+}
+
+func (node *Node) IsMap() bool {
+	_, isMap := node.Value.(*MapValue)
+
+	return isMap
 }
 
 func (node *Node) String() string {

--- a/pkg/parser/node/yaml_test.go
+++ b/pkg/parser/node/yaml_test.go
@@ -82,7 +82,14 @@ aliases_test:
 	}
 
 	aliasesTestNode.Children = []*node.Node{
-		{Name: "STATE", Parent: aliasesTestNode, Value: &node.ScalarValue{Value: "OFF"}, Line: 10, Column: 3},
+		{
+			Name:   "STATE",
+			Parent: aliasesTestNode,
+			Value:  &node.ScalarValue{Value: "OFF"},
+			Merged: true,
+			Line:   10,
+			Column: 3,
+		},
 	}
 
 	root.Children = []*node.Node{

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/boolevator"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/issue"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/modifier/matrix"
+	"github.com/cirruslabs/cirrus-cli/pkg/parser/modifier/merger"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/nameable"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/node"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/parseable"
@@ -218,6 +219,9 @@ func (p *Parser) Parse(ctx context.Context, config string) (result *Result, err 
 
 	// Run modifiers on it
 	if err := matrix.ExpandMatrices(tree); err != nil {
+		return nil, err
+	}
+	if err := merger.MergeMapEntries(tree); err != nil {
 		return nil, err
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -41,6 +41,7 @@ var validCases = []string{
 	"upload-caches",
 	"cache-fingerprint-key",
 	"docker-arguments-expansion",
+	"yaml-scripts-merging",
 }
 
 func absolutize(file string) string {

--- a/pkg/parser/testdata/yaml-scripts-merging.json
+++ b/pkg/parser/testdata/yaml-scripts-merging.json
@@ -1,0 +1,73 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "install_tools",
+        "scriptInstruction": {
+          "scripts": [
+            "apt-get install tmux"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "merge"
+  },
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "install_tools",
+        "scriptInstruction": {
+          "scripts": [
+            "apt-get install tmux"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "localGroupId": "1",
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "1",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "no_merge"
+  }
+]

--- a/pkg/parser/testdata/yaml-scripts-merging.yml
+++ b/pkg/parser/testdata/yaml-scripts-merging.yml
@@ -1,0 +1,16 @@
+container:
+  image: debian:latest
+
+.task_template: &task-template
+  install_tools_script:
+    - apt-get install screen
+
+merge_task:
+  << : *task-template
+  install_tools_script:
+    - apt-get install tmux
+
+no_merge_task:
+  install_tools_script:
+    - apt-get install tmux
+  <<: *task-template


### PR DESCRIPTION
This one focuses only on aliases, because merging everything per YAML spec is not easy as it sounds at this moment:

* we have to exclude `always`, `on_failure`, `upload_caches` and possibly others
* we have to support old behavior where duplicate key contents are merged together, e.g.: https://github.com/cirruslabs/cirrus-cli/blob/9f9dfcda39cbbd9ac260c1a30c3023a1c3111ea5/pkg/parser/testdata/via-rpc/new-deduplicator-same-type.yml#L6-L12

Resolves https://github.com/cirruslabs/cirrus-ci-docs/issues/980.