### PR TITLE
Tart executor: always pass --no-clipboard to "tart run"

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -145,7 +145,7 @@ func (vm *VM) Start(
 	go func() {
 		defer vm.wg.Done()
 
-		args := []string{"--no-graphics"}
+		args := []string{"--no-graphics", "--no-clipboard"}
 
 		if softnet {
 			args = append(args, "--net-softnet")


### PR DESCRIPTION
For security reasons.