### PR TITLE
Fixed counting of matched affected files

### DIFF
--- a/pkg/parser/bfunc.go
+++ b/pkg/parser/bfunc.go
@@ -71,7 +71,7 @@ func bfuncArgsToStrings(arguments []interface{}) ([]string, error) {
 }
 
 func CountMatchingAffectedFiles(affectedFiles []string, patterns []string) (int, error) {
-	var count int
+	matchedFilesMask := make([]bool, len(affectedFiles))
 
 	for _, pattern := range patterns {
 		re, err := glob.ToRegexPattern(pattern, false)
@@ -79,10 +79,17 @@ func CountMatchingAffectedFiles(affectedFiles []string, patterns []string) (int,
 			return 0, err
 		}
 
-		for _, affectedFile := range affectedFiles {
+		for index, affectedFile := range affectedFiles {
 			if re.MatchString(affectedFile) {
-				count++
+				matchedFilesMask[index] = true
 			}
+		}
+	}
+
+	var count int
+	for _, match := range matchedFilesMask {
+		if match {
+			count++
 		}
 	}
 

--- a/pkg/parser/bfunc_test.go
+++ b/pkg/parser/bfunc_test.go
@@ -47,7 +47,7 @@ func TestBfuncChangesIncludeOnly(t *testing.T) {
   image: debian:latest
 
 positive_match_task:
-  only_if: "changesIncludeOnly('**.go', '**.mod')"
+  only_if: "changesIncludeOnly('**.go', '**/*.go', '**.mod')"
   script: true
 
 negative_match_task:


### PR DESCRIPTION
If a file was matched by two patterns than I was counted multiple times which was leading to incorrect behaviour of `changesIncludeOnly`