### PR TITLE
Evaluator: instantiate a filesystem for running Cirrus Hooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/breml/rootcerts v0.2.11
-	github.com/cirruslabs/cirrus-ci-agent v1.125.0
+	github.com/cirruslabs/cirrus-ci-agent v1.128.1
 	github.com/cirruslabs/echelon v1.9.0
 	github.com/cirruslabs/go-java-glob v0.1.0
 	github.com/cirruslabs/podmanapi v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cirruslabs/cirrus-ci-agent v1.125.0 h1:PLt+XFt7UpTJB1k9CKSQ/R/YJAasWVgfHZ/mb5fBJ3o=
-github.com/cirruslabs/cirrus-ci-agent v1.125.0/go.mod h1:AK4yb4yo3ofyHGCu5L9OQc3JKhC7s2D7iD2dU1eGO9I=
+github.com/cirruslabs/cirrus-ci-agent v1.128.1 h1:K0yce9YKzAj0FoZF6sagChqXRZNTxCqWx6bFbgLEv38=
+github.com/cirruslabs/cirrus-ci-agent v1.128.1/go.mod h1:AK4yb4yo3ofyHGCu5L9OQc3JKhC7s2D7iD2dU1eGO9I=
 github.com/cirruslabs/echelon v1.9.0 h1:UtHAtoc+C7KZoYtbMCOL8JYA1Ndi6/4u0+gWxw9sB8I=
 github.com/cirruslabs/echelon v1.9.0/go.mod h1:Zk4IGe8upeefcwPGE143JCM7iwOkJnZ2ZFCbDWwoadA=
 github.com/cirruslabs/go-java-glob v0.1.0 h1:qC4Fzrq2sXKTLLsBb7ih7BNdCjCR6ZJAAK4nOZ6d/Ak=

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -200,7 +200,15 @@ func (r *ConfigurationEvaluatorServiceServer) EvaluateFunction(
 	ctx context.Context,
 	request *api.EvaluateFunctionRequest,
 ) (*api.EvaluateFunctionResponse, error) {
-	lrk := larker.New(larker.WithEnvironment(request.Environment))
+	fs, err := convertFS(request.Fs)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to initialize file system: %v", err)
+	}
+
+	lrk := larker.New(
+		larker.WithFileSystem(fs),
+		larker.WithEnvironment(request.Environment),
+	)
 
 	// Run Starlark hook
 	result, err := lrk.Hook(ctx, request.StarlarkConfig, request.FunctionName, request.Arguments.AsSlice())

--- a/internal/testutil/api.go
+++ b/internal/testutil/api.go
@@ -13,9 +13,6 @@ func TasksToJSON(t *testing.T, tasks []*api.Task) []byte {
 	for _, task := range tasks {
 		var unmarshalledTask interface{}
 
-		// Shun obsolete fields
-		task.DeprecatedInstance = nil
-
 		marshalled, err := protojson.MarshalOptions{Indent: "  "}.Marshal(task)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Let's use the old-way of instantiating a FS from environment variables for now, will switch to https://github.com/cirruslabs/cirrus-cli/pull/629 later.