### PR TITLE
Log Softnet status and stacktraces of all goroutines on executor error

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -67,6 +67,12 @@ func New(vmName string, sshUser string, sshPassword string, cpu uint32, memory u
 }
 
 func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {
+	if localHub := sentry.GetHubFromContext(ctx); localHub != nil {
+		localHub.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetExtra("Softnet enabled", tart.softnet)
+		})
+	}
+
 	tmpVMName := fmt.Sprintf("%s%d-", vmNamePrefix, config.TaskID) + uuid.NewString()
 	vm, err := NewVMClonedFrom(ctx,
 		tart.vmName, tmpVMName,

--- a/internal/worker/task.go
+++ b/internal/worker/task.go
@@ -10,6 +10,7 @@ import (
 	upstreampkg "github.com/cirruslabs/cirrus-cli/internal/worker/upstream"
 	"github.com/getsentry/sentry-go"
 	"net/url"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -119,6 +120,11 @@ func (worker *Worker) runTask(
 
 			localHub.WithScope(func(scope *sentry.Scope) {
 				scope.SetTags(cirrusSentryTags)
+
+				buf := make([]byte, 1*1024*1024)
+				n := runtime.Stack(buf, true)
+				scope.SetExtra("Stack trace for all goroutines", string(buf[:n]))
+
 				localHub.CaptureException(err)
 			})
 


### PR DESCRIPTION
Unfortunately [`sentry-go` doesn't support attachments](https://github.com/getsentry/sentry-go/issues/574), so let's just log a potentially large dump as extra data and hope for the best effort on Sentry web UI's side.