### PR TITLE
Dockerfile: use correct path to "cirrus" binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN goreleaser build --timeout 60m --single-target
 FROM alpine:latest
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/cirrus-cli/
 
-COPY --from=builder /build/dist/cirrus_linux_*/cirrus /usr/local/bin/
+COPY --from=builder /build/dist/linux_*/cirrus_linux_*/cirrus /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/cirrus"]


### PR DESCRIPTION
```
% docker run -it --rm ghcr.io/cirruslabs/cirrus-cli:v0.106.1
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/usr/local/bin/cirrus": stat /usr/local/bin/cirrus: no such file or directory: unknown.
```