### PR TITLE
Add `-OutputFormat Text` to the `ps:` syntactic sugar

### DIFF
--- a/pkg/parser/node/accessor.go
+++ b/pkg/parser/node/accessor.go
@@ -204,7 +204,7 @@ func (node *Node) GetScript() ([]string, error) {
 
 					encodedValue := base64.StdEncoding.EncodeToString(valueBytes)
 
-					result = append(result, fmt.Sprintf("powershell.exe -NoLogo -EncodedCommand %s", encodedValue))
+					result = append(result, fmt.Sprintf("powershell.exe -OutputFormat Text -NoLogo -EncodedCommand %s", encodedValue))
 				} else {
 					// Minimally support incorrect, but historically accepted syntax, when a list value is unquoted
 					// and is treated as map, but then converted to a scalar by the parser silently, e.g.:


### PR DESCRIPTION
Currently, the output in Cirrus CI is rather unpleasant to read through when things such as `Write-Output` are used as PowerShell sets `OutputFormat` to `XML` *if* the output of the script is redirected:
https://github.com/PowerShell/PowerShell/blob/bcafe74c174091a0f47cf7a5eeb4bca8aefa8718/src/System.Management.Automation/engine/MinishellParameterBinderController.cs#L208

Programs such as chocolatey use that function a lot which makes its output incredibly hard to read through.

Here's a simple reproduction:
```yaml
windows_task:
  windows_container:
    image: cirrusci/windowsservercore:2019
  install_instructions_script:
    - ps: 'Write-Output "string"'
```
Produces output:
```
#< CLIXML
string
<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>
```

Or you could just run `choco install some_program` and the same should happen.

This PR would also need an appropriate update to the documentation.