### PR TITLE
Improve command for Go installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ curl -L -o cirrus https://github.com/cirruslabs/cirrus-cli/releases/latest/downl
 If you have [Go](https://golang.org/) 1.17 or newer installed, you can run:
 
 ```
-cd && GO111MODULE=on go install github.com/cirruslabs/cirrus-cli/...@latest && cd -
+go install github.com/cirruslabs/cirrus-cli/...@latest
 ```
 
 This will build and place the `cirrus` binary in `$GOPATH/bin`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ curl -L -o cirrus https://github.com/cirruslabs/cirrus-cli/releases/latest/downl
 If you have [Go](https://golang.org/) 1.17 or newer installed, you can run:
 
 ```
-(cd && GO111MODULE=on go install github.com/cirruslabs/cirrus-cli/...@latest)
+cd && GO111MODULE=on go install github.com/cirruslabs/cirrus-cli/...@latest && cd -
 ```
 
 This will build and place the `cirrus` binary in `$GOPATH/bin`.


### PR DESCRIPTION
1. I don't know why there are parentheses, they look redundant.
2. Add `cd -` at the end to return to the original directory (after `cd` to home at the begin).