### PR TITLE
Ridiculously large timeout

### DIFF
--- a/internal/worker/upstream/upstream.go
+++ b/internal/worker/upstream/upstream.go
@@ -24,7 +24,10 @@ const (
 	DefaultRPCEndpoint = "https://grpc.cirrus-ci.com:443"
 
 	defaultPollIntervalSeconds = 10
-	defaultDeadlineInSeconds   = 5
+
+	// Ridiculously large per-call timout in case some upstream hangs
+	// which might happen, but we've never experienced so far.
+	defaultDeadlineInSeconds = 900
 )
 
 type Upstream struct {


### PR DESCRIPTION
While investigating https://github.com/cirruslabs/cirrus-ci-docs/issues/1120 it appeared that occasional slowdowns happen for different reasons: network, load balancer, microservice scaling up and cold startup time, etc. Unfortunately, for some reason the call cancelation is not propogated to the backend properly, so it finishes assigning a task to a worker but worker never gets the assigment.

This timeout is our safeguard in case one of the upstream services like Cirrus CI and Cirrus Runners hangs indefinitely. But we've never seen such behaviour, so it make sense to increase this timeout to some very large value inversely proportional to a very low probability of an upstream hang.