### PR TITLE
GHA cache: retry temporary failures on part uploads and commits

### DIFF
--- a/internal/agent/http_cache/ghacache/uploadable/uploadable_test.go
+++ b/internal/agent/http_cache/ghacache/uploadable/uploadable_test.go
@@ -10,12 +10,11 @@ import (
 func TestPartsAreOrdered(t *testing.T) {
 	uploadable := uploadable.New("key", "version", "upload-id")
 
-	require.NoError(t, uploadable.AppendPart(2, "etag-2", 42))
-	require.NoError(t, uploadable.AppendPart(1, "etag-1", 12))
-	require.NoError(t, uploadable.AppendPart(3, "etag-3", 46))
+	uploadable.AppendPart(2, "etag-2", 42)
+	uploadable.AppendPart(1, "etag-1", 12)
+	uploadable.AppendPart(3, "etag-3", 46)
 
-	parts, size, err := uploadable.BuildCommitRequestParts()
-	require.NoError(t, err)
+	parts, size := uploadable.BuildCommitRequestParts()
 
 	require.Equal(t, []*api.MultipartCacheUploadCommitRequest_Part{
 		{PartNumber: 1, Etag: "etag-1"},

--- a/internal/agent/http_cache/ghacache/uploadable/uploadable_test.go
+++ b/internal/agent/http_cache/ghacache/uploadable/uploadable_test.go
@@ -14,7 +14,7 @@ func TestPartsAreOrdered(t *testing.T) {
 	require.NoError(t, uploadable.AppendPart(1, "etag-1", 12))
 	require.NoError(t, uploadable.AppendPart(3, "etag-3", 46))
 
-	parts, size, err := uploadable.Finalize()
+	parts, size, err := uploadable.BuildCommitRequestParts()
 	require.NoError(t, err)
 
 	require.Equal(t, []*api.MultipartCacheUploadCommitRequest_Part{


### PR DESCRIPTION
By propagating proper status and using StatusServiceUnavailable which is re-triable by the GHA client.

Plus made the parts commit re-triable by not marking parts as finalized.

https://github.com/actions/toolkit/blob/6dd369c0e648ed58d0ead326cf2426906ea86401/packages/cache/src/internal/requestUtils.ts#L24-L34