### PR TITLE
Gracefully terminate Tart VMs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   - bodyclose
   - deadcode
   - depguard
-  - dogsled
   - dupl
   - errcheck
   - exhaustive

--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -144,6 +144,7 @@ func (vm *VM) Close() error {
 	ctx := context.Background()
 
 	// Try to gracefully terminate the VM
+	//nolint:dogsled // not interested in the output for now
 	_, _, _ = Cmd(ctx, vm.env, "stop", "--timeout", "5", vm.ident)
 
 	vm.subCtxCancel()

--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -141,10 +141,15 @@ func (vm *VM) RetrieveIP(ctx context.Context) (string, error) {
 }
 
 func (vm *VM) Close() error {
+	ctx := context.Background()
+
+	// Try to gracefully terminate the VM
+	_, _, _ = Cmd(ctx, vm.env, "stop", "--timeout", "5", vm.ident)
+
 	vm.subCtxCancel()
 	vm.wg.Wait()
 
-	_, _, err := Cmd(context.Background(), vm.env, "delete", vm.ident)
+	_, _, err := Cmd(ctx, vm.env, "delete", vm.ident)
 
 	return err
 }


### PR DESCRIPTION
This should help with the Softnet "connection reset by peer" errors.