### PR TITLE
GHA cache: handle io.EOF when uploading a part

### DIFF
--- a/internal/agent/http_cache/ghacache/ghacache.go
+++ b/internal/agent/http_cache/ghacache/ghacache.go
@@ -226,12 +226,13 @@ func (cache *GHACache) updateUploadable(writer http.ResponseWriter, request *htt
 
 		return
 	}
-	// Cause the cache-related code in the Actions Toolkit to make a re-try[1].
-	//
-	// [1]: https://github.com/actions/toolkit/blob/6dd369c0e648ed58d0ead326cf2426906ea86401/packages/cache/src/internal/requestUtils.ts#L24-L34
+
 	if uploadPartResponse.StatusCode != http.StatusOK {
 		status := http.StatusInternalServerError
 
+		// Cause the cache-related code in the Actions Toolkit to make a re-try[1].
+		//
+		// [1]: https://github.com/actions/toolkit/blob/6dd369c0e648ed58d0ead326cf2426906ea86401/packages/cache/src/internal/requestUtils.ts#L24-L34
 		if uploadPartResponse.StatusCode == http.StatusBadGateway ||
 			uploadPartResponse.StatusCode == http.StatusServiceUnavailable ||
 			uploadPartResponse.StatusCode == http.StatusGatewayTimeout {

--- a/internal/agent/http_cache/ghacache/ghacache.go
+++ b/internal/agent/http_cache/ghacache/ghacache.go
@@ -228,18 +228,11 @@ func (cache *GHACache) updateUploadable(writer http.ResponseWriter, request *htt
 	}
 
 	if uploadPartResponse.StatusCode != http.StatusOK {
-		status := http.StatusInternalServerError
-
-		// Cause the cache-related code in the Actions Toolkit to make a re-try[1].
+		// We pass through the status code here so that the cache-related
+		// code in the Actions Toolkit will hopefully make a re-try[1].
 		//
 		// [1]: https://github.com/actions/toolkit/blob/6dd369c0e648ed58d0ead326cf2426906ea86401/packages/cache/src/internal/requestUtils.ts#L24-L34
-		if uploadPartResponse.StatusCode == http.StatusBadGateway ||
-			uploadPartResponse.StatusCode == http.StatusServiceUnavailable ||
-			uploadPartResponse.StatusCode == http.StatusGatewayTimeout {
-			status = uploadPartResponse.StatusCode
-		}
-
-		fail(writer, request, status, "GHA cache failed to upload part "+
+		fail(writer, request, uploadPartResponse.StatusCode, "GHA cache failed to upload part "+
 			"for key %q, version %q and part %d: got HTTP %d", uploadable.Key(), uploadable.Version(), partNumber,
 			uploadPartResponse.StatusCode)
 


### PR DESCRIPTION
And pass-through other errors that Actions Toolkit deems as retryable.