### PR TITLE
Disable client side gRPC metrics

### DIFF
--- a/internal/opentelemetry/opentelemetry.go
+++ b/internal/opentelemetry/opentelemetry.go
@@ -11,6 +11,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"os"
+	"runtime"
 )
 
 func Init(ctx context.Context) (func(), error) {
@@ -31,8 +32,11 @@ func Init(ctx context.Context) (func(), error) {
 
 	customResource, err := resource.New(ctx,
 		resource.WithSchemaURL(semconv.SchemaURL),
-		resource.WithHost(),
 		resource.WithOSType(),
+		resource.WithHost(),
+		resource.WithAttributes(
+			semconv.HostArchKey.String(runtime.GOARCH),
+		),
 		resource.WithAttributes(
 			semconv.ServiceName("cirrus-cli"),
 			semconv.ServiceVersion(version.Version),

--- a/internal/worker/upstream/upstream.go
+++ b/internal/worker/upstream/upstream.go
@@ -9,8 +9,6 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/pkg/grpchelper"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/endpoint"
 	"github.com/sirupsen/logrus"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel/metric/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -122,9 +120,6 @@ func (upstream *Upstream) Connect(ctx context.Context) error {
 	// https://github.com/grpc/grpc-go/blob/master/Documentation/concurrency.md
 	conn, err := grpc.DialContext(ctx, upstream.rpcTarget, rpcSecurity,
 		grpc.WithUnaryInterceptor(deadlineUnaryInterceptor(defaultDeadlineInSeconds*time.Second)),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler(
-			otelgrpc.WithMeterProvider(noop.NewMeterProvider()),
-		)),
 	)
 	if err != nil {
 		return fmt.Errorf("%w: failed to dial upstream %s: %v",


### PR DESCRIPTION
Seems there is no need for the client side metrics. Cloud Run gives us a pretty good server side observability.

Plus included architecture in attributes to distinguish vetu hosts.