### PR TITLE
Executor: use proper format string when logging logs

### DIFF
--- a/internal/executor/rpc/rpc.go
+++ b/internal/executor/rpc/rpc.go
@@ -243,7 +243,7 @@ func (r *RPC) StreamLogs(stream api.CirrusCIService_StreamLogsServer) error {
 			logLines := strings.Split(log, "\n")
 
 			for _, logLine := range logLines {
-				streamLogger.Infof(logLine)
+				streamLogger.Infof("%s", logLine)
 			}
 		}
 	}


### PR DESCRIPTION
Similar to https://github.com/cirruslabs/cirrus-cli/pull/632.