### PR TITLE
.goreleaser.yml: remove binary signatures before notarizing

### DIFF
--- a/.ci/remove-signature.sh
+++ b/.ci/remove-signature.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Set shell options to enable fail-fast behavior
+#
+# * -e: fail the script when an error occurs or command fails
+# * -u: fail the script when attempting to reference unset parameters
+# * -o pipefail: by default an exit status of a pipeline is that of its
+#                last command, this fails the pipe early if an error in
+#                any of its commands occurs
+#
+set -euo pipefail
+
+codesign --remove-signature "$@" || true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
       - ppc64le
     hooks:
       post:
-        - codesign --remove-signature {{ .Path }}
+        - bash .ci/remove-signature.sh {{ .Path }}
 
 archives:
   - id: binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,9 @@ builds:
       - arm64
       - s390x
       - ppc64le
+    hooks:
+      post:
+        - codesign --remove-signature {{ .Path }}
 
 archives:
   - id: binary


### PR DESCRIPTION
To prevent the `unable to remove existing code signature: code signing command is not the last loader command, so cannot remove it (easily) without corrupting the binary` error [from Quill](https://github.com/anchore/quill/commit/5b8e07f50a58c3493c277936f1b0754b749cf468).