### PR TITLE
Abstractions for StandBy functionality of Tart

### DIFF
--- a/internal/commands/worker/config.go
+++ b/internal/commands/worker/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/endpoint"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/isolation/tart"
 	"github.com/cirruslabs/cirrus-cli/internal/worker"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/security"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/upstream"
@@ -34,6 +35,8 @@ type Config struct {
 	Upstreams []ConfigUpstream `yaml:"upstreams"`
 
 	Security *security.Security `yaml:"security"`
+
+	TartParameters *tart.LaunchParameters `yaml:"standby_tart_instance"`
 }
 
 type ConfigLog struct {
@@ -199,6 +202,11 @@ func buildWorker(output io.Writer) (*worker.Worker, error) {
 	// Configure security
 	if security := config.Security; security != nil {
 		opts = append(opts, worker.WithSecurity(security))
+	}
+
+	if tartParams := config.TartParameters; tartParams != nil {
+		standByLauncher := tart.NewStandByLauncher(*tartParams)
+		opts = append(opts, worker.WithSubscriber(standByLauncher))
 	}
 
 	// Instantiate worker

--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
@@ -67,7 +67,8 @@ func (parallels *Parallels) Run(ctx context.Context, config *runconfig.RunConfig
 		return fmt.Errorf("%w: failed to retrieve VM %q IP-address: %v", ErrFailed, vm.name, err)
 	}
 
-	return remoteagent.WaitForAgent(ctx, parallels.logger, ip, parallels.sshUser, parallels.sshPassword, parallels.agentOS, "amd64", config, vm.ClonedFromSuspended(), nil, nil)
+	return remoteagent.WaitForAgent(ctx, parallels.logger, ip, parallels.sshUser, parallels.sshPassword,
+		parallels.agentOS, "amd64", config, vm.ClonedFromSuspended(), nil, nil)
 }
 
 func (parallels *Parallels) WorkingDirectory(projectDir string, dirtyMode bool) string {

--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
@@ -67,9 +67,7 @@ func (parallels *Parallels) Run(ctx context.Context, config *runconfig.RunConfig
 		return fmt.Errorf("%w: failed to retrieve VM %q IP-address: %v", ErrFailed, vm.name, err)
 	}
 
-	return remoteagent.WaitForAgent(ctx, parallels.logger, ip,
-		parallels.sshUser, parallels.sshPassword, parallels.agentOS, "amd64",
-		config, vm.ClonedFromSuspended(), nil, nil, "")
+	return remoteagent.WaitForAgent(ctx, parallels.logger, ip, parallels.sshUser, parallels.sshPassword, parallels.agentOS, "amd64", config, vm.ClonedFromSuspended(), nil, nil)
 }
 
 func (parallels *Parallels) WorkingDirectory(projectDir string, dirtyMode bool) string {

--- a/internal/executor/instance/persistentworker/isolation/tart/launcher.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/launcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/abstract"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
 	"github.com/cirruslabs/echelon"
 	"github.com/getsentry/sentry-go"
@@ -13,15 +14,16 @@ import (
 )
 
 type LaunchParameters struct {
-	Image       string
-	SSHUser     string
-	SSHPassword string
-	CPU         uint32
-	Memory      uint32
-	DiskSize    uint32
-	Softnet     bool
-	Display     string
-	Volumes     []*api.Isolation_Tart_Volume
+	Image       string `yaml:"image"`
+	SSHUser     string `yaml:"ssh_user"`
+	SSHPassword string `yaml:"ssh_password"`
+	CPU         uint32 `yaml:"cpu"`
+	Memory      uint32 `yaml:"memory"`
+	DiskSize    uint32 `yaml:"disk_size"`
+	Softnet     bool   `yaml:"softnet"`
+	Display     string `yaml:"display"`
+	// dont't support volumes for standby instances
+	Volumes []*api.Isolation_Tart_Volume
 }
 
 type Launcher interface {
@@ -145,4 +147,38 @@ func (l *OnDemandLauncher) PrepareVM(
 			return vm.Close()
 		},
 	}, nil
+}
+
+type StandByLauncher struct {
+	parameters LaunchParameters
+	vm         *VM
+}
+
+func NewStandByLauncher(parameters LaunchParameters) *StandByLauncher {
+	return &StandByLauncher{
+		parameters: parameters,
+	}
+
+}
+
+func (l *StandByLauncher) PrepareVM(
+	ctx context.Context,
+	tartParameters LaunchParameters,
+	tartOptions options.TartOptions,
+	additionalEnvironment map[string]string,
+	logger *echelon.Logger,
+) (*LaunchedVM, error) {
+	return nil, nil
+}
+
+func (l *StandByLauncher) Name() string {
+	return "TartStandByLauncher"
+}
+
+func (l *StandByLauncher) BeforePoll(ctx context.Context, request *api.PollRequest) error {
+	return nil
+}
+
+func (l *StandByLauncher) BeforeRunInstance(ctx context.Context, inst abstract.Instance) error {
+	return nil
 }

--- a/internal/executor/instance/persistentworker/isolation/tart/launcher.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/launcher.go
@@ -66,7 +66,8 @@ func (l *OnDemandLauncher) PrepareVM(
 		return nil, fmt.Errorf("%w: failed to create VM cloned from %q: %v", ErrFailed, tartParameters.Image, err)
 	}
 
-	if err := vm.Configure(ctx, tartParameters.CPU, tartParameters.Memory, tartParameters.DiskSize, tartParameters.Display, logger); err != nil {
+	if err := vm.Configure(ctx, tartParameters.CPU, tartParameters.Memory,
+		tartParameters.DiskSize, tartParameters.Display, logger); err != nil {
 		return nil, fmt.Errorf("%w: failed to configure VM %q: %v", ErrFailed, vm.Ident(), err)
 	}
 

--- a/internal/executor/instance/persistentworker/isolation/tart/launcher.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/launcher.go
@@ -1,0 +1,134 @@
+package tart
+
+import (
+	"context"
+	"fmt"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/options"
+	"github.com/cirruslabs/echelon"
+	"github.com/getsentry/sentry-go"
+	"github.com/google/uuid"
+	"os"
+	"time"
+)
+
+type Launcher interface {
+	PrepareVM(
+		ctx context.Context,
+		tart *Tart,
+		tartOptions options.TartOptions,
+		additionalEnvironment map[string]string,
+		logger *echelon.Logger,
+	) (*LaunchedVM, error)
+}
+
+type LaunchedVM struct {
+	IP      string
+	Release func(context.Context) error
+}
+
+type OnDemandLauncher struct {
+}
+
+func (l *OnDemandLauncher) PrepareVM(
+	ctx context.Context,
+	tart *Tart,
+	tartOptions options.TartOptions,
+	additionalEnvironment map[string]string,
+	logger *echelon.Logger,
+) (*LaunchedVM, error) {
+	if localHub := sentry.GetHubFromContext(ctx); localHub != nil {
+		localHub.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetExtra("Softnet enabled", tart.softnet)
+		})
+	}
+
+	tmpVMName := vmNamePrefix + uuid.NewString()
+	vm, err := NewVMClonedFrom(ctx,
+		tart.vmName, tmpVMName,
+		tartOptions.LazyPull,
+		additionalEnvironment,
+		logger,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to create VM cloned from %q: %v", ErrFailed, tart.vmName, err)
+	}
+
+	if err := vm.Configure(ctx, tart.cpu, tart.memory, tart.diskSize, tart.display, logger); err != nil {
+		return nil, fmt.Errorf("%w: failed to configure VM %q: %v", ErrFailed, vm.Ident(), err)
+	}
+
+	// Convert volumes to directory mounts
+	var directoryMounts []directoryMount
+	for _, volume := range tart.volumes {
+		if volume.Name == "" {
+			volume.Name = uuid.NewString()
+		}
+
+		_, err = os.Stat(volume.Source)
+		if err != nil {
+			if os.IsNotExist(err) {
+				if err := os.Mkdir(volume.Source, 0755); err != nil {
+					return nil, fmt.Errorf("%w: volume source %q doesn't exist, failed to pre-create it: %v",
+						ErrFailed, volume.Source, err)
+				}
+
+				volume.Cleanup = true
+			} else {
+				return nil, fmt.Errorf("%w: volume source %q cannot be accessed: %v",
+					ErrFailed, volume.Source, err)
+			}
+		}
+
+		directoryMounts = append(directoryMounts, directoryMount{
+			Name:     volume.Name,
+			Path:     volume.Source,
+			ReadOnly: volume.ReadOnly,
+		})
+	}
+
+	// Start the VM (asynchronously)
+	vm.Start(ctx, tart.softnet, directoryMounts)
+
+	// Wait for the VM to start and get it's DHCP address
+	var ip string
+	bootLogger := logger.Scoped("boot virtual machine")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case err := <-vm.ErrChan():
+			return nil, err
+		default:
+			time.Sleep(time.Second)
+		}
+
+		ip, err = vm.RetrieveIP(ctx)
+		if err != nil {
+			tart.logger.Debugf("failed to retrieve VM %s IP: %v\n", vm.Ident(), err)
+			continue
+		}
+
+		break
+	}
+
+	tart.logger.Debugf("IP %s retrieved from VM %s, running agent...", ip, vm.Ident())
+
+	bootLogger.Errorf("VM was assigned with %s IP", ip)
+	bootLogger.Finish(true)
+
+	addDHCPDLeasesBreadcrumb(ctx)
+
+	return &LaunchedVM{
+		IP: ip,
+		Release: func(ctx context.Context) error {
+			if localHub := sentry.GetHubFromContext(ctx); localHub != nil {
+				localHub.AddBreadcrumb(&sentry.Breadcrumb{
+					Message: fmt.Sprintf("stopping and deleting the VM %s", vm.ident),
+				}, nil)
+			}
+
+			return vm.Close()
+		},
+	}, nil
+}

