### PR TITLE
Initialize container backend lazily

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -183,9 +183,9 @@ func newRunCmd() *cobra.Command {
 			"(helpful in case of registry rate limits; enables --container-lazy-pull and --tart-lazy-pull)")
 
 	// Container-related flags
-	cmd.PersistentFlags().StringVar(&containerBackendType, "container-backend", containerbackend.BackendAutoType,
+	cmd.PersistentFlags().StringVar(&containerBackendType, "container-backend", containerbackend.BackendTypeAuto,
 		fmt.Sprintf("container engine backend to use, either \"%s\", \"%s\" or \"%s\"",
-			containerbackend.BackendDockerType, containerbackend.BackendPodmanType, containerbackend.BackendAutoType))
+			containerbackend.BackendTypeDocker, containerbackend.BackendTypePodman, containerbackend.BackendTypeAuto))
 	cmd.PersistentFlags().BoolVar(&containerLazyPull, "container-lazy-pull", false,
 		"attempt to pull images only if they are missing locally (helpful in case of registry rate limits)")
 

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -36,7 +36,7 @@ var verbose bool
 var lazyPull bool
 
 // Container-related flags.
-var containerBackend string
+var containerBackendType string
 var containerLazyPull bool
 
 // Container-related flags: Dockerfile as CI environment[1] feature.
