### PR TITLE
.goreleaser.yml: disable Solaris and ppc64 builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,13 +18,11 @@ builds:
       - freebsd
       - openbsd
       - netbsd
-      - solaris
     goarch:
       - amd64
       - arm
       - arm64
       - s390x
-      - ppc64le
     hooks:
       post:
         - bash .ci/remove-signature.sh {{ .Path }}


### PR DESCRIPTION
These builds take space and I haven't heard from anyone running Cirrus CLI on Solaris nor ppc64. If you fall into this category, please let us know 🙌 

We had someone use Cirrus CLI on `linux` + `s390x`, though, so keeping this combo for now.