### PR TITLE
When task is stopped delete it right away

### DIFF
--- a/internal/worker/task.go
+++ b/internal/worker/task.go
@@ -115,6 +115,7 @@ func (worker *Worker) runTask(
 func (worker *Worker) stopTask(taskID int64) {
 	if task, ok := worker.tasks[taskID]; ok {
 		task.cancel()
+		delete(worker.tasks, taskID)
 	}
 
 	worker.logger.Infof("sent cancellation signal to task %d", taskID)


### PR DESCRIPTION
There is no need to wait for the next completion handler call to clean this up