### PR TITLE
Bump default version

### DIFF
--- a/internal/executor/platform/platform.go
+++ b/internal/executor/platform/platform.go
@@ -11,7 +11,7 @@ const (
 	agentImageBase = "ghcr.io/cirruslabs/cirrus-cli:v"
 
 	// DefaultAgentVersion represents the default version of the https://github.com/cirruslabs/cirrus-ci-agent to use.
-	DefaultAgentVersion = "0.119.0"
+	DefaultAgentVersion = "0.127.1"
 )
 
 type CopyCommand struct {


### PR DESCRIPTION
To have the agent version that support both int and string task ids