### PR TITLE
Improve installation docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,7 @@ sudo apt-get update && sudo apt-get -y install cirrus-cli
 First, create a `/etc/yum.repos.d/cirruslabs.repo` file with the following contents:
 
 ```
-[fury]
+[cirruslabs]
 name=Cirrus Labs Repo
 baseurl=https://yum.fury.io/cirruslabs/
 enabled=1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,10 +53,10 @@ brew install cirruslabs/cli/cirrus
 
 ## Debian-based distributions
 
-Firstly, make sure that the APT transport for downloading packages via HTTPS is installed:
+Firstly, make sure that the APT transport for downloading packages via HTTPS and common X.509 certificates are installed:
 
 ```shell
-sudo apt-get update && sudo apt-get -y install apt-transport-https
+sudo apt-get update && sudo apt-get -y install apt-transport-https ca-certificates
 ```
 
 Then, add the Cirrus Labs repository:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ the tasks will be executed the same way years from now regardless what versions 
 ## Installation
 
 * [Homebrew](INSTALL.md#homebrew)
+* [Debian-based distributions](INSTALL.md#debian-based-distributions) (Debian, Ubuntu, etc.)
+* [RPM-based distributions](INSTALL.md#rpm-based-distributions) (Fedora, CentOS, etc.)
 * [Prebuilt Binary](INSTALL.md#prebuilt-binary)
 * [Golang](INSTALL.md#golang)
 * CI integrations


### PR DESCRIPTION
Installing Cirrus CLI package in Debian 12 and Fedora 38 seems to be working great, there are some nits to improve related to https://github.com/cirruslabs/cirrus-cli/pull/658, however.