### PR TITLE
Update `go` installation method

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ curl -L -o cirrus https://github.com/cirruslabs/cirrus-cli/releases/latest/downl
 If you have [Go](https://golang.org/) 1.17 or newer installed, you can run:
 
 ```
-(cd && GO111MODULE=on go get github.com/cirruslabs/cirrus-cli/...)
+(cd && GO111MODULE=on go install github.com/cirruslabs/cirrus-cli/...@latest)
 ```
 
 This will build and place the `cirrus` binary in `$GOPATH/bin`.


### PR DESCRIPTION
`get` is deprecated:

```
> cd && GO111MODULE=on go get github.com/cirruslabs/cirrus-cli/...
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

`install` requires version (`@latest`, for example).