### PR TITLE
Boolevator: disallow <regular expression> =~ <string> matching

### DIFF
--- a/pkg/parser/boolevator/boolevator_test.go
+++ b/pkg/parser/boolevator/boolevator_test.go
@@ -56,8 +56,8 @@ func TestComplex(t *testing.T) {
 }
 
 func TestRegEx(t *testing.T) {
-	assert.True(t, evalHelper(t, "'release-.*' =~ 'release-2018.1'", nil))
-	assert.False(t, evalHelper(t, "'release-.*' !=~ 'release-2018.1'", nil))
+	assert.True(t, evalHelper(t, "'release-2018.1' =~ 'release-.*'", nil))
+	assert.False(t, evalHelper(t, "'release-2018.1' !=~ 'release-.*'", nil))
 	assert.True(t, evalHelper(t, "'release-.*' !=~ 'foo'", nil))
 	assert.True(t, evalHelper(t, "'1.2.34' =~ '\\d+\\.\\d+\\.\\d+'", nil))
 }
@@ -79,7 +79,7 @@ func TestQuotes(t *testing.T) {
 }
 
 func TestPrRegEx(t *testing.T) {
-	assert.True(t, evalHelper(t, "'pull/.*' =~ 'pull/123'", nil))
+	assert.True(t, evalHelper(t, "'pull/123' =~ 'pull/.*'", nil))
 	assert.True(t, evalHelper(t, "'pull/123' =~ 'pull/.*'", nil))
 	assert.True(t, evalHelper(t, "'branch-foo' =~ 'branch-.*'", nil))
 }

--- a/pkg/parser/boolevator/operator.go
+++ b/pkg/parser/boolevator/operator.go
@@ -83,12 +83,12 @@ func opRegexEquals(a, b interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	// We don't check for the errors here because we don't know
-	// which operand (left or right) is the actual regular expression
-	equalsOneWay, _ := regexp.MatchString(PrepareRegexp(a.(string)), b.(string))
-	equalsOtherWay, _ := regexp.MatchString(PrepareRegexp(b.(string)), a.(string))
+	matches, err := regexp.MatchString(PrepareRegexp(b.(string)), a.(string))
+	if err != nil {
+		return nil, err
+	}
 
-	return strconv.FormatBool(equalsOneWay || equalsOtherWay), nil
+	return strconv.FormatBool(matches), nil
 }
 
 func opRegexNotEquals(a, b interface{}) (interface{}, error) {


### PR DESCRIPTION
Should help with https://github.com/cirruslabs/cirrus-ci-docs/issues/1016#issuecomment-1157946130.

I don't remember why this was done this way, but we'll need to make sure this doesn't break things for users first.