### PR TITLE
Fixed NPE

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -186,7 +186,7 @@ func (worker *Worker) pollSingleUpstream(ctx context.Context, upstream *upstream
 
 	response, err := upstream.Poll(ctx, request)
 	if err != nil {
-		worker.logger.Errorf("failed to poll upstream %s: %v", upstream.Name(), err)
+		return err
 	}
 
 	for _, taskToStop := range response.TasksToStop {


### PR DESCRIPTION
Otherwise response is `nil` on an `err` and it will crash worker in the next lines.