### PR TITLE
[worker] Increased deadline timeout for unary calls to upstream

### DIFF
--- a/internal/worker/upstream/upstream.go
+++ b/internal/worker/upstream/upstream.go
@@ -24,7 +24,7 @@ const (
 	DefaultRPCEndpoint = "https://grpc.cirrus-ci.com:443"
 
 	defaultPollIntervalSeconds = 10
-	defaultDeadlineInSeconds   = 1
+	defaultDeadlineInSeconds   = 5
 )
 
 type Upstream struct {


### PR DESCRIPTION
If there are a lot of task candidates for a persistent worker to run is might take a little longer to load and do the logic.