@@ -53,11 +53,6 @@ var debugNoCleanup bool
 func run(cmd *cobra.Command, args []string) error {
 	// https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
-
-	backend, err := containerbackend.New(containerBackend)
-	if err != nil {
-		return err
-	}
 
 	projectDir := "."
 	baseEnvironment := eenvironment.Merge(
@@ -145,7 +140,7 @@ func run(cmd *cobra.Command, args []string) error {
 	)
 
 	// Container backend
-	executorOpts = append(executorOpts, executor.WithContainerBackend(backend))
+	executorOpts = append(executorOpts, executor.WithContainerBackend(containerBackendType))
 
 	// Run
 	e, err := executor.New(projectDir, result.Tasks, executorOpts...)
@@ -188,9 +183,9 @@ func newRunCmd() *cobra.Command {
 			"(helpful in case of registry rate limits; enables --container-lazy-pull and --tart-lazy-pull)")
 
 	// Container-related flags
-	cmd.PersistentFlags().StringVar(&containerBackend, "container-backend", containerbackend.BackendAuto,
+	cmd.PersistentFlags().StringVar(&containerBackendType, "container-backend", containerbackend.BackendAutoType,
 		fmt.Sprintf("container engine backend to use, either \"%s\", \"%s\" or \"%s\"",
-			containerbackend.BackendDocker, containerbackend.BackendPodman, containerbackend.BackendAuto))
+			containerbackend.BackendDockerType, containerbackend.BackendPodmanType, containerbackend.BackendAutoType))
 	cmd.PersistentFlags().BoolVar(&containerLazyPull, "container-lazy-pull", false,
 		"attempt to pull images only if they are missing locally (helpful in case of registry rate limits)")
 

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -140,7 +140,7 @@ func run(cmd *cobra.Command, args []string) error {
 	)
 
 	// Container backend
-	executorOpts = append(executorOpts, executor.WithContainerBackend(containerBackendType))
+	executorOpts = append(executorOpts, executor.WithContainerBackendType(containerBackendType))
 
 	// Run
 	e, err := executor.New(projectDir, result.Tasks, executorOpts...)

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -224,7 +224,7 @@ func TestRunYAMLAndStarlarkHooks(t *testing.T) {
 
 // TestRunContainerPull ensures that container images are pulled by default.
 func TestRunContainerPull(t *testing.T) {
-	backend, err := containerbackend.New(containerbackend.BackendAuto)
+	backend, err := containerbackend.New(containerbackend.BackendAutoType)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -224,7 +224,7 @@ func TestRunYAMLAndStarlarkHooks(t *testing.T) {
 
 // TestRunContainerPull ensures that container images are pulled by default.
 func TestRunContainerPull(t *testing.T) {
-	backend, err := containerbackend.New(containerbackend.BackendAutoType)
+	backend, err := containerbackend.New(containerbackend.BackendTypeAuto)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/environment"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/container"
-	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/rpc"
@@ -35,7 +34,7 @@ type Executor struct {
 	baseEnvironment          map[string]string
 	userSpecifiedEnvironment map[string]string
 	dirtyMode                bool
-	containerBackend         containerbackend.ContainerBackend
+	containerBackendType     string
 	containerOptions         options.ContainerOptions
 	tartOptions              options.TartOptions
 }
@@ -159,15 +158,15 @@ func (e *Executor) runSingleTask(ctx context.Context, task *build.Task) error {
 
 	// Prepare task's instance
 	instanceRunOpts := runconfig.RunConfig{
-		ContainerBackend: e.containerBackend,
-		ProjectDir:       e.build.ProjectDir,
-		Endpoint:         endpoint.NewLocal(e.rpc.ContainerEndpoint(), e.rpc.DirectEndpoint()),
-		ServerSecret:     e.rpc.ServerSecret(),
-		ClientSecret:     e.rpc.ClientSecret(),
-		TaskID:           task.ID,
-		DirtyMode:        e.dirtyMode,
-		ContainerOptions: e.containerOptions,
-		TartOptions:      e.tartOptions,
+		ContainerBackendType: e.containerBackendType,
+		ProjectDir:           e.build.ProjectDir,
+		Endpoint:             endpoint.NewLocal(e.rpc.ContainerEndpoint(), e.rpc.DirectEndpoint()),
+		ServerSecret:         e.rpc.ServerSecret(),
+		ClientSecret:         e.rpc.ClientSecret(),
+		TaskID:               task.ID,
+		DirtyMode:            e.dirtyMode,
+		ContainerOptions:     e.containerOptions,
+		TartOptions:          e.tartOptions,
 	}
 
 	instanceRunOpts.SetLogger(taskLogger)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -36,7 +36,7 @@ import (
 func TestExecutorEmpty(t *testing.T) {
 	dir := testutil.TempDir(t)
 
-	e, err := executor.New(dir, []*api.Task{}, executor.WithContainerBackend(testutil.ContainerBackendFromEnv(t)))
+	e, err := executor.New(dir, []*api.Task{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestExecutorClone(t *testing.T) {
 			},
 			Instance: testutil.GetBasicContainerInstance(t, "debian:latest"),
 		},
-	}, executor.WithContainerBackend(testutil.ContainerBackendFromEnv(t)))
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestExecutorScript(t *testing.T) {
 			},
 			Instance: testutil.GetBasicContainerInstance(t, "debian:latest"),
 		},
-	}, executor.WithLogger(logger), executor.WithContainerBackend(testutil.ContainerBackendFromEnv(t)))
+	}, executor.WithLogger(logger))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestExecutorFails(t *testing.T) {
 			},
 			Instance: testutil.GetBasicContainerInstance(t, "debian:latest"),
 		},
-	}, executor.WithContainerBackend(testutil.ContainerBackendFromEnv(t)))
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/executor/executor_windows_test.go
+++ b/internal/executor/executor_windows_test.go
@@ -63,7 +63,7 @@ func TestExecutorClone(t *testing.T) {
 			},
 			Instance: instance,
 		},
