### PR TITLE
Parser: implement merge exemptions to work around YAML merging issue

### DIFF
--- a/pkg/parser/parseable/parseable.go
+++ b/pkg/parser/parseable/parseable.go
@@ -13,6 +13,7 @@ type Parseable interface {
 	Parse(node *nodepkg.Node, parserKit *parserkit.ParserKit) error
 	Schema() *schema.Schema
 	CollectibleFields() []CollectibleField
+	Fields() []Field
 	Proto() interface{}
 }
 
@@ -24,6 +25,14 @@ type Field struct {
 	repeatable bool
 	onFound    nodeFunc
 	schema     *schema.Schema
+}
+
+func (field *Field) Name() nameable.Nameable {
+	return field.name
+}
+
+func (field *Field) Repeatable() bool {
+	return field.repeatable
 }
 
 type CollectibleField struct {
@@ -135,6 +144,10 @@ func (parser *DefaultParser) Schema() *schema.Schema {
 
 func (parser *DefaultParser) CollectibleFields() []CollectibleField {
 	return parser.collectibleFields
+}
+
+func (parser *DefaultParser) Fields() []Field {
+	return parser.fields
 }
 
 func evaluateCollectible(node *nodepkg.Node, field CollectibleField) error {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -45,6 +45,7 @@ var validCases = []string{
 	"singleGKEContainer3",
 	"yaml-merge-sequence",
 	"additional-container-port-and-ports-are-optional",
+	"yaml-merge-collectible",
 }
 
 func absolutize(file string) string {

--- a/pkg/parser/testdata/yaml-merge-collectible.json
+++ b/pkg/parser/testdata/yaml-merge-collectible.json
@@ -1,0 +1,39 @@
+[
+  {
+    "commands": [
+      {
+        "cloneInstruction": {},
+        "name": "clone"
+      },
+      {
+        "name": "main",
+        "scriptInstruction": {
+          "scripts": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "environment": {
+      "CIRRUS_OS": "linux",
+      "FIRST": "first",
+      "SECOND": "second"
+    },
+    "instance": {
+      "@type": "type.googleapis.com/org.cirruslabs.ci.services.cirruscigrpc.ContainerInstance",
+      "cpu": 2,
+      "image": "debian:latest",
+      "memory": 4096
+    },
+    "metadata": {
+      "properties": {
+        "allow_failures": "false",
+        "experimental": "false",
+        "indexWithinBuild": "0",
+        "timeout_in": "3600",
+        "trigger_type": "AUTOMATIC"
+      }
+    },
+    "name": "main"
+  }
+]

--- a/pkg/parser/testdata/yaml-merge-collectible.yml
+++ b/pkg/parser/testdata/yaml-merge-collectible.yml
@@ -1,0 +1,15 @@
+container:
+  image: debian:latest
+
+first: &first
+  env:
+    FIRST: first
+
+second: &second
+  env:
+    SECOND: second
+
+task:
+  <<: *first
+  <<: *second
+  script: true


### PR DESCRIPTION
The issue is as follows, let's say we have the following Cirrus CI configuration:

```YAML
container:
  image: debian:latest

first: &first
  env:
    FIRST: first

second: &second
  env:
    SECOND: second

task:
  <<: *first
  <<: *second
```

Per YAML spec (https://yaml.org/type/merge.html), the result should be:

```yaml
container:
  image: debian:latest

task:
  env:
    FIRST: first
```

However, that's not how Cirrus Cloud parser worked before. It worked like this:

```yaml
container:
  image: debian:latest

task:
  env:
    FIRST: first
    SECOND: second
```

However, if we were to stop following the YAML spec, things like this wouldn't work correctly:

```yaml
container:
  image: debian:latest

.task_template: &task-template
  install_tools_script:
    - apt-get install screen

install_tmux_task:
  install_tools_script:
    - apt-get install tmux
  <<: *task-template
```

This example is a bit a synthetic one, the real task would look like this (inspired by https://github.com/cirruslabs/cirrus-ci-docs/issues/980):

```yaml
install_tmux_task:
  << : *task-template
  install_tools_script:
    - apt-get install tmux
```

It seems that we can try at least do implement a trade-off between following the spec and supporting the old behavior.