### PR TITLE
Worker: do not report the task as failed if it's context was canceled

### DIFF
--- a/internal/worker/task.go
+++ b/internal/worker/task.go
@@ -112,7 +112,7 @@ func (worker *Worker) runTask(
 
 		err := inst.Run(taskCtx, &config)
 
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(taskCtx.Err(), context.Canceled) {
 			worker.logger.Errorf("failed to run task %d: %v", agentAwareTask.TaskId, err)
 
 			boundedCtx, cancel := context.WithTimeout(context.Background(), perCallTimeout)


### PR DESCRIPTION
Unfortunately, `golang.org/x/crypto/ssh` [does not support `context.Context`](https://github.com/golang/go/issues/20288) and when we close `*ssh.Client` in the [monitor's snippet](https://github.com/cirruslabs/cirrus-cli/blob/fec82422350e7f45e59511f2b25609b16c6d1d3a/internal/executor/instance/persistentworker/remoteagent/remoteagent.go#L72-L77) due to context cancellation, we can get pretty much all sorts of random errors, depending on which stage the SSH connection was in, but we won't get the `context.Canceled` which we already try to filter out.

I think the simplest way to work around this is to additionally check if we've actually canceled the context, and if so — ignore the error from the underlying code.