### PR TITLE
Disable gRPC metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.23.0-rc.1
 	go.opentelemetry.io/otel/sdk v1.23.0-rc.1
 	go.opentelemetry.io/otel/sdk/metric v1.23.0-rc.1
+	go.opentelemetry.io/otel/trace v1.23.0-rc.1
 )
 
 replace github.com/opencontainers/image-spec v1.1.0-rc4 => github.com/opencontainers/image-spec v1.1.0-rc2
@@ -158,7 +159,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.22.0 // indirect
-	go.opentelemetry.io/otel/trace v1.23.0-rc.1 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/mod v0.10.0 // indirect

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/parser"
 	"github.com/cirruslabs/cirrus-cli/pkg/parser/parsererror"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/metric/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -56,7 +57,9 @@ func addVersion(
 func Serve(ctx context.Context, lis net.Listener) error {
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(addVersion),
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.StatsHandler(otelgrpc.NewServerHandler(
+			otelgrpc.WithMeterProvider(noop.NewMeterProvider()),
+		)),
 	)
 
 	api.RegisterCirrusConfigurationEvaluatorServiceServer(server, &ConfigurationEvaluatorServiceServer{})

--- a/internal/worker/upstream/upstream.go
+++ b/internal/worker/upstream/upstream.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/endpoint"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/metric/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -121,7 +122,9 @@ func (upstream *Upstream) Connect(ctx context.Context) error {
 	// https://github.com/grpc/grpc-go/blob/master/Documentation/concurrency.md
 	conn, err := grpc.DialContext(ctx, upstream.rpcTarget, rpcSecurity,
 		grpc.WithUnaryInterceptor(deadlineUnaryInterceptor(defaultDeadlineInSeconds*time.Second)),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(
+			otelgrpc.WithMeterProvider(noop.NewMeterProvider()),
+		)),
 	)
 	if err != nil {
 		return fmt.Errorf("%w: failed to dial upstream %s: %v",


### PR DESCRIPTION
They seem to generate an insane amount of metrics (e.g. `rpc_client_responses_per_rpc_bucket`) that we don't need.

Let's only keep the tracing enabled.