### PR TITLE
Persistent Worker: allow pre-pulling specified Tart VMs periodically

### DIFF
--- a/internal/commands/worker/config.go
+++ b/internal/commands/worker/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	Standby *worker.StandbyConfig `yaml:"standby"`
 
 	ResourceModifiers []*resourcemodifier.Modifier `yaml:"resource-modifiers"`
+
+	TartPrePull []string `yaml:"tart-pre-pull"`
 }
 
 type ConfigLog struct {
@@ -223,6 +225,10 @@ func buildWorker(output io.Writer) (*worker.Worker, error) {
 		opts = append(opts, worker.WithResourceModifiersManager(
 			resourcemodifier.NewManager(config.ResourceModifiers...),
 		))
+	}
+
+	if len(config.TartPrePull) != 0 {
+		opts = append(opts, worker.WithTartPrePull(config.TartPrePull))
 	}
 
 	// Instantiate worker

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -105,6 +105,12 @@ func (tart *Tart) Warmup(
 	return tart.bootVM(ctx, ident, additionalEnvironment, "", false, logger)
 }
 
+func PrePull(ctx context.Context, image string, logger *echelon.Logger) error {
+	_, _, err := CmdWithLogger(ctx, nil, logger, "pull", image)
+
+	return err
+}
+
 func (tart *Tart) bootVM(
 	ctx context.Context,
 	ident string,

--- a/internal/worker/options.go
+++ b/internal/worker/options.go
@@ -50,3 +50,9 @@ func WithResourceModifiersManager(resourceModifiersManager *resourcemodifier.Man
 		e.resourceModifierManager = resourceModifiersManager
 	}
 }
+
+func WithTartPrePull(tartPrePull []string) Option {
+	return func(e *Worker) {
+		e.tartPrePull = tartPrePull
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -235,6 +235,11 @@ func (worker *Worker) tryCreateStandby(ctx context.Context) {
 		return
 	}
 
+	// Do nothing if there are tasks that are running to simplify the resource management
+	if !worker.canFitResources(worker.standbyConfig.Resources) {
+		return
+	}
+
 	// Pre-pull the configured Tart VM images first
 	for _, image := range worker.tartPrePull {
 		worker.logger.Infof("pre-pulling Tart VM image %q...", image)
@@ -242,11 +247,6 @@ func (worker *Worker) tryCreateStandby(ctx context.Context) {
 		if err := tart.PrePull(ctx, image, worker.echelonLogger); err != nil {
 			worker.logger.Errorf("failed to pre-pull Tart VM image %q: %v", image, err)
 		}
-	}
-
-	// Do nothing if there are tasks that are running to simplify the resource management
-	if !worker.canFitResources(worker.standbyConfig.Resources) {
-		return
 	}
 
 	worker.logger.Debugf("creating a new standby instance with isolation %s", worker.standbyConfig.Isolation)


### PR DESCRIPTION
Can be configured as follows:

```yaml
tart-pre-pull:
  - ghcr.io/cirruslabs/macos-runner:sonoma
  - ghcr.io/cirruslabs/macos-runner:sequoia
```

Only works when standby is configured and only triggers before the standby creation/re-creation.