### PR TITLE
Properly separate the os.Args for the agent

### DIFF
--- a/cmd/cirrus/main.go
+++ b/cmd/cirrus/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	// Run the Cirrus CI Agent if requested
 	if len(os.Args) >= 2 && os.Args[1] == "agent" {
-		agent.Run()
+		agent.Run(os.Args[2:])
 
 		return
 	}

--- a/internal/agent/main.go
+++ b/internal/agent/main.go
@@ -33,7 +33,7 @@ import (
 	"time"
 )
 
-func Run() {
+func Run(args []string) {
 	apiEndpointPtr := flag.String("api-endpoint", "https://grpc.cirrus-ci.com:443", "GRPC endpoint URL")
 	taskIdPtr := flag.String("task-id", "0", "Task ID")
 	clientTokenPtr := flag.String("client-token", "", "Secret token")
@@ -45,7 +45,7 @@ func Run() {
 	commandToPtr := flag.String("command-to", "", "Command to stop execution at (exclusive)")
 	preCreatedWorkingDir := flag.String("pre-created-working-dir", "",
 		"working directory to use when spawned via Persistent Worker")
-	flag.Parse()
+	_ = flag.CommandLine.Parse(args)
 
 	// Parse task ID as an integer for backwards-compatibility with the TaskIdentification message
 	oldStyleTaskID, err := strconv.ParseInt(*taskIdPtr, 10, 64)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -488,6 +489,11 @@ func TestWorkerSecurityVolumes(t *testing.T) {
 }
 
 func TestTaskCancellation(t *testing.T) {
+	// Windows has no "sleep" command
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
 	//nolint:gosec // this is a test, so it's fine to bind on 0.0.0.0
 	lis, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {


### PR DESCRIPTION
Without this the agent seems to ignore any flags.