### PR TITLE
Plug goroutine leak

### DIFF
--- a/internal/executor/instance/runconfig/runconfig.go
+++ b/internal/executor/instance/runconfig/runconfig.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
+var stubLogger = echelon.NewLogger(echelon.ErrorLevel, &renderers.StubRenderer{})
+
 type RunConfig struct {
 	ContainerBackendType       string
 	ProjectDir                 string
@@ -45,7 +47,7 @@ func (rc *RunConfig) GetContainerBackend() (containerbackend.ContainerBackend, e
 
 func (rc *RunConfig) Logger() *echelon.Logger {
 	if rc.logger == nil {
-		rc.logger = echelon.NewLogger(echelon.ErrorLevel, &renderers.StubRenderer{})
+		return stubLogger
 	}
 
 	return rc.logger


### PR DESCRIPTION
In Persistent Worker, for each task we were initializing a new echelon logger, and it had created a new logging goroutine that wasn't terminated:

```
goroutine 827 [chan receive, 19910 minutes]:
github.com/cirruslabs/echelon.(*Logger).streamEntries(0x140001d4b00, {0x1012aee60, 0x101b489c0})
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:74 +0x40
created by github.com/cirruslabs/echelon.NewLogger in goroutine 826
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:52 +0x110

goroutine 1313 [chan receive, 19688 minutes]:
github.com/cirruslabs/echelon.(*Logger).streamEntries(0x140001d4940, {0x1012aee60, 0x101b489c0})
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:74 +0x40
created by github.com/cirruslabs/echelon.NewLogger in goroutine 1274
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:52 +0x110

goroutine 21076 [chan receive, 6112 minutes]:
github.com/cirruslabs/echelon.(*Logger).streamEntries(0x140001d4780, {0x1012aee60, 0x101b489c0})
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:74 +0x40
created by github.com/cirruslabs/echelon.NewLogger in goroutine 21062
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:52 +0x110

goroutine 3144 [chan receive, 18517 minutes]:
github.com/cirruslabs/echelon.(*Logger).streamEntries(0x140002a8c00, {0x1012aee60, 0x101b489c0})
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:74 +0x40
created by github.com/cirruslabs/echelon.NewLogger in goroutine 3143
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:52 +0x110

goroutine 10950 [chan receive, 14001 minutes]:
github.com/cirruslabs/echelon.(*Logger).streamEntries(0x140005529c0, {0x1012aee60, 0x101b489c0})
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:74 +0x40
created by github.com/cirruslabs/echelon.NewLogger in goroutine 11014
	/go/pkg/mod/github.com/cirruslabs/echelon@v1.9.0/logger.go:52 +0x110
```