### PR TITLE
Support configurable CPU/Memory for Tart isolation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
-	github.com/cirruslabs/cirrus-ci-agent v1.76.0
+	github.com/cirruslabs/cirrus-ci-agent v1.77.0
 	github.com/cirruslabs/echelon v1.7.0
 	github.com/cirruslabs/go-java-glob v0.1.0
 	github.com/cirruslabs/podmanapi v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYAY6jsqz75eHc4teh2nCY=
 github.com/cirruslabs/cirrus-ci-agent v1.76.0 h1:0cJUbe+WQIITOj4RGEzjH1naQhYE164VikVb49R2JAE=
 github.com/cirruslabs/cirrus-ci-agent v1.76.0/go.mod h1:FGsKASlhaawnIOxgKKJNwd7h4UpNwVjjOuP5+LQbeUE=
+github.com/cirruslabs/cirrus-ci-agent v1.76.2-0.20220408145417-8a075a9cc675 h1:JCh0mPj/Ij8Z2pprfj2F4wLxuyBf5+zCYVYDN8WfbF0=
+github.com/cirruslabs/cirrus-ci-agent v1.76.2-0.20220408145417-8a075a9cc675/go.mod h1:mR7NM7u1X4yrQlAo9elKcYxOM9oaDQOdfDHxRoEaMF4=
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/cirrus-ci-annotations v0.8.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/echelon v1.7.0 h1:CENBpP6UXA2yind+JRR4ZtKOWejlkn51mEfVBaBeor4=

--- a/go.sum
+++ b/go.sum
@@ -245,10 +245,8 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYAY6jsqz75eHc4teh2nCY=
-github.com/cirruslabs/cirrus-ci-agent v1.76.0 h1:0cJUbe+WQIITOj4RGEzjH1naQhYE164VikVb49R2JAE=
-github.com/cirruslabs/cirrus-ci-agent v1.76.0/go.mod h1:FGsKASlhaawnIOxgKKJNwd7h4UpNwVjjOuP5+LQbeUE=
-github.com/cirruslabs/cirrus-ci-agent v1.76.2-0.20220408145417-8a075a9cc675 h1:JCh0mPj/Ij8Z2pprfj2F4wLxuyBf5+zCYVYDN8WfbF0=
-github.com/cirruslabs/cirrus-ci-agent v1.76.2-0.20220408145417-8a075a9cc675/go.mod h1:mR7NM7u1X4yrQlAo9elKcYxOM9oaDQOdfDHxRoEaMF4=
+github.com/cirruslabs/cirrus-ci-agent v1.77.0 h1:CS+4vj55DcP61btuuBdA1FUEH+rh4LpS/z4qK54trTE=
+github.com/cirruslabs/cirrus-ci-agent v1.77.0/go.mod h1:mR7NM7u1X4yrQlAo9elKcYxOM9oaDQOdfDHxRoEaMF4=
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/cirrus-ci-annotations v0.8.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/echelon v1.7.0 h1:CENBpP6UXA2yind+JRR4ZtKOWejlkn51mEfVBaBeor4=

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -20,13 +20,17 @@ type Tart struct {
 	vmName      string
 	sshUser     string
 	sshPassword string
+	cpu         uint32
+	memory      uint32
 }
 
