### PR TITLE
Tart: mount the working directory to $HOME when --dirty is specified

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/hook.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/hook.go
@@ -1,0 +1,66 @@
+package tart
+
+import (
+	"context"
+	"fmt"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker/remoteagent"
+	"github.com/cirruslabs/echelon"
+	"golang.org/x/crypto/ssh"
+)
+
+func mountWorkingDirectoryHook(tag string, logger *echelon.Logger) remoteagent.WaitForAgentHook {
+	return func(ctx context.Context, sshClient *ssh.Client) error {
+		syncLogger := logger.Scoped("mounting the working directory")
+
+		command := fmt.Sprintf("mkdir %q && mount_virtiofs %q %q",
+			macOSAutomountDirectoryPath, tag, macOSAutomountDirectoryPath)
+
+		syncLogger.Infof("running command: %s", command)
+
+		sshSess, err := sshClient.NewSession()
+		if err != nil {
+			syncLogger.Finish(false)
+			return err
+		}
+
+		if err := sshSess.Run(command); err != nil {
+			_ = sshSess.Close()
+
+			syncLogger.Finish(false)
+			return err
+		}
+
+		_ = sshSess.Close()
+
+		syncLogger.Finish(true)
+		return nil
+	}
+}
+
+func unmountWorkingDirectoryHook(logger *echelon.Logger) remoteagent.WaitForAgentHook {
+	return func(ctx context.Context, sshClient *ssh.Client) error {
+		syncLogger := logger.Scoped("unmounting the working directory")
+
+		command := fmt.Sprintf("umount %q", macOSAutomountDirectoryPath)
+
+		syncLogger.Infof("running command: %s", command)
+
+		sshSess, err := sshClient.NewSession()
+		if err != nil {
+			syncLogger.Finish(false)
+			return err
+		}
+
+		if err := sshSess.Run(command); err != nil {
+			_ = sshSess.Close()
+
+			syncLogger.Finish(false)
+			return err
+		}
+
+		_ = sshSess.Close()
+
+		syncLogger.Finish(true)
+		return nil
+	}
+}

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -33,7 +33,7 @@ var (
 
 const (
 	vmNamePrefix                = "cirrus-cli-"
-	macOSAutomountDirectoryPath = "/Volumes/My Shared Files"
+	macOSAutomountDirectoryPath = "$HOME/working-dir"
 	macOSAutomountDirectoryItem = "working-dir"
 )
 
@@ -50,7 +50,9 @@ type Tart struct {
 	display     string
 	volumes     []*api.Isolation_Tart_Volume
 
-	vm *VM
+	vm              *VM
+	initializeHooks []remoteagent.WaitForAgentHook
+	terminateHooks  []remoteagent.WaitForAgentHook
 }
 
 func New(
@@ -144,11 +146,17 @@ func (tart *Tart) bootVM(
 
 	var directoryMounts []directoryMount
 	if automountDir != "" {
+		tag := fmt.Sprintf("tart.virtiofs.%s", macOSAutomountDirectoryItem)
+
 		directoryMounts = append(directoryMounts, directoryMount{
 			Name:     macOSAutomountDirectoryItem,
 			Path:     automountDir,
+			Tag:      tag,
 			ReadOnly: false,
 		})
+
+		tart.initializeHooks = append(tart.initializeHooks, mountWorkingDirectoryHook(tag, logger))
+		tart.terminateHooks = append(tart.terminateHooks, unmountWorkingDirectoryHook(logger))
 	}
 
 	// Convert volumes to directory mounts
@@ -250,8 +258,8 @@ func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err err
 		return err
 	}
 
-	initializeHooks := tart.initializeHooks(config)
-	terminateHooks := tart.terminateHooks(config)
+	initializeHooks := tart.getInitializeHooks(config)
+	terminateHooks := tart.getTerminateHooks(config)
 
 	addTartListBreadcrumb(ctx)
 	addDHCPDLeasesBreadcrumb(ctx)
@@ -334,7 +342,7 @@ func Cleanup() error {
 	return nil
 }
 
-func (tart *Tart) initializeHooks(config *runconfig.RunConfig) []remoteagent.WaitForAgentHook {
+func (tart *Tart) getInitializeHooks(config *runconfig.RunConfig) []remoteagent.WaitForAgentHook {
 	var hooks []remoteagent.WaitForAgentHook
 
 	if config.ProjectDir != "" && !config.DirtyMode {
@@ -366,12 +374,14 @@ func (tart *Tart) initializeHooks(config *runconfig.RunConfig) []remoteagent.Wai
 
 				sshSess, err := sshClient.NewSession()
 				if err != nil {
+					syncLogger.Finish(false)
 					return err
 				}
 
 				if err := sshSess.Run(command); err != nil {
 					_ = sshSess.Close()
 
+					syncLogger.Finish(false)
 					return err
 				}
 
@@ -383,10 +393,10 @@ func (tart *Tart) initializeHooks(config *runconfig.RunConfig) []remoteagent.Wai
 		})
 	}
 
-	return hooks
+	return append(tart.initializeHooks, hooks...)
 }
 
-func (tart *Tart) terminateHooks(config *runconfig.RunConfig) []remoteagent.WaitForAgentHook {
+func (tart *Tart) getTerminateHooks(config *runconfig.RunConfig) []remoteagent.WaitForAgentHook {
 	var hooks []remoteagent.WaitForAgentHook
 
 	targetfulVolumes := lo.Filter(tart.volumes, func(volume *api.Isolation_Tart_Volume, index int) bool {
@@ -421,7 +431,7 @@ func (tart *Tart) terminateHooks(config *runconfig.RunConfig) []remoteagent.Wait
 		})
 	}
 
-	return hooks
+	return append(tart.terminateHooks, hooks...)
 }
 
 func addTartListBreadcrumb(ctx context.Context) {

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -101,7 +101,7 @@ func (tart *Tart) Warmup(
 	additionalEnvironment map[string]string,
 	logger *echelon.Logger,
 ) error {
-	return tart.bootVM(ctx, ident, additionalEnvironment, "", logger)
+	return tart.bootVM(ctx, ident, additionalEnvironment, "", false, logger)
 }
 
 func (tart *Tart) bootVM(
@@ -109,6 +109,7 @@ func (tart *Tart) bootVM(
 	ident string,
 	additionalEnvironment map[string]string,
 	automountDir string,
+	lazyPull bool,
 	logger *echelon.Logger,
 ) error {
 	ctx, prepareInstanceSpan := tracer.Start(ctx, "prepare-instance")
@@ -128,7 +129,7 @@ func (tart *Tart) bootVM(
 	tmpVMName := vmNamePrefix + identToBeInjected + uuid.NewString()
 	vm, err := NewVMClonedFrom(ctx,
 		tart.vmName, tmpVMName,
-		false, // always clone from the base image
+		lazyPull,
 		additionalEnvironment,
 		logger,
 	)
@@ -237,7 +238,7 @@ func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err err
 			automountProjectDir = config.ProjectDir
 		}
 		err = tart.bootVM(ctx, strconv.FormatInt(config.TaskID, 10), config.AdditionalEnvironment,
-			automountProjectDir, config.Logger())
+			automountProjectDir, config.TartOptions.LazyPull, config.Logger())
 		if err != nil {
 			return err
 		}

--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -24,6 +24,7 @@ type VM struct {
 type directoryMount struct {
 	Name     string
 	Path     string
+	Tag      string
 	ReadOnly bool
 }
 
@@ -146,10 +147,20 @@ func (vm *VM) Start(
 		}
 
 		for _, directoryMount := range directoryMounts {
-			dirArgumentValue := fmt.Sprintf("%s:%s", directoryMount.Name, directoryMount.Path)
+			var opts []string
+
+			if tag := directoryMount.Tag; tag != "" {
+				opts = append(opts, fmt.Sprintf("tag=%s", tag))
+			}
 
 			if directoryMount.ReadOnly {
-				dirArgumentValue += ":ro"
+				opts = append(opts, "ro")
+			}
+
+			dirArgumentValue := fmt.Sprintf("%s:%s", directoryMount.Name, directoryMount.Path)
+
+			if len(opts) != 0 {
+				dirArgumentValue += ":" + strings.Join(opts, ",")
 			}
 
 			args = append(args, "--dir", dirArgumentValue)


### PR DESCRIPTION
To avoid issues with spaces in "/Volumes/My Shared Files".

Also makes `cirrus run` respect `--{,tart-}lazy-pull` for non-standby Tart instances.

Resolves https://github.com/cirruslabs/cirrus-cli/issues/720.