### PR TITLE
OpenTelemetry: do not export metrics each second

### DIFF
--- a/internal/opentelemetry/opentelemetry.go
+++ b/internal/opentelemetry/opentelemetry.go
@@ -11,7 +11,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"os"
-	"time"
 )
 
 func Init(ctx context.Context) (func(), error) {
@@ -57,10 +56,7 @@ func Init(ctx context.Context) (func(), error) {
 	}
 	meterProvider := sdkmetric.NewMeterProvider(
 		sdkmetric.WithResource(resource),
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(
-			metricExporter,
-			sdkmetric.WithInterval(time.Second),
-		)),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)),
 	)
 	finalizers = append(finalizers, func() {
 		_ = meterProvider.Shutdown(ctx)


### PR DESCRIPTION
When not specified, the interval defaults to 60 seconds.

Should help with the [DPM usage](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/metrics-invoice/#billing-calculations).