### PR TITLE
cirrus run: support "privileged: true" for additional containers

### DIFF
--- a/internal/executor/instance/container/run.go
+++ b/internal/executor/instance/container/run.go
@@ -275,7 +275,8 @@ func runAdditionalContainer(
 			NanoCPUs: int64(additionalContainer.Cpu * nano),
 			Memory:   int64(additionalContainer.Memory * mebi),
 		},
-		Network: fmt.Sprintf("container:%s", connectToContainer),
+		Network:    fmt.Sprintf("container:%s", connectToContainer),
+		Privileged: additionalContainer.Privileged,
 	}
 	cont, err := backend.ContainerCreate(ctx, input, "")
 	if err != nil {

--- a/internal/executor/instance/containerbackend/containerbackend.go
+++ b/internal/executor/instance/containerbackend/containerbackend.go
@@ -57,6 +57,7 @@ type ContainerCreateInput struct {
 	Network        string
 	Resources      ContainerResources
 	DisableSELinux bool
+	Privileged     bool
 }
 
 type ContainerMountType int

--- a/internal/executor/instance/containerbackend/docker.go
+++ b/internal/executor/instance/containerbackend/docker.go
@@ -209,6 +209,7 @@ func (backend *Docker) ContainerCreate(
 			Memory:   input.Resources.Memory,
 		},
 		NetworkMode: container.NetworkMode(input.Network),
+		Privileged:  input.Privileged,
 	}
 
 	for _, ourMount := range input.Mounts {

--- a/internal/executor/instance/containerbackend/podman_linux.go
+++ b/internal/executor/instance/containerbackend/podman_linux.go
@@ -353,6 +353,7 @@ func (backend *Podman) ContainerCreate(
 		Command:    input.Command,
 		Env:        input.Env,
 		Image:      input.Image,
+		Privileged: input.Privileged,
 	}
 
 	if strings.HasPrefix(input.Network, "container:") {


### PR DESCRIPTION
So that it would be possible to run [`docker:dind` examples](https://cirrus-ci.org/guide/docker-builds-on-kubernetes/#how-to).