### PR TITLE
Wait for the Tart VM IP on Tart side

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -132,7 +132,8 @@ func (vm *VM) ErrChan() chan error {
 }
 
 func (vm *VM) RetrieveIP(ctx context.Context) (string, error) {
-	stdout, _, err := Cmd(ctx, vm.env, "ip", vm.ident)
+	// wait 30 seconds since usually a VM boots in 15
+	stdout, _, err := Cmd(ctx, vm.env, "ip", "--wait", "30", vm.ident)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Otherwise, Tart reports noisy exceptions fot Sentry