### PR TITLE
Vetu instance: separate configuration from cloning

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -85,8 +85,6 @@ func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err err
 	tmpVMName := fmt.Sprintf("%s%d-", vmNamePrefix, config.TaskID) + uuid.NewString()
 	vm, err := NewVMClonedFrom(ctx,
 		tart.vmName, tmpVMName,
-		tart.cpu, tart.memory,
-		tart.diskSize, tart.display,
 		config.TartOptions.LazyPull,
 		config.AdditionalEnvironment,
 		config.Logger(),
@@ -103,6 +101,10 @@ func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err err
 
 		_ = vm.Close()
 	}()
+
+	if err := vm.Configure(ctx, tart.cpu, tart.memory, tart.diskSize, tart.display, config.Logger()); err != nil {
+		return fmt.Errorf("%w: failed to configure VM %q: %v", ErrFailed, vm.Ident(), err)
+	}
 
 	// Start the VM (asynchronously)
 	var preCreatedWorkingDir string

--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -31,10 +31,6 @@ func NewVMClonedFrom(
 	ctx context.Context,
 	from string,
 	to string,
-	cpu uint32,
-	memory uint32,
-	diskSize uint32,
-	display string,
 	lazyPull bool,
 	env map[string]string,
 	logger *echelon.Logger,
@@ -71,47 +67,66 @@ func NewVMClonedFrom(
 		return nil, err
 	}
 
-	if cpu != 0 {
-		cpuStr := strconv.FormatUint(uint64(cpu), 10)
-
-		_, _, err := CmdWithLogger(ctx, vm.env, cloneLogger, "set", vm.ident, "--cpu", cpuStr)
-		if err != nil {
-			cloneLogger.Finish(false)
-			return nil, err
-		}
-	}
-	if memory != 0 {
-		memoryStr := strconv.FormatUint(uint64(memory), 10)
-
-		_, _, err := CmdWithLogger(ctx, vm.env, cloneLogger, "set", vm.ident, "--memory", memoryStr)
-		if err != nil {
-			cloneLogger.Finish(false)
-			return nil, err
-		}
-	}
-	if diskSize != 0 {
-		diskSizeStr := strconv.FormatUint(uint64(diskSize), 10)
-
-		_, _, err := CmdWithLogger(ctx, vm.env, cloneLogger, "set", vm.ident, "--disk-size", diskSizeStr)
-		if err != nil {
-			cloneLogger.Finish(false)
-			return nil, err
-		}
-	}
-	if display != "" {
-		_, _, err := CmdWithLogger(ctx, vm.env, cloneLogger, "set", vm.ident, "--display", display)
-		if err != nil {
-			cloneLogger.Finish(false)
-			return nil, err
-		}
-	}
-
 	cloneLogger.Finish(true)
 	return vm, nil
 }
 
 func (vm *VM) Ident() string {
 	return vm.ident
+}
+
+func (vm *VM) Configure(
+	ctx context.Context,
+	cpu uint32,
+	memory uint32,
+	diskSize uint32,
+	display string,
+	logger *echelon.Logger,
+) error {
+	configureLogger := logger.Scoped("configure virtual machine")
+	configureLogger.Infof("Configuring virtual machine %s...", vm.ident)
+
+	if cpu != 0 {
+		cpuStr := strconv.FormatUint(uint64(cpu), 10)
+
+		_, _, err := CmdWithLogger(ctx, vm.env, configureLogger, "set", vm.ident, "--cpu", cpuStr)
+		if err != nil {
+			configureLogger.Finish(false)
+			return err
+		}
+	}
+
+	if memory != 0 {
+		memoryStr := strconv.FormatUint(uint64(memory), 10)
+
+		_, _, err := CmdWithLogger(ctx, vm.env, configureLogger, "set", vm.ident, "--memory", memoryStr)
+		if err != nil {
+			configureLogger.Finish(false)
+			return err
+		}
+	}
+
+	if diskSize != 0 {
+		diskSizeStr := strconv.FormatUint(uint64(diskSize), 10)
+
+		_, _, err := CmdWithLogger(ctx, vm.env, configureLogger, "set", vm.ident, "--disk-size", diskSizeStr)
+		if err != nil {
+			configureLogger.Finish(false)
+			return err
+		}
+	}
+
+	if display != "" {
+		_, _, err := CmdWithLogger(ctx, vm.env, configureLogger, "set", vm.ident, "--display", display)
+		if err != nil {
+			configureLogger.Finish(false)
+			return err
+		}
+	}
+
+	configureLogger.Finish(true)
+
+	return nil
 }
 
 func (vm *VM) Start(

--- a/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
+++ b/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
@@ -69,8 +69,6 @@ func (vetu *Vetu) Run(ctx context.Context, config *runconfig.RunConfig) error {
 	tmpVMName := fmt.Sprintf("%s%d-", vmNamePrefix, config.TaskID) + uuid.NewString()
 	vm, err := NewVMClonedFrom(ctx,
 		vetu.vmName, tmpVMName,
-		vetu.cpu, vetu.memory,
-		vetu.diskSize,
 		config.VetuOptions.LazyPull,
 		config.AdditionalEnvironment,
 		config.Logger(),
@@ -87,6 +85,10 @@ func (vetu *Vetu) Run(ctx context.Context, config *runconfig.RunConfig) error {
 
 		_ = vm.Close()
 	}()
+
+	if err := vm.Configure(ctx, vetu.cpu, vetu.memory, vetu.diskSize, config.Logger()); err != nil {
+		return fmt.Errorf("%w: failed to configure VM %q: %v", ErrFailed, vm.Ident(), err)
+	}
 
 	// Start the VM (asynchronously)
 	vm.Start(ctx, vetu.bridgedInterface, vetu.hostNetworking)

--- a/internal/executor/instance/persistentworker/isolation/vetu/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/vetu/vm.go
@@ -87,6 +87,7 @@ func (vm *VM) Configure(
 			return err
 		}
 	}
+
 	if memory != 0 {
 		memoryStr := strconv.FormatUint(uint64(memory), 10)
 
@@ -96,6 +97,7 @@ func (vm *VM) Configure(
 			return err
 		}
 	}
+
 	if diskSize != 0 {
 		diskSizeStr := strconv.FormatUint(uint64(diskSize), 10)
 
@@ -107,6 +109,7 @@ func (vm *VM) Configure(
 	}
 
 	configureLogger.Finish(true)
+
 	return nil
 }
 

--- a/internal/executor/instance/persistentworker/isolation/vetu/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/vetu/vm.go
@@ -24,9 +24,6 @@ func NewVMClonedFrom(
 	ctx context.Context,
 	from string,
 	to string,
-	cpu uint32,
-	memory uint32,
-	diskSize uint32,
 	lazyPull bool,
 	env map[string]string,
 	logger *echelon.Logger,
@@ -63,40 +60,54 @@ func NewVMClonedFrom(
 		return nil, err
 	}
 
-	if cpu != 0 {
-		cpuStr := strconv.FormatUint(uint64(cpu), 10)
-
-		_, _, err := CmdWithLogger(ctx, vm.env, cloneLogger, "set", vm.ident, "--cpu", cpuStr)
-		if err != nil {
-			cloneLogger.Finish(false)
-			return nil, err
-		}
-	}
-	if memory != 0 {
-		memoryStr := strconv.FormatUint(uint64(memory), 10)
-
-		_, _, err := CmdWithLogger(ctx, vm.env, cloneLogger, "set", vm.ident, "--memory", memoryStr)
-		if err != nil {
-			cloneLogger.Finish(false)
-			return nil, err
-		}
-	}
-	if diskSize != 0 {
-		diskSizeStr := strconv.FormatUint(uint64(diskSize), 10)
-
-		_, _, err := CmdWithLogger(ctx, vm.env, cloneLogger, "set", vm.ident, "--disk-size", diskSizeStr)
-		if err != nil {
-			cloneLogger.Finish(false)
-			return nil, err
-		}
-	}
-
 	cloneLogger.Finish(true)
 	return vm, nil
 }
 
 func (vm *VM) Ident() string {
 	return vm.ident
+}
+
+func (vm *VM) Configure(
+	ctx context.Context,
+	cpu uint32,
+	memory uint32,
+	diskSize uint32,
+	logger *echelon.Logger,
+) error {
+	configureLogger := logger.Scoped("configure virtual machine")
+	configureLogger.Infof("Configuring virtual machine %s...", vm.ident)
+
+	if cpu != 0 {
+		cpuStr := strconv.FormatUint(uint64(cpu), 10)
+
+		_, _, err := CmdWithLogger(ctx, vm.env, configureLogger, "set", vm.ident, "--cpu", cpuStr)
+		if err != nil {
+			configureLogger.Finish(false)
+			return err
+		}
+	}
+	if memory != 0 {
+		memoryStr := strconv.FormatUint(uint64(memory), 10)
+
+		_, _, err := CmdWithLogger(ctx, vm.env, configureLogger, "set", vm.ident, "--memory", memoryStr)
+		if err != nil {
+			configureLogger.Finish(false)
+			return err
+		}
+	}
+	if diskSize != 0 {
+		diskSizeStr := strconv.FormatUint(uint64(diskSize), 10)
+
+		_, _, err := CmdWithLogger(ctx, vm.env, configureLogger, "set", vm.ident, "--disk-size", diskSizeStr)
+		if err != nil {
+			configureLogger.Finish(false)
+			return err
+		}
+	}
+
+	configureLogger.Finish(true)
+	return nil
 }
 
 func (vm *VM) Start(


### PR DESCRIPTION
This way when the configuration fails, we will still cleanup the cloned VM to prevent disk space growth.