### PR TITLE
Add Instance Attributed to OTEL spans

### DIFF
--- a/internal/executor/instance/abstract/abstract.go
+++ b/internal/executor/instance/abstract/abstract.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/echelon"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type Instance interface {
 	Run(context.Context, *runconfig.RunConfig) error
 	WorkingDirectory(projectDir string, dirtyMode bool) string
 	Close(ctx context.Context) error
+	Attributes() []attribute.KeyValue
 }
 
 type WarmableInstance interface {

--- a/internal/executor/instance/container/container.go
+++ b/internal/executor/instance/container/container.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/volume"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type Instance struct {
@@ -31,6 +32,13 @@ type Params struct {
 	WorkingVolumeName      string
 	WorkingDirectory       string
 	Volumes                []*api.Volume
+}
+
+func (inst *Instance) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("image", inst.Image),
+		attribute.String("instance_type", "container"),
+	}
 }
 
 func (inst *Instance) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {

--- a/internal/executor/instance/persistentworker/isolation/container/container.go
+++ b/internal/executor/instance/persistentworker/isolation/container/container.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/pwdir"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
+	"go.opentelemetry.io/otel/attribute"
 	"os"
 )
 
@@ -36,6 +37,13 @@ func New(image string, cpu float32, memory uint32, volumes []*api.Volume) (*Cont
 			return os.RemoveAll(tempDir)
 		},
 	}, nil
+}
+
+func (cont *Container) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("image", cont.instance.Image),
+		attribute.String("instance_type", "container"),
+	}
 }
 
 func (cont *Container) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {

--- a/internal/executor/instance/persistentworker/isolation/none/none.go
+++ b/internal/executor/instance/persistentworker/isolation/none/none.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/logger"
 	"github.com/otiai10/copy"
+	"go.opentelemetry.io/otel/attribute"
 	"os"
 	"os/exec"
 	"runtime"
@@ -51,6 +52,12 @@ func New(opts ...Option) (*PersistentWorkerInstance, error) {
 	}
 
 	return pwi, nil
+}
+
+func (pwi *PersistentWorkerInstance) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("instance_type", "none"),
+	}
 }
 
 func (pwi *PersistentWorkerInstance) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {

--- a/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/parallels.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"github.com/cirruslabs/cirrus-cli/internal/logger"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var (
@@ -42,6 +43,13 @@ func New(vmImage, sshUser, sshPassword, agentOS string, opts ...Option) (*Parall
 	}
 
 	return parallels, nil
+}
+
+func (parallels *Parallels) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("image", parallels.vmImage),
+		attribute.String("instance_type", "parallels"),
+	}
 }
 
 func (parallels *Parallels) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/crypto/ssh"
 	"os"
 	"path"
@@ -78,6 +79,13 @@ func New(
 	}
 
 	return tart, nil
+}
+
+func (tart *Tart) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("image", tart.Image()),
+		attribute.String("instance_type", "tart"),
+	}
 }
 
 func (tart *Tart) Warmup(

--- a/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
+++ b/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/crypto/ssh"
 	"runtime"
 	"strings"
@@ -66,6 +67,13 @@ func New(
 	}
 
 	return vetu, nil
+}
+
+func (vetu *Vetu) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("image", vetu.Image()),
+		attribute.String("instance_type", "vetu"),
+	}
 }
 
 func (vetu *Vetu) Run(ctx context.Context, config *runconfig.RunConfig) error {

--- a/internal/executor/instance/pipe.go
+++ b/internal/executor/instance/pipe.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/volume"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var ErrPipeCreationFailed = errors.New("failed to create pipe instance")
@@ -52,6 +53,12 @@ func PipeStagesFromCommands(commands []*api.Command) ([]PipeStage, error) {
 	}
 
 	return stages, nil
+}
+
+func (pi *PipeInstance) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("instance_type", "pipe"),
+	}
 }
 
 func (pi *PipeInstance) Run(ctx context.Context, config *runconfig.RunConfig) (err error) {

--- a/internal/executor/instance/prebuilt.go
+++ b/internal/executor/instance/prebuilt.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
+	"go.opentelemetry.io/otel/attribute"
 	"io"
 	"os"
 	"path/filepath"
@@ -80,6 +81,13 @@ func CreateTempArchive(dir string) (string, error) {
 	}
 
 	return tmpFile.Name(), nil
+}
+
+func (prebuilt *PrebuiltInstance) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("image", prebuilt.Image),
+		attribute.String("instance_type", "prebuilt"),
+	}
 }
 
 func (prebuilt *PrebuiltInstance) Run(ctx context.Context, config *runconfig.RunConfig) error {

--- a/internal/executor/instance/unsupported.go
+++ b/internal/executor/instance/unsupported.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type UnsupportedInstance struct {
@@ -18,5 +19,9 @@ func (si *UnsupportedInstance) WorkingDirectory(projectDir string, dirtyMode boo
 }
 
 func (si *UnsupportedInstance) Close(context.Context) error {
+	return nil
+}
+
+func (si *UnsupportedInstance) Attributes() []attribute.KeyValue {
 	return nil
 }

--- a/internal/worker/task.go
+++ b/internal/worker/task.go
@@ -7,8 +7,6 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/abstract"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker"
-	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/isolation/tart"
-	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/isolation/vetu"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	upstreampkg "github.com/cirruslabs/cirrus-cli/internal/worker/upstream"
 	"github.com/getsentry/sentry-go"
@@ -66,19 +64,7 @@ func (worker *Worker) startTask(
 		return
 	}
 
-	switch typedInst := inst.(type) {
-	case *tart.Tart:
-		worker.imagesCounter.Add(ctx, 1, metric.WithAttributes(
-			attribute.String("image", typedInst.Image()),
-			attribute.String("instance_type", "tart"),
-		))
-	case *vetu.Vetu:
-		worker.imagesCounter.Add(ctx, 1, metric.WithAttributes(
-			attribute.String("image", typedInst.Image()),
-			attribute.String("instance_type", "vetu"),
-		))
-	}
-
+	worker.imagesCounter.Add(ctx, 1, metric.WithAttributes(inst.Attributes()...))
 	go worker.runTask(taskCtx, agentAwareTask, upstream, inst, taskIdentification)
 
 	worker.logger.Infof("started task %d", agentAwareTask.TaskId)
@@ -136,7 +122,7 @@ func (worker *Worker) runTask(
 
 	// Start an OpenTelemetry span with the same attributes
 	// we propagate through Sentry
-	var otelAttributes []attribute.KeyValue
+	var otelAttributes = inst.Attributes()
 
 	for key, value := range cirrusSentryTags {
 		otelAttributes = append(otelAttributes, attribute.String(key, value))


### PR DESCRIPTION
This way we can see improvements to `prepare-instance` and `connect-via-ssh` spans after we roll out "StandBy" support:

<img width="1284" alt="Screenshot 2024-04-03 at 8 50 31 AM" src="https://github.com/cirruslabs/cirrus-cli/assets/989066/1fc597b8-3410-4e61-9439-a3a8bde0be1a">
