### PR TITLE
tuistcache: unconditionally presign download cache artifact requests

### DIFF
--- a/internal/agent/http_cache/tuistcache/tuistcache.go
+++ b/internal/agent/http_cache/tuistcache/tuistcache.go
@@ -55,18 +55,6 @@ func (tc *TuistCache) DownloadCacheArtifact(
 ) (tuistapi.DownloadCacheArtifactRes, error) {
 	cacheKey := getCacheKey(params.CacheCategory, params.ProjectID, params.Hash, params.Name)
 
-	_, err := client.CirrusClient.CacheInfo(ctx, &api.CacheInfoRequest{
-		TaskIdentification: client.CirrusTaskIdentification,
-		CacheKey:           cacheKey,
-	})
-	if err != nil {
-		if status, ok := status.FromError(err); ok && status.Code() == codes.NotFound {
-			return &tuistapi.DownloadCacheArtifactNotFound{}, nil
-		}
-
-		return nil, err
-	}
-
 	generateCacheUploadURLResponse, err := client.CirrusClient.GenerateCacheDownloadURLs(ctx, &api.CacheKey{
 		TaskIdentification: client.CirrusTaskIdentification,
 		CacheKey:           cacheKey,

--- a/internal/agent/http_cache/tuistcache/tuistcache_test.go
+++ b/internal/agent/http_cache/tuistcache/tuistcache_test.go
@@ -52,7 +52,13 @@ func TestTuistCache(t *testing.T) {
 		Name:      name,
 	})
 	require.NoError(t, err)
-	require.IsType(t, &tuistapi.DownloadCacheArtifactNotFound{}, downloadCacheArtifactResp)
+
+	require.IsType(t, &tuistapi.CacheArtifactDownloadURL{}, downloadCacheArtifactResp)
+	cacheArtifactDownloadUrl := downloadCacheArtifactResp.(*tuistapi.CacheArtifactDownloadURL)
+
+	cacheArtifactDownloadUrlResp, err := http.Get(cacheArtifactDownloadUrl.Data.URL)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, cacheArtifactDownloadUrlResp.StatusCode)
 
 	// Create the cache entry
 	startCacheArtifactMultipartUploadResp, err := tuistCacheClient.StartCacheArtifactMultipartUpload(


### PR DESCRIPTION
Because that's what the API is supposed to do and [according to docs](https://cloud.tuist.io/api/docs#tag/cache/GET/api/cache), HTTP 404 should be returned only when "The project or the cache artifact doesn't exist".