### PR TITLE
Executor: only check for heartbeats if --heartbeat-timeout was given

### DIFF
--- a/internal/commands/run_darwin_test.go
+++ b/internal/commands/run_darwin_test.go
@@ -53,7 +53,7 @@ task:
 
 	// Run the test
 	command := commands.NewRootCmd()
-	command.SetArgs([]string{"run", "--tart-lazy-pull", "-v", "-o simple"})
+	command.SetArgs([]string{"run", "--heartbeat-timeout=2m", "--tart-lazy-pull", "-v", "-o simple"})
 	command.SetOut(writer)
 	command.SetErr(writer)
 	err := command.Execute()

--- a/internal/executor/instance/persistentworker/isolation/tart/cmd.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/cmd.go
@@ -30,6 +30,12 @@ func (l loggerAsWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+func Installed() bool {
+	_, err := exec.LookPath(tartCommandName)
+
+	return err == nil
+}
+
 func Cmd(
 	ctx context.Context,
 	additionalEnvironment map[string]string,

--- a/internal/executor/options.go
+++ b/internal/executor/options.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/taskfilter"
 	"github.com/cirruslabs/echelon"
+	"time"
 )
 
 type Option func(*Executor)
@@ -35,6 +36,12 @@ func WithUserSpecifiedEnvironment(environment map[string]string) Option {
 func WithDirtyMode() Option {
 	return func(e *Executor) {
 		e.dirtyMode = true
+	}
+}
+
+func WithHeartbeatTimeout(heartbeatTimeout time.Duration) Option {
+	return func(e *Executor) {
+		e.heartbeatTimeout = heartbeatTimeout
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -150,8 +150,10 @@ func (worker *Worker) Run(ctx context.Context) error {
 	worker.oldWorkingDirectoryCleanup()
 
 	// https://github.com/cirruslabs/cirrus-cli/issues/571
-	if err := tart.Cleanup(); err != nil {
-		worker.logger.Warnf("failed to cleanup Tart VMs: %v", err)
+	if tart.Installed() {
+		if err := tart.Cleanup(); err != nil {
+			worker.logger.Warnf("failed to cleanup Tart VMs: %v", err)
+		}
 	}
 
 	// A sub-context to cancel out all Run() side-effects when it finishes


### PR DESCRIPTION
Also do not attempt to cleanup Tart VMs if Tart is not installed to prevent unactionable warnings.

Resolves https://github.com/cirruslabs/cirrus-cli/issues/656.