-func New(vmName string, sshUser string, sshPassword string, opts ...Option) (*Tart, error) {
+func New(vmName string, sshUser string, sshPassword string, cpu uint32, memory uint32, opts ...Option) (*Tart, error) {
 	tart := &Tart{
 		vmName:      vmName,
 		sshUser:     sshUser,
 		sshPassword: sshPassword,
+		cpu:         cpu,
+		memory:      memory,
 	}
 
 	// Apply options
@@ -43,7 +47,7 @@ func New(vmName string, sshUser string, sshPassword string, opts ...Option) (*Ta
 }
 
 func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {
-	vm, err := NewVMClonedFrom(ctx, tart.vmName)
+	vm, err := NewVMClonedFrom(ctx, tart.vmName, tart.cpu, tart.memory)
 	if err != nil {
 		return fmt.Errorf("%w: failed to create VM cloned from %q: %v", ErrFailed, tart.vmName, err)
 	}

--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -3,6 +3,7 @@ package tart
 import (
 	"context"
 	"github.com/google/uuid"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -16,7 +17,7 @@ type VM struct {
 	errChan      chan error
 }
 
-func NewVMClonedFrom(ctx context.Context, from string) (*VM, error) {
+func NewVMClonedFrom(ctx context.Context, from string, cpu uint32, memory uint32) (*VM, error) {
 	subCtx, subCtxCancel := context.WithCancel(ctx)
 
 	vm := &VM{
@@ -28,6 +29,17 @@ func NewVMClonedFrom(ctx context.Context, from string) (*VM, error) {
 
 	if _, _, err := Cmd(ctx, "clone", from, vm.ident); err != nil {
 		return nil, err
+	}
+
+	if cpu != 0 {
+		if _, _, err := Cmd(ctx, "set", vm.ident, "--cpu", strconv.FormatUint(uint64(cpu), 10)); err != nil {
+			return nil, err
+		}
+	}
+	if memory != 0 {
+		if _, _, err := Cmd(ctx, "set", vm.ident, "--memory", strconv.FormatUint(uint64(memory), 10)); err != nil {
+			return nil, err
+		}
 	}
 
 	return vm, nil

--- a/internal/executor/instance/persistentworker/persistentworker.go
+++ b/internal/executor/instance/persistentworker/persistentworker.go
@@ -39,7 +39,8 @@ func New(isolation *api.Isolation, logger logger.Lightweight) (abstract.Instance
 	case *api.Isolation_Container_:
 		return container.New(iso.Container.Image, iso.Container.Cpu, iso.Container.Memory, iso.Container.Volumes)
 	case *api.Isolation_Tart_:
-		return tart.New(iso.Tart.Vm, iso.Tart.User, iso.Tart.Password, tart.WithLogger(logger))
+		return tart.New(iso.Tart.Vm, iso.Tart.User, iso.Tart.Password, iso.Tart.Cpu, iso.Tart.Memory,
+			tart.WithLogger(logger))
 	default:
 		return nil, fmt.Errorf("%w: unsupported isolation type %T", ErrInvalidIsolation, iso)
 	}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -201,6 +201,8 @@ func TestWorkerIsolationTart(t *testing.T) {
 				Vm:       vm,
 				User:     user,
 				Password: password,
+				Cpu:      5,
+				Memory:   1024 * 5,
 			},
 		},
 	}

--- a/pkg/parser/testdata/cirrus.json
+++ b/pkg/parser/testdata/cirrus.json
@@ -2517,6 +2517,15 @@
                 "tart": {
                   "description": "Tart VM isolation.",
                   "properties": {
+                    "cpu": {
+                      "description": "Number of VM CPUs.",
+                      "type": "number"
+                    },
+                    "memory": {
+                      "description": "VM memory size in megabytes.",
+                      "pattern": "\\d+(G|Mb)?",
+                      "type": "string"
+                    },
                     "password": {
                       "description": "SSH password",
                       "type": "string"
@@ -2842,6 +2851,15 @@
             "tart": {
               "description": "Tart VM isolation.",
               "properties": {
+                "cpu": {
+                  "description": "Number of VM CPUs.",
+                  "type": "number"
+                },
+                "memory": {
+                  "description": "VM memory size in megabytes.",
+                  "pattern": "\\d+(G|Mb)?",
+                  "type": "string"
+                },
                 "password": {
                   "description": "SSH password",
                   "type": "string"

--- a/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-tart.json
+++ b/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-tart.json
@@ -23,7 +23,9 @@
         "tart": {
           "password": "secret",
           "user": "admin",
-          "vm": "big-sur-base"
+          "vm": "big-sur-base",
+          "cpu": 8,
+          "memory": 16384
         }
       },
       "labels": {

--- a/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-tart.yml
+++ b/pkg/parser/testdata/via-rpc/new-persistentworker-isolation-tart.yml
@@ -4,7 +4,8 @@ persistent_worker:
       vm: big-sur-base
       user: admin
       password: secret
-      platform: darwin
+      cpu: 8
+      memory: 16G
   labels:
     A: B
     C: D


### PR DESCRIPTION
Tart tests will pass once a new `tart` binary will be deployed to a test machine.

Resolves https://github.com/cirruslabs/cirrus-cli/issues/496.