### PR TITLE
Bump agent to 1.106.0 and render agent's warnings and errors received from RPC

### DIFF
--- a/internal/executor/platform/platform.go
+++ b/internal/executor/platform/platform.go
@@ -11,7 +11,7 @@ const (
 	agentImageBase = "ghcr.io/cirruslabs/cirrus-ci-agent:v"
 
 	// DefaultAgentVersion represents the default version of the https://github.com/cirruslabs/cirrus-ci-agent to use.
-	DefaultAgentVersion = "1.100.0"
+	DefaultAgentVersion = "1.106.0"
 )
 
 type CopyCommand struct {

--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -273,7 +273,7 @@ func (r *RPC) ReportAgentError(ctx context.Context, req *api.ReportAgentProblemR
 		return nil, err
 	}
 
-	r.logger.Scoped(task.UniqueDescription()).Debugf("agent error: %s", req.Message)
+	r.logger.Scoped(task.UniqueDescription()).Errorf("agent error: %s", req.Message)
 
 	return &empty.Empty{}, nil
 }
@@ -284,7 +284,7 @@ func (r *RPC) ReportAgentWarning(ctx context.Context, req *api.ReportAgentProble
 		return nil, err
 	}
 
-	r.logger.Scoped(task.UniqueDescription()).Debugf("agent warning: %s", req.Message)
+	r.logger.Scoped(task.UniqueDescription()).Warnf("agent warning: %s", req.Message)
 
 	return &empty.Empty{}, nil
 }


### PR DESCRIPTION
Merge after https://github.com/cirruslabs/cirrus-ci-agent/pull/291 gets merged and released as `1.106.0`.

See https://github.com/cirruslabs/cirrus-cli/issues/620#issuecomment-1556779772.