### PR TITLE
Revert "Extra boolevator test case (#529)"

### DIFF
--- a/pkg/parser/boolevator/boolevator_test.go
+++ b/pkg/parser/boolevator/boolevator_test.go
@@ -140,13 +140,3 @@ func TestComplexTag(t *testing.T) {
 
 	assert.True(t, evalHelper(t, "$CIRRUS_TAG =~ 'v\\d+(\\.\\d+){2}(-.*)?'", env))
 }
-
-// https://github.com/cirruslabs/cirrus-ci-docs/issues/1016
-func TestDocsIssue1016(t *testing.T) {
-	env := map[string]string{
-		"TASKS_TO_RUN":     "|windows|linux|",
-		"CIRRUS_TASK_NAME": "windows",
-	}
-
-	assert.True(t, evalHelper(t, "$TASKS_TO_RUN == '' || $TASKS_TO_RUN =~ '.*\\|$CIRRUS_TASK_NAME\\|.*'", env))
-}


### PR DESCRIPTION
We don't support variable expansion in strings for now.