--- a/internal/executor/instance/persistentworker/isolation/tart/options.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/options.go
@@ -25,12 +25,6 @@ func WithDisplay(display string) Option {
 	}
 }
 
-func WithMountTemporaryWorkingDirectoryFromHost() Option {
-	return func(tart *Tart) {
-		tart.mountTemporaryWorkingDirectoryFromHost = true
-	}
-}
-
 func WithVolumes(volumes []*api.Isolation_Tart_Volume) Option {
 	return func(tart *Tart) {
 		tart.volumes = volumes

--- a/internal/executor/instance/persistentworker/isolation/tart/options.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/options.go
@@ -15,24 +15,24 @@ func WithLogger(logger logger.Lightweight) Option {
 
 func WithSoftnet() Option {
 	return func(tart *Tart) {
-		tart.softnet = true
+		tart.Softnet = true
 	}
 }
 
 func WithDisplay(display string) Option {
 	return func(tart *Tart) {
-		tart.display = display
+		tart.Display = display
 	}
 }
 
 func WithVolumes(volumes []*api.Isolation_Tart_Volume) Option {
 	return func(tart *Tart) {
-		tart.volumes = volumes
+		tart.Volumes = volumes
 	}
 }
 
 func WithDiskSize(diskSize uint32) Option {
 	return func(tart *Tart) {
-		tart.diskSize = diskSize
+		tart.DiskSize = diskSize
 	}
 }

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -40,7 +40,7 @@ type Tart struct {
 }
 
 func New(
-	vmName string,
+	image string,
 	sshUser string,
 	sshPassword string,
 	cpu uint32,
@@ -49,7 +49,7 @@ func New(
 ) (*Tart, error) {
 	tart := &Tart{
 		LaunchParameters: LaunchParameters{
-			Image:       vmName,
+			Image:       image,
 			SSHUser:     sshUser,
 			SSHPassword: sshPassword,
 			CPU:         cpu,

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -87,7 +87,8 @@ func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err err
 	ctx, prepareInstanceSpan := tracer.Start(ctx, "prepare-instance")
 	defer prepareInstanceSpan.End()
 
-	vm, err := tart.launcher.PrepareVM(ctx, tart.LaunchParameters, config.TartOptions, config.AdditionalEnvironment, config.Logger())
+	vm, err := tart.launcher.PrepareVM(ctx, tart.LaunchParameters, config.TartOptions,
+		config.AdditionalEnvironment, config.Logger())
 	if err != nil {
 		prepareInstanceSpan.SetStatus(codes.Error, err.Error())
 		return err

--- a/internal/executor/instance/persistentworker/isolation/vetu/options.go
+++ b/internal/executor/instance/persistentworker/isolation/vetu/options.go
@@ -14,18 +14,18 @@ func WithLogger(logger logger.Lightweight) Option {
 
 func WithBridgedInterface(bridgedInterface string) Option {
 	return func(tart *Vetu) {
-		tart.bridgedInterface = bridgedInterface
+		tart.BridgedInterface = bridgedInterface
 	}
 }
 
 func WithHostNetworking() Option {
 	return func(tart *Vetu) {
-		tart.hostNetworking = true
+		tart.HostNetworking = true
 	}
 }
 
 func WithDiskSize(diskSize uint32) Option {
 	return func(vetu *Vetu) {
-		vetu.diskSize = diskSize
+		vetu.DiskSize = diskSize
 	}
 }

--- a/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
+++ b/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
@@ -130,9 +130,7 @@ func (vetu *Vetu) Run(ctx context.Context, config *runconfig.RunConfig) error {
 
 	prepareInstanceSpan.End()
 
-	err = remoteagent.WaitForAgent(ctx, vetu.logger, ip,
-		vetu.sshUser, vetu.sshPassword, "linux", runtime.GOARCH,
-		config, true, vetu.initializeHooks(config), nil, "")
+	err = remoteagent.WaitForAgent(ctx, vetu.logger, ip, vetu.sshUser, vetu.sshPassword, "linux", runtime.GOARCH, config, true, vetu.initializeHooks(config), nil)
 	if err != nil {
 		return err
 	}

--- a/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
+++ b/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
@@ -130,7 +130,8 @@ func (vetu *Vetu) Run(ctx context.Context, config *runconfig.RunConfig) error {
 
 	prepareInstanceSpan.End()
 
-	err = remoteagent.WaitForAgent(ctx, vetu.logger, ip, vetu.sshUser, vetu.sshPassword, "linux", runtime.GOARCH, config, true, vetu.initializeHooks(config), nil)
+	err = remoteagent.WaitForAgent(ctx, vetu.logger, ip, vetu.sshUser, vetu.sshPassword,
+		"linux", runtime.GOARCH, config, true, vetu.initializeHooks(config), nil)
 	if err != nil {
 		return err
 	}

--- a/internal/executor/instance/persistentworker/persistentworker.go
+++ b/internal/executor/instance/persistentworker/persistentworker.go
@@ -110,10 +110,6 @@ func newTart(iso *api.Isolation_Tart_, security *security.Security, logger logge
 		opts = append(opts, tart.WithDisplay(iso.Tart.Display))
 	}
 
-	if iso.Tart.MountTemporaryWorkingDirectoryFromHost {
-		opts = append(opts, tart.WithMountTemporaryWorkingDirectoryFromHost())
-	}
-
 	if iso.Tart.DiskSize != 0 {
 		opts = append(opts, tart.WithDiskSize(iso.Tart.DiskSize))
 	}

--- a/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
+++ b/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
@@ -41,7 +41,19 @@ func (hooks WaitForAgentHooks) Run(ctx context.Context, cli *ssh.Client) error {
 	return nil
 }
 
-func WaitForAgent(ctx context.Context, logger logger.Lightweight, ip string, sshUser string, sshPassword string, agentOS string, agentArchitecture string, config *runconfig.RunConfig, synchronizeTime bool, initializeHooks WaitForAgentHooks, terminateHooks WaitForAgentHooks) error {
+func WaitForAgent(
+	ctx context.Context,
+	logger logger.Lightweight,
+	ip string,
+	sshUser string,
+	sshPassword string,
+	agentOS string,
+	agentArchitecture string,
+	config *runconfig.RunConfig,
+	synchronizeTime bool,
+	initializeHooks WaitForAgentHooks,
+	terminateHooks WaitForAgentHooks,
+) error {
 	ctx, span := tracer.Start(ctx, "upload-and-wait-for-agent")
 	defer span.End()
 

--- a/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
+++ b/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
@@ -41,20 +41,7 @@ func (hooks WaitForAgentHooks) Run(ctx context.Context, cli *ssh.Client) error {
 	return nil
 }
 
-func WaitForAgent(
-	ctx context.Context,
-	logger logger.Lightweight,
-	ip string,
-	sshUser string,
-	sshPassword string,
-	agentOS string,
-	agentArchitecture string,
-	config *runconfig.RunConfig,
-	synchronizeTime bool,
-	initializeHooks WaitForAgentHooks,
-	terminateHooks WaitForAgentHooks,
-	preCreatedWorkingDir string,
-) error {
+func WaitForAgent(ctx context.Context, logger logger.Lightweight, ip string, sshUser string, sshPassword string, agentOS string, agentArchitecture string, config *runconfig.RunConfig, synchronizeTime bool, initializeHooks WaitForAgentHooks, terminateHooks WaitForAgentHooks) error {
 	ctx, span := tracer.Start(ctx, "upload-and-wait-for-agent")
 	defer span.End()
 
@@ -158,10 +145,6 @@ func WaitForAgent(
 		"\"" + config.ClientSecret + "\"",
 		"-task-id",
 		strconv.FormatInt(config.TaskID, 10),
-	}
-
-	if preCreatedWorkingDir != "" {
-		command = append(command, "-pre-created-working-dir", "\""+preCreatedWorkingDir+"\"")
 	}
 
 	// Start the agent and wait for it to terminate

--- a/internal/worker/lifecycle.go
+++ b/internal/worker/lifecycle.go
@@ -1,0 +1,11 @@
+package worker
+
+import (
+	"context"
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+)
+
+type LifecycleSubscriber interface {
+	Name() string
+	BeforePoll(ctx context.Context, request *api.PollRequest) error
+}

--- a/internal/worker/lifecycle.go
+++ b/internal/worker/lifecycle.go
@@ -3,9 +3,11 @@ package worker
 import (
 	"context"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/abstract"
 )
 
 type LifecycleSubscriber interface {
 	Name() string
 	BeforePoll(ctx context.Context, request *api.PollRequest) error
+	BeforeRunInstance(ctx context.Context, inst abstract.Instance) error
 }

--- a/internal/worker/options.go
+++ b/internal/worker/options.go
@@ -37,3 +37,9 @@ func WithSecurity(security *security.Security) Option {
 		e.security = security
 	}
 }
+
+func WithSubscriber(subscriber LifecycleSubscriber) Option {
+	return func(e *Worker) {
+		e.subscribers = append(e.subscribers, subscriber)
+	}
+}

--- a/internal/worker/task.go
+++ b/internal/worker/task.go
@@ -67,7 +67,7 @@ func (worker *Worker) startTask(
 	switch typedInst := inst.(type) {
 	case *tart.Tart:
 		worker.imagesCounter.Add(ctx, 1, metric.WithAttributes(
-			attribute.String("image", typedInst.Image()),
+			attribute.String("image", typedInst.Image),
 			attribute.String("instance_type", "tart"),
 		))
 	case *vetu.Vetu:

--- a/internal/worker/task.go
+++ b/internal/worker/task.go
@@ -72,7 +72,7 @@ func (worker *Worker) startTask(
 		))
 	case *vetu.Vetu:
 		worker.imagesCounter.Add(ctx, 1, metric.WithAttributes(
-			attribute.String("image", typedInst.Image()),
+			attribute.String("image", typedInst.Image),
 			attribute.String("instance_type", "vetu"),
 		))
 	}

--- a/internal/worker/task.go
+++ b/internal/worker/task.go
@@ -77,6 +77,19 @@ func (worker *Worker) startTask(
 		))
 	}
 
+	for _, subscriber := range worker.subscribers {
+		err := subscriber.BeforeRunInstance(taskCtx, inst)
+		if err != nil {
+			worker.logger.Errorf("failed to call subscriber %s for the task %d: %v", subscriber.Name(), agentAwareTask.TaskId, err)
+			_ = upstream.TaskFailed(taskCtx, &api.TaskFailedRequest{
+				TaskIdentification: taskIdentification,
+				Message:            err.Error(),
+			})
+
+			return
+		}
+	}
+
 	go worker.runTask(taskCtx, agentAwareTask, upstream, inst, taskIdentification)
 
 	worker.logger.Infof("started task %d", agentAwareTask.TaskId)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -236,49 +236,6 @@ func TestWorkerIsolationTart(t *testing.T) {
 	workerTestHelper(t, lis, isolation, nil, worker.WithUpstream(upstream))
 }
 
-func TestWorkerIsolationTartMountTemporaryWorkingDirectoryFromHost(t *testing.T) {
-	// Support Tart isolation testing configured via environment variables
-	image, vmOk := os.LookupEnv("CIRRUS_INTERNAL_TART_VM")
-	user, userOk := os.LookupEnv("CIRRUS_INTERNAL_TART_SSH_USER")
-	password, passwordOk := os.LookupEnv("CIRRUS_INTERNAL_TART_SSH_PASSWORD")
-	if !vmOk || !userOk || !passwordOk {
-		t.Skip("no Tart credentials configured")
-	}
-
-	t.Logf("Using Tart VM %s for testing...", image)
-
-	lis, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	isolation := &api.Isolation{
-		Type: &api.Isolation_Tart_{
-			Tart: &api.Isolation_Tart{
-				Image:                                  image,
-				User:                                   user,
-				Password:                               password,
-				Cpu:                                    5,
-				Memory:                                 1024 * 5,
-				MountTemporaryWorkingDirectoryFromHost: true,
-			},
-		},
-	}
-
-	listenerPort := lis.Addr().(*net.TCPAddr).Port
-	rpcEndpoint := fmt.Sprintf("http://127.0.0.1:%d", listenerPort)
-	upstream, err := upstream.New("test", registrationToken,
-		upstream.WithRPCEndpoint(rpcEndpoint),
-		upstream.WithAgentEndpoint(endpoint.NewLocal(rpcEndpoint, rpcEndpoint)),
-	)
-	require.NoError(t, err)
-
-	workerTestHelper(t, lis, isolation, []string{
-		"pwd",
-		"test \"$(pwd)\" = \"/Volumes/My Shared Files/working-dir\"",
-	}, worker.WithUpstream(upstream))
-}
-
 func TestWorkerSecurity(t *testing.T) {
 	//nolint:gosec // this is a test, so it's fine to bind on 0.0.0.0
 	lis, err := net.Listen("tcp", "0.0.0.0:0")

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -65,6 +65,7 @@ func unaryInterceptor(
 	return handler(ctx, req)
 }
 
+//nolint:unparam // checkScripts will be used in the future
 func workerTestHelper(
 	t *testing.T,
 	lis net.Listener,


### PR DESCRIPTION
#690 seems to be a bit too complex but if we decide to narrow down functionality to only Tart which takes the longest to boot, then we can simplify things. This PR abstracts "Tart VM Preparation" phase into an interface which by default creates VMs on demand. For  *StandBy* we'll be able to introduce another implementation.

Plus I think the surface of this approach is smaller which will simplify testing and lower probability of a regression.