### PR TITLE
Introduce `LifecycleSubscriber`

### DIFF
--- a/internal/worker/lifecycle.go
+++ b/internal/worker/lifecycle.go
@@ -1,0 +1,11 @@
+package worker
+
+import (
+	"context"
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+)
+
+type LifecycleSubscriber interface {
+	Name() string
+	BeforePoll(ctx context.Context, request *api.PollRequest) error
+}


### PR DESCRIPTION
I think this way a potential `StandByLauncher` for StandBy functionality of Tart can just make sure that before we poll for the new tasks we have one VM running matching a predefined `LaunchParameters`. Anyway we just start one task at a time.

In `StandByLauncher#BeforePoll` we can check `ResourcesInUse` and see if we can start a new VM. In `StandByLauncher#PrepareVM` we either return the existing VM or stop it and recreate from scratch.