### PR TITLE
Fixed `failed to retrieve a Git repository: already up-to-date`

### DIFF
--- a/pkg/larker/fs/git/git.go
+++ b/pkg/larker/fs/git/git.go
@@ -57,7 +57,7 @@ func New(ctx context.Context, url string, revision string) (*Git, error) {
 	// Without this ResolveRevision() would only work for default branch (e.g. master)
 	if err := repo.Fetch(&git.FetchOptions{
 		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
-	}); err != nil {
+	}); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return nil, fmt.Errorf("%w: %v", ErrRetrievalFailed, err)
 	}
 

--- a/pkg/larker/resolver/module_fs_test.go
+++ b/pkg/larker/resolver/module_fs_test.go
@@ -84,7 +84,14 @@ func TestRetrieve(t *testing.T) {
 				Revision: "v0.1.0",
 			},
 		},
-		{"hash",
+		{"default branch (git)",
+			gitLocation{
+				URL:      "https://github.com/cirrus-modules/helpers",
+				Path:     "lib.star",
+				Revision: "main",
+			},
+		},
+		{"hash (git)",
 			gitLocation{
 				URL:      "https://github.com/cirrus-modules/helpers",
 				Path:     "lib.star",


### PR DESCRIPTION
Because go-got returns a "no err" in case there is nothing new to fetch.