### PR TITLE
Plug container backend's Close() into instance's Close()

### DIFF
--- a/internal/executor/instance/container/container.go
+++ b/internal/executor/instance/container/container.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/volume"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
@@ -18,6 +19,8 @@ type Instance struct {
 	Platform             platform.Platform
 	CustomWorkingDir     string
 	Volumes              []*api.Volume
+
+	containerBackend containerbackend.ContainerBackend
 }
 
 type Params struct {
@@ -48,6 +51,7 @@ func (inst *Instance) Run(ctx context.Context, config *runconfig.RunConfig) (err
 	if err != nil {
 		return err
 	}
+	inst.containerBackend = containerBackend
 
 	agentVolume, workingVolume, err := volume.CreateWorkingVolumeFromConfig(ctx, config, inst.Platform,
 		inst.Architecture)
@@ -100,5 +104,9 @@ func (inst *Instance) WorkingDirectory(projectDir string, dirtyMode bool) string
 }
 
 func (inst *Instance) Close(context.Context) error {
+	if inst.containerBackend != nil {
+		return inst.containerBackend.Close()
+	}
+
 	return nil
 }

--- a/internal/executor/instance/containerbackend/podman_linux.go
+++ b/internal/executor/instance/containerbackend/podman_linux.go
@@ -111,7 +111,7 @@ func (backend *Podman) Close() error {
 			return err
 		default:
 			if !interruptSent {
-				if err := backend.cmd.Process.Signal(os.Interrupt); err != nil {
+				if err := backend.cmd.Process.Signal(syscall.SIGTERM); err != nil {
 					return err
 				}
 				interruptSent = true

--- a/internal/executor/instance/pipe.go
+++ b/internal/executor/instance/pipe.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/container"
+	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/containerbackend"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/runconfig"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/volume"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
@@ -24,6 +25,8 @@ type PipeInstance struct {
 	CPU              float32
 	Memory           uint32
 	CustomWorkingDir string
+
+	containerBackend containerbackend.ContainerBackend
 }
 
 // PipeStagesFromCommands uses image hints in commands to build the stages.
@@ -69,6 +72,7 @@ func (pi *PipeInstance) Run(ctx context.Context, config *runconfig.RunConfig) (e
 	if err != nil {
 		return err
 	}
+	pi.containerBackend = containerBackend
 
 	agentVolume, workingVolume, err := volume.CreateWorkingVolumeFromConfig(ctx, config, platform, nil)
 	if err != nil {
@@ -125,5 +129,9 @@ func (pi *PipeInstance) WorkingDirectory(projectDir string, dirtyMode bool) stri
 }
 
 func (pi *PipeInstance) Close(context.Context) error {
+	if pi.containerBackend != nil {
+		return pi.containerBackend.Close()
+	}
+
 	return nil
 }

--- a/internal/executor/instance/prebuilt.go
+++ b/internal/executor/instance/prebuilt.go
@@ -16,6 +16,8 @@ type PrebuiltInstance struct {
 	Image      string
 	Dockerfile string
 	Arguments  map[string]string
+
+	containerBackend containerbackend.ContainerBackend
 }
 
 func CreateTempArchive(dir string) (string, error) {
@@ -96,6 +98,7 @@ func (prebuilt *PrebuiltInstance) Run(ctx context.Context, config *runconfig.Run
 	if err != nil {
 		return err
 	}
+	prebuilt.containerBackend = backend
 
 	// Check if the image we're about to build is available locally
 	if err = backend.ImageInspect(ctx, prebuilt.Image); err == nil {
@@ -165,5 +168,9 @@ func (prebuilt *PrebuiltInstance) WorkingDirectory(projectDir string, dirtyMode 
 }
 
 func (prebuilt *PrebuiltInstance) Close(context.Context) error {
+	if prebuilt.containerBackend != nil {
+		return prebuilt.containerBackend.Close()
+	}
+
 	return nil
 }


### PR DESCRIPTION
We were only calling instance's `Close()`, but not container backend's `Close()`.

Also, Podman expects a `SIGTERM`, not `SIGINT`, otherwise exit code won't be `0` and we'll error out.

Resolves https://github.com/cirruslabs/cirrus-cli/issues/766.