### PR TITLE
Persistent Worker: fix RPC endpoint configuration when ran via CLI

### DIFF
--- a/internal/commands/worker/run.go
+++ b/internal/commands/worker/run.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"errors"
 	"fmt"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/endpoint"
 	"github.com/cirruslabs/cirrus-cli/internal/worker"
 	"github.com/dustin/go-humanize"
 	"github.com/sirupsen/logrus"
@@ -69,6 +70,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// Configure RPC server (used for testing)
 	if rpcEndpointAddress != "" {
 		opts = append(opts, worker.WithRPCEndpoint(rpcEndpointAddress))
+		opts = append(opts, worker.WithAgentEndpoint(endpoint.NewRemote(rpcEndpointAddress)))
 	}
 
 	// Configure logging


### PR DESCRIPTION
The fix is primarily for the integration tests.

Previously the command-line argument was propagated:

https://github.com/cirruslabs/cirrus-cli/blob/2946d2a8301056ea5bb3fca6bd1c3e0f74e54af3/internal/worker/task.go#L53

But now it's not due to `endpoint.Endpoint` revamp.