### PR TITLE
[gha cache] propagate an original status code on failure

### DIFF
--- a/internal/agent/http_cache/ghacache/ghacache.go
+++ b/internal/agent/http_cache/ghacache/ghacache.go
@@ -220,7 +220,7 @@ func (cache *GHACache) commitUploadable(writer http.ResponseWriter, request *htt
 	}
 
 	if !(resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated) {
-		fail(writer, request, http.StatusInternalServerError, "GHA cache failed to "+
+		fail(writer, request, resp.StatusCode, "GHA cache failed to "+
 			"upload the uploadable with ID %d: got HTTP %d", id, resp.StatusCode)
 
 		return


### PR DESCRIPTION
Instead of just 500