### PR TITLE
Use x509.SetFallbackRoots and switch away from gocertifi

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ docker_builder:
   name: Test (Linux with Docker)
   alias: Tests
   test_script:
-    - wget --no-verbose -O - https://golang.org/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xz
+    - wget --no-verbose -O - https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -C /usr/local -xz
     - export PATH=$PATH:/usr/local/go/bin
     - go test ./...
   env:
@@ -22,7 +22,7 @@ docker_builder:
   run_podman_background_script:
     - podman system service -t 0 unix:///tmp/podman.sock
   test_script:
-    - wget --no-verbose -O - https://golang.org/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xz
+    - wget --no-verbose -O - https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -C /usr/local -xz
     - export PATH=$PATH:/usr/local/go/bin
     - go test ./...
   env:

--- a/cmd/cirrus/main.go
+++ b/cmd/cirrus/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
+	"github.com/breml/rootcerts/embedded"
 	"github.com/cirruslabs/cirrus-cli/internal/commands"
 	"github.com/cirruslabs/cirrus-cli/internal/version"
 	"github.com/getsentry/sentry-go"
@@ -14,6 +16,11 @@ import (
 )
 
 func main() {
+	// Provide fallback root CA certificates
+	mozillaRoots := x509.NewCertPool()
+	mozillaRoots.AppendCertsFromPEM([]byte(embedded.MozillaCACertificatesPEM()))
+	x509.SetFallbackRoots(mozillaRoots)
+
 	// Initialize Sentry
 	var release string
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/PaesslerAG/gval v1.2.2
 	github.com/antihax/optional v1.0.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
+	github.com/breml/rootcerts v0.2.11
+	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/cirruslabs/cirrus-ci-agent v1.108.0
 	github.com/cirruslabs/echelon v1.9.0
 	github.com/cirruslabs/go-java-glob v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cirruslabs/cirrus-cli
 
-go 1.19
+go 1.20
 
 require (
 	github.com/PaesslerAG/gval v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/bitly/go-hostpool v0.1.0/go.mod h1:4gOCgp6+NZnVqlKyZ/iBZFTAJKembaVENU
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/breml/rootcerts v0.2.11 h1:njUAtoyZ6HUXPAPk63tGz0BEZk1/6gyfqK5fTzksHkM=
+github.com/breml/rootcerts v0.2.11/go.mod h1:S/PKh+4d1HUn4HQovEB8hPJZO6pUZYrIhmXBhsegfXw=
 github.com/bugsnag/bugsnag-go v1.0.5-0.20150529004307-13fd6b8acda0 h1:s7+5BfS4WFJoVF9pnB8kBk03S7pZXRdKamnV0FOl5Sc=
 github.com/bugsnag/bugsnag-go v1.0.5-0.20150529004307-13fd6b8acda0/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=

--- a/internal/worker/upstream/upstream.go
+++ b/internal/worker/upstream/upstream.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/certifi/gocertifi"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-ci-agent/pkg/grpchelper"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/endpoint"
@@ -112,10 +111,8 @@ func (upstream *Upstream) Connect(ctx context.Context) error {
 	if upstream.rpcInsecure {
 		rpcSecurity = grpc.WithTransportCredentials(insecure.NewCredentials())
 	} else {
-		certPool, _ := gocertifi.CACerts()
 		tlsCredentials := credentials.NewTLS(&tls.Config{
 			MinVersion: tls.VersionTLS13,
-			RootCAs:    certPool,
 		})
 		rpcSecurity = grpc.WithTransportCredentials(tlsCredentials)
 	}

--- a/pkg/executorservice/executorservice.go
+++ b/pkg/executorservice/executorservice.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/certifi/gocertifi"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	grpcretry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"google.golang.org/grpc"
@@ -35,10 +34,8 @@ func (p *ExecutorService) SupportedInstances() (*api.AdditionalInstancesInfo, er
 	defer cancel()
 
 	// Setup Cirrus CI RPC connection
-	certPool, _ := gocertifi.CACerts()
 	tlsCredentials := credentials.NewTLS(&tls.Config{
 		MinVersion: tls.VersionTLS13,
-		RootCAs:    certPool,
 	})
 	conn, err := grpc.DialContext(
 		ctx,

--- a/pkg/larker/loader/loader.go
+++ b/pkg/larker/loader/loader.go
@@ -2,10 +2,8 @@ package loader
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/certifi/gocertifi"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/builtin"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/fs"
 	"github.com/cirruslabs/cirrus-cli/pkg/larker/resolver"
@@ -18,7 +16,6 @@ import (
 	starlarkjson "go.starlark.net/lib/json"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
-	gohttp "net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,18 +142,6 @@ func (loader *Loader) loadCirrusModule() (starlark.StringDict, error) {
 		Members: builtin.FS(loader.ctx, func(locator string) (fs.FileSystem, string, error) {
 			return loader.ResolveFS(loader.fs, locator)
 		}),
-	}
-
-	certPool, err := gocertifi.CACerts()
-	if err != nil {
-		http.Client = &gohttp.Client{
-			Transport: &gohttp.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs:    certPool,
-					MinVersion: tls.VersionTLS12,
-				},
-			},
-		}
 	}
 
 	httpModule, err := http.LoadModule()


### PR DESCRIPTION
1. Use `x509.SetFallbackRoots` to prefer the OS-provided CA certificate store over some static set of certificates we've got through a package dependency that had chosen some arbitrary CA set to use and needs to be updated periodically both on our side and on the side of the package.

    This change simplifies the code greatly by only requiring a single `x509.SetFallbackRoots()` call in each `main` package, and in our case we only need one such call.

    The only downside of this approach is that if the operating-system's CA certificate store is not empty and some of the certificates are outdated, the connection might fail.
4. Switch away from [`github.com/certifi/gocertifi`](github.com/certifi/gocertifi) because [it hasn't been maintained for more than 2 years](https://github.com/certifi/gocertifi/issues/27).

    Unfortunately, the official [`golang.org/x/crypto/x509roots/fallback` is not ready yet](https://github.com/golang/go/issues/43958#issuecomment-1335517072), but the package of the person who initially created the issue (https://github.com/golang/go/issues/43958) seems to be well maintained and documented.