### PR TITLE
Use unique task id in temporary VM name

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -60,7 +60,8 @@ func New(vmName string, sshUser string, sshPassword string, cpu uint32, memory u
 }
 
 func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {
-	vm, err := NewVMClonedFrom(ctx, tart.vmName, fmt.Sprintf("cirrus-cli-%d", config.TaskID), tart.cpu, tart.memory, config.TartOptions.LazyPull, config.Logger())
+	tmpVmName := fmt.Sprintf("cirrus-cli-%d", config.TaskID)
+	vm, err := NewVMClonedFrom(ctx, tart.vmName, tmpVmName, tart.cpu, tart.memory, config.TartOptions.LazyPull, config.Logger())
 	if err != nil {
 		return fmt.Errorf("%w: failed to create VM cloned from %q: %v", ErrFailed, tart.vmName, err)
 	}

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -60,7 +60,7 @@ func New(vmName string, sshUser string, sshPassword string, cpu uint32, memory u
 }
 
 func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {
-	vm, err := NewVMClonedFrom(ctx, tart.vmName, tart.cpu, tart.memory, config.TartOptions.LazyPull, config.Logger())
+	vm, err := NewVMClonedFrom(ctx, tart.vmName, fmt.Sprintf("cirrus-cli-%d", config.TaskID), tart.cpu, tart.memory, config.TartOptions.LazyPull, config.Logger())
 	if err != nil {
 		return fmt.Errorf("%w: failed to create VM cloned from %q: %v", ErrFailed, tart.vmName, err)
 	}

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"github.com/cirruslabs/cirrus-cli/internal/logger"
+	"github.com/google/uuid"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	"io"
@@ -60,8 +61,8 @@ func New(vmName string, sshUser string, sshPassword string, cpu uint32, memory u
 }
 
 func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {
-	tmpVmName := fmt.Sprintf("cirrus-cli-%d", config.TaskID)
-	vm, err := NewVMClonedFrom(ctx, tart.vmName, tmpVmName, tart.cpu, tart.memory, config.TartOptions.LazyPull, config.Logger())
+	tmpVMName := fmt.Sprintf("cirrus-cli-%d-", config.TaskID) + uuid.NewString()
+	vm, err := NewVMClonedFrom(ctx, tart.vmName, tmpVMName, tart.cpu, tart.memory, config.TartOptions.LazyPull, config.Logger())
 	if err != nil {
 		return fmt.Errorf("%w: failed to create VM cloned from %q: %v", ErrFailed, tart.vmName, err)
 	}

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -62,7 +62,12 @@ func New(vmName string, sshUser string, sshPassword string, cpu uint32, memory u
 
 func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {
 	tmpVMName := fmt.Sprintf("cirrus-cli-%d-", config.TaskID) + uuid.NewString()
-	vm, err := NewVMClonedFrom(ctx, tart.vmName, tmpVMName, tart.cpu, tart.memory, config.TartOptions.LazyPull, config.Logger())
+	vm, err := NewVMClonedFrom(ctx,
+		tart.vmName, tmpVMName,
+		tart.cpu, tart.memory,
+		config.TartOptions.LazyPull,
+		config.Logger(),
+	)
 	if err != nil {
 		return fmt.Errorf("%w: failed to create VM cloned from %q: %v", ErrFailed, tart.vmName, err)
 	}

--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/cirruslabs/echelon"
-	"github.com/google/uuid"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,6 +27,7 @@ type directoryMount struct {
 func NewVMClonedFrom(
 	ctx context.Context,
 	from string,
+	to string,
 	cpu uint32,
 	memory uint32,
 	lazyPull bool,
@@ -36,8 +36,7 @@ func NewVMClonedFrom(
 	subCtx, subCtxCancel := context.WithCancel(ctx)
 
 	vm := &VM{
-		ident: "cirrus-cli-" + uuid.New().String(),
-
+		ident:        to,
 		subCtx:       subCtx,
 		subCtxCancel: subCtxCancel,
 		errChan:      make(chan error, 1),


### PR DESCRIPTION
So it's easier to debug things like #571