### PR TITLE
Tart isolation: use proper format string when logging "tart run" output

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/cmd.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/cmd.go
@@ -25,7 +25,7 @@ type loggerAsWriter struct {
 
 func (l loggerAsWriter) Write(p []byte) (n int, err error) {
 	if l.delegate != nil {
-		l.delegate.Logf(l.level, string(p))
+		l.delegate.Logf(l.level, "%s", strings.TrimSpace(string(p)))
 	}
 	return len(p), nil
 }


### PR DESCRIPTION
Resolves https://github.com/cirruslabs/cirrus-cli/issues/631.