### PR TITLE
Bump default agent version to 1.85.0

### DIFF
--- a/internal/executor/platform/platform.go
+++ b/internal/executor/platform/platform.go
@@ -11,7 +11,7 @@ const (
 	agentImageBase = "gcr.io/cirrus-ci-community/cirrus-ci-agent:v"
 
 	// DefaultAgentVersion represents the default version of the https://github.com/cirruslabs/cirrus-ci-agent to use.
-	DefaultAgentVersion = "1.79.0"
+	DefaultAgentVersion = "1.85.0"
 )
 
 type CopyCommand struct {

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -208,7 +208,7 @@ func (r *RPC) StreamLogs(stream api.CirrusCIService_StreamLogsServer) error {
 			break
 		}
 		if err != nil {
-			streamLogger.Warnf("Error while receivieng logs: %v", err)
+			streamLogger.Warnf("Error while receiving logs: %v", err)
 			return err
 		}
 


### PR DESCRIPTION
The tests will pass once https://github.com/cirruslabs/cirrus-ci-agent/pull/245 is merged and the new agent version is released as `1.85.0`.