### PR TITLE
Don't fail fast on `tart pull` failure

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -48,7 +48,7 @@ func NewVMClonedFrom(
 		pullLogger.Infof("Pulling virtual machine %s...", from)
 
 		if _, _, err := CmdWithLogger(ctx, pullLogger, "pull", from); err != nil {
-			pullLogger.Infof("Ignoring pull failure: %w", err)
+			pullLogger.Errorf("Ignoring pull failure: %w", err)
 			pullLogger.FinishWithType(echelon.FinishTypeFailed)
 		} else {
 			pullLogger.FinishWithType(echelon.FinishTypeSucceeded)

--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -48,11 +48,11 @@ func NewVMClonedFrom(
 		pullLogger.Infof("Pulling virtual machine %s...", from)
 
 		if _, _, err := CmdWithLogger(ctx, pullLogger, "pull", from); err != nil {
+			pullLogger.Infof("Ignoring pull failure: %w", err)
 			pullLogger.FinishWithType(echelon.FinishTypeFailed)
-			return nil, err
+		} else {
+			pullLogger.FinishWithType(echelon.FinishTypeSucceeded)
 		}
-
-		pullLogger.FinishWithType(echelon.FinishTypeSucceeded)
 	} else {
 		pullLogger.FinishWithType(echelon.FinishTypeSkipped)
 	}


### PR DESCRIPTION
In case of registry being down we'll continue execution with already pulled image. And in case image missing then the next `clone` will fail.

Motivated by https://github.com/cirruslabs/tart/issues/277