-	}, executor.WithContainerBackend(testutil.ContainerBackendFromEnv(t)), executor.WithLogger(logger))
+	}, executor.WithLogger(logger))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/executor/instance/container/container.go
+++ b/internal/executor/instance/container/container.go
@@ -34,6 +34,11 @@ type Params struct {
 func (inst *Instance) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {
 	logger := config.Logger()
 
+	containerBackend, err := config.GetContainerBackend()
+	if err != nil {
+		return err
+	}
+
 	agentVolume, workingVolume, err := volume.CreateWorkingVolumeFromConfig(ctx, config, inst.Platform)
 	if err != nil {
 		return err
@@ -46,11 +51,6 @@ func (inst *Instance) Run(ctx context.Context, config *runconfig.RunConfig) (err
 				workingVolume.Name(), workingVolume.Name())
 
 			return
-		}
-
-		containerBackend, creationError := config.GetContainerBackend()
-		if err == nil {
-			err = creationError
 		}
 
 		cleanupErr := agentVolume.Close(containerBackend)

--- a/internal/executor/instance/container/run.go
+++ b/internal/executor/instance/container/run.go
@@ -33,7 +33,10 @@ var (
 // nolint:gocognit
 func RunContainerizedAgent(ctx context.Context, config *runconfig.RunConfig, params *Params) error {
 	logger := config.Logger()
-	backend := config.ContainerBackend
+	backend, err := config.GetContainerBackend()
+	if err != nil {
+		return err
+	}
 
 	// Clamp resources to those available for container backend daemon
 	info, err := backend.SystemInfo(ctx)

--- a/internal/executor/instance/containerbackend/containerbackend.go
+++ b/internal/executor/instance/containerbackend/containerbackend.go
@@ -98,24 +98,24 @@ type Version struct {
 }
 
 const (
-	BackendAutoType   = "auto"
-	BackendDockerType = "docker"
-	BackendPodmanType = "podman"
+	BackendTypeAuto   = "auto"
+	BackendTypeDocker = "docker"
+	BackendTypePodman = "podman"
 )
 
 func New(name string) (ContainerBackend, error) {
-	if name == BackendAutoType {
+	if name == BackendTypeAuto {
 		if nameFromEnv, ok := os.LookupEnv("CIRRUS_CONTAINER_BACKEND"); ok {
 			name = nameFromEnv
 		}
 	}
 
 	switch name {
-	case BackendDockerType:
+	case BackendTypeDocker:
 		return NewDocker()
-	case BackendPodmanType:
+	case BackendTypePodman:
 		return NewPodman()
-	case BackendAutoType:
+	case BackendTypeAuto:
 		if backend, err := NewDocker(); err == nil {
 			return backend, nil
 		}
@@ -126,7 +126,7 @@ func New(name string) (ContainerBackend, error) {
 
 		return nil, fmt.Errorf("%w: failed to instantiate all supported container backends"+
 			" (tried %q and %q, are these actually installed on the system?)",
-			ErrNewFailed, BackendDockerType, BackendPodmanType)
+			ErrNewFailed, BackendTypeDocker, BackendTypePodman)
 	default:
 		return nil, fmt.Errorf("%w: unknown container backend name %q", ErrNewFailed, name)
 	}

--- a/internal/executor/instance/containerbackend/containerbackend.go
+++ b/internal/executor/instance/containerbackend/containerbackend.go
@@ -98,24 +98,24 @@ type Version struct {
 }
 
 const (
-	BackendAuto   = "auto"
-	BackendDocker = "docker"
-	BackendPodman = "podman"
+	BackendAutoType   = "auto"
+	BackendDockerType = "docker"
+	BackendPodmanType = "podman"
 )
 
 func New(name string) (ContainerBackend, error) {
-	if name == BackendAuto {
+	if name == BackendAutoType {
 		if nameFromEnv, ok := os.LookupEnv("CIRRUS_CONTAINER_BACKEND"); ok {
 			name = nameFromEnv
 		}
 	}
 
 	switch name {
-	case BackendDocker:
+	case BackendDockerType:
 		return NewDocker()
-	case BackendPodman:
+	case BackendPodmanType:
 		return NewPodman()
-	case BackendAuto:
+	case BackendAutoType:
 		if backend, err := NewDocker(); err == nil {
 			return backend, nil
 		}
@@ -126,7 +126,7 @@ func New(name string) (ContainerBackend, error) {
 
 		return nil, fmt.Errorf("%w: failed to instantiate all supported container backends"+
 			" (tried %q and %q, are these actually installed on the system?)",
-			ErrNewFailed, BackendDocker, BackendPodman)
+			ErrNewFailed, BackendDockerType, BackendPodmanType)
 	default:
 		return nil, fmt.Errorf("%w: unknown container backend name %q", ErrNewFailed, name)
 	}

--- a/internal/executor/instance/pipe.go
+++ b/internal/executor/instance/pipe.go
@@ -58,6 +58,11 @@ func (pi *PipeInstance) Run(ctx context.Context, config *runconfig.RunConfig) (e
 	platform := platform.NewUnix()
 	logger := config.Logger()
 
+	containerBackend, err := config.GetContainerBackend()
+	if err != nil {
+		return err
+	}
+
 	agentVolume, workingVolume, err := volume.CreateWorkingVolumeFromConfig(ctx, config, platform)
 	if err != nil {
 		return err
@@ -70,11 +75,6 @@ func (pi *PipeInstance) Run(ctx context.Context, config *runconfig.RunConfig) (e
 				workingVolume.Name(), workingVolume.Name())
 
 			return
-		}
-
-		containerBackend, creationError := config.GetContainerBackend()
-		if err == nil {
-			err = creationError
 		}
 
 		cleanupErr := agentVolume.Close(containerBackend)

--- a/internal/executor/instance/prebuilt.go
+++ b/internal/executor/instance/prebuilt.go
@@ -85,10 +85,13 @@ func CreateTempArchive(dir string) (string, error) {
 
 func (prebuilt *PrebuiltInstance) Run(ctx context.Context, config *runconfig.RunConfig) error {
 	logger := config.Logger()
-	backend := config.ContainerBackend
+	backend, err := config.GetContainerBackend()
+	if err != nil {
+		return err
+	}
 
 	// Check if the image we're about to build is available locally
-	if err := backend.ImageInspect(ctx, prebuilt.Image); err == nil {
+	if err = backend.ImageInspect(ctx, prebuilt.Image); err == nil {
 		logger.Infof("Re-using local image %s...", prebuilt.Image)
 		return nil
 	}

--- a/internal/executor/instance/runconfig/runconfig.go
+++ b/internal/executor/instance/runconfig/runconfig.go
@@ -30,7 +30,7 @@ func (rc *RunConfig) GetContainerBackend() (containerbackend.ContainerBackend, e
 	}
 
 	if rc.ContainerBackendType == "" {
-		rc.ContainerBackendType = containerbackend.BackendAutoType
+		rc.ContainerBackendType = containerbackend.BackendTypeAuto
 	}
 
 	backend, err := containerbackend.New(rc.ContainerBackendType)

--- a/internal/executor/instance/runconfig/runconfig.go
+++ b/internal/executor/instance/runconfig/runconfig.go
@@ -38,6 +38,7 @@ func (rc *RunConfig) GetContainerBackend() (containerbackend.ContainerBackend, e
 		return nil, err
 	}
 	rc.containerBackend = backend
+
 	return rc.containerBackend, nil
 }
 

--- a/internal/executor/instance/runconfig/runconfig.go
+++ b/internal/executor/instance/runconfig/runconfig.go
@@ -11,7 +11,7 @@ import (
 )
 
 type RunConfig struct {
-	ContainerBackend           containerbackend.ContainerBackend
+	ContainerBackendType       string
 	ProjectDir                 string
 	Endpoint                   endpoint.Endpoint
 	ServerSecret, ClientSecret string
@@ -21,6 +21,24 @@ type RunConfig struct {
 	ContainerOptions           options.ContainerOptions
 	TartOptions                options.TartOptions
 	agentVersion               string
+	containerBackend           containerbackend.ContainerBackend
+}
+
+func (rc *RunConfig) GetContainerBackend() (containerbackend.ContainerBackend, error) {
+	if rc.containerBackend != nil {
+		return rc.containerBackend, nil
+	}
+
+	if rc.ContainerBackendType == "" {
+		rc.ContainerBackendType = containerbackend.BackendAutoType
+	}
+
+	backend, err := containerbackend.New(rc.ContainerBackendType)
+	if err != nil {
+		return nil, err
+	}
+	rc.containerBackend = backend
+	return rc.containerBackend, nil
 }
 
 func (rc *RunConfig) Logger() *echelon.Logger {

--- a/internal/executor/instance/volume/volume.go
+++ b/internal/executor/instance/volume/volume.go
@@ -35,7 +35,12 @@ func CreateWorkingVolumeFromConfig(
 	agentVolumeName := fmt.Sprintf("cirrus-agent-volume-%s", identifier)
 	workingVolumeName := fmt.Sprintf("cirrus-working-volume-%s", identifier)
 
-	agentVolume, workingVolume, err := CreateWorkingVolume(ctx, config.ContainerBackend, config.ContainerOptions,
+	backend, err := config.GetContainerBackend()
+
+	if err != nil {
+		return nil, nil, err
+	}
+	agentVolume, workingVolume, err := CreateWorkingVolume(ctx, backend, config.ContainerOptions,
 		agentVolumeName, workingVolumeName, config.ProjectDir, config.DirtyMode, config.GetAgentVersion(), platform)
 	if err != nil {
 		initLogger.Warnf("Failed to create a volume from working directory: %v", err)

--- a/internal/executor/instance/volume/volume.go
+++ b/internal/executor/instance/volume/volume.go
@@ -36,10 +36,10 @@ func CreateWorkingVolumeFromConfig(
 	workingVolumeName := fmt.Sprintf("cirrus-working-volume-%s", identifier)
 
 	backend, err := config.GetContainerBackend()
-
 	if err != nil {
 		return nil, nil, err
 	}
+
 	agentVolume, workingVolume, err := CreateWorkingVolume(ctx, backend, config.ContainerOptions,
 		agentVolumeName, workingVolumeName, config.ProjectDir, config.DirtyMode, config.GetAgentVersion(), platform)
 	if err != nil {

--- a/internal/executor/options.go
+++ b/internal/executor/options.go
@@ -44,7 +44,7 @@ func WithContainerOptions(containerOptions options.ContainerOptions) Option {
 	}
 }
 
-func WithContainerBackend(containerBackendType string) Option {
+func WithContainerBackendType(containerBackendType string) Option {
 	return func(e *Executor) {
 		e.containerBackendType = containerBackendType
 	}

--- a/internal/executor/options.go
+++ b/internal/executor/options.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/taskfilter"
 	"github.com/cirruslabs/echelon"
@@ -45,9 +44,9 @@ func WithContainerOptions(containerOptions options.ContainerOptions) Option {
 	}
 }
 
-func WithContainerBackend(containerBackend containerbackend.ContainerBackend) Option {
+func WithContainerBackend(containerBackendType string) Option {
 	return func(e *Executor) {
-		e.containerBackend = containerBackend
+		e.containerBackendType = containerBackendType
 	}
 }
 

--- a/internal/executor/options/container_test.go
+++ b/internal/executor/options/container_test.go
@@ -15,7 +15,7 @@ func TestForcePull(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	backend, err := containerbackend.New(containerbackend.BackendAutoType)
+	backend, err := containerbackend.New(containerbackend.BackendTypeAuto)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestLazyPull(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	backend, err := containerbackend.New(containerbackend.BackendAutoType)
+	backend, err := containerbackend.New(containerbackend.BackendTypeAuto)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/executor/options/container_test.go
+++ b/internal/executor/options/container_test.go
@@ -15,7 +15,7 @@ func TestForcePull(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	backend, err := containerbackend.New(containerbackend.BackendAuto)
+	backend, err := containerbackend.New(containerbackend.BackendAutoType)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestLazyPull(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	backend, err := containerbackend.New(containerbackend.BackendAuto)
+	backend, err := containerbackend.New(containerbackend.BackendAutoType)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutil/containerbackend.go
+++ b/internal/testutil/containerbackend.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ContainerBackendFromEnv(t *testing.T) containerbackend.ContainerBackend {
-	backend, err := containerbackend.New(containerbackend.BackendAutoType)
+	backend, err := containerbackend.New(containerbackend.BackendTypeAuto)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutil/containerbackend.go
+++ b/internal/testutil/containerbackend.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ContainerBackendFromEnv(t *testing.T) containerbackend.ContainerBackend {
-	backend, err := containerbackend.New(containerbackend.BackendAuto)
+	backend, err := containerbackend.New(containerbackend.BackendAutoType)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutil/executor.go
+++ b/internal/testutil/executor.go
@@ -44,8 +44,6 @@ func ExecuteWithOptions(t *testing.T, dir string, opts ...executor.Option) error
 
 	require.NotEmpty(t, result.Tasks)
 
-	opts = append(opts, executor.WithContainerBackend(ContainerBackendFromEnv(t)))
-
 	e, err := executor.New(dir, result.Tasks, opts...)
 	if err != nil {
 		t.Fatal(err)
@@ -68,8 +66,6 @@ func ExecuteWithOptionsNewContext(ctx context.Context, t *testing.T, dir string,
 	}
 
 	require.NotEmpty(t, result.Tasks)
-
-	opts = append(opts, executor.WithContainerBackend(ContainerBackendFromEnv(t)))
 
 	e, err := executor.New(dir, result.Tasks, opts...)
 	if err != nil {


### PR DESCRIPTION
Very similar to #524 but IMO a bit easier to understand: we initialize a container backend only when we need it.

Fixes https://github.com/cirruslabs/tart/issues/119