### PR TITLE
Introduce macOS "Local Network" permission helper process

### DIFF
--- a/internal/commands/localnetworkhelper.go
+++ b/internal/commands/localnetworkhelper.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"github.com/cirruslabs/cirrus-cli/pkg/localnetworkhelper"
+	"github.com/spf13/cobra"
+)
+
+func newLocalNetworkHelperCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    localnetworkhelper.CommandName,
+		Short:  "Run the macOS \"Local Network\" permission helper process",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// When we start the macOS "Local Network" permission helper process,
+			// we pass it one of the socketpair(2)'s descriptors through ExtraFiles
+			// field of Golang's exec.Cmd[1]. Here it becomes FD number 3, according
+			// to the ExtraFiles documentation:
+			//
+			// >If non-nil, entry i becomes file descriptor 3+i.
+			//
+			// [1]: https://pkg.go.dev/os/exec#Cmd
+			return localnetworkhelper.Serve(cmd.Context(), 3)
+		},
+	}
+	return cmd
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -24,6 +24,7 @@ func NewRootCmd() *cobra.Command {
 		newServeCmd(),
 		internal.NewRootCmd(),
 		worker.NewRootCmd(),
+		newLocalNetworkHelperCmd(),
 	}
 
 	return helpers.ConsumeSubCommands(cmd, commands)

--- a/internal/commands/worker/run.go
+++ b/internal/commands/worker/run.go
@@ -3,16 +3,36 @@ package worker
 import (
 	"errors"
 	"fmt"
+	"github.com/cirruslabs/cirrus-cli/pkg/localnetworkhelper"
+	"github.com/cirruslabs/cirrus-cli/pkg/privdrop"
 	"github.com/spf13/cobra"
+	"runtime"
 )
 
 var ErrRun = errors.New("run failed")
+
+var username string
 
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run persistent worker",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Drop the privileges, if requested
+			if username != "" {
+				// Additionally, when running on macOS, start the macOS "Local
+				// Network" permission helper and establish a connection with it
+				if runtime.GOOS == "darwin" {
+					if err := localnetworkhelper.StartAndConnect(cmd.Context()); err != nil {
+						return err
+					}
+				}
+
+				if err := privdrop.Drop(username); err != nil {
+					return err
+				}
+			}
+
 			worker, err := buildWorker(cmd.ErrOrStderr())
 			if err != nil {
 				return err
@@ -23,6 +43,8 @@ func NewRunCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&username, "user", "", "user name to drop privileges to")
 
 	attachFlags(cmd)
 

--- a/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
+++ b/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
@@ -58,7 +58,9 @@ func WaitForAgent(
 	ctx, span := tracer.Start(ctx, "upload-and-wait-for-agent")
 	defer span.End()
 
-	cli, err := connectViaSSH(ctx, logger, addr, sshUser, sshPassword)
+	logger.Debugf("connecting via SSH to %s...", addr)
+
+	cli, err := WaitForSSH(ctx, addr, sshUser, sshPassword, logger)
 	if err != nil {
 		return err
 	}
@@ -230,27 +232,6 @@ func forwardViaSSH(vmListener net.Listener, logger logger.Lightweight, endpoint 
 			_, _ = io.Copy(localConn, vmConn)
 		}()
 	}
-}
-
-func connectViaSSH(
-	ctx context.Context,
-	logger logger.Lightweight,
-	addr string,
-	sshUser string,
-	sshPassword string,
-) (*ssh.Client, error) {
-	// Connect to the VM and upload the agent
-
-	logger.Debugf("connecting via SSH to %s...", addr)
-
-	sshClient, err := WaitForSSH(ctx, addr, sshUser, sshPassword, logger)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Debugf("creating new SSH client...")
-
-	return sshClient, nil
 }
 
 func WaitForSSH(

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -96,6 +96,9 @@ func StartAndConnect(ctx context.Context) error {
 func Serve(ctx context.Context, fd int) error {
 	// Convert file descriptor number to *os.File
 	file := os.NewFile(uintptr(fd), "")
+	defer func() {
+		_ = file.Close()
+	}()
 
 	// Convert *os.File to net.Conn
 	conn, err := net.FileConn(file)

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -1,0 +1,206 @@
+package localnetworkhelper
+
+import (
+	"context"
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
+	"errors"
+	"fmt"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sys/unix"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const (
+	CommandName = "local-network-helper"
+
+	// "ssh -J" uses channels of type "direct-tcpip", which are documented
+	// in the RFC 4254 (7.2. TCP/IP Forwarding Channels)[1].
+	//
+	// [1]: https://datatracker.ietf.org/doc/html/rfc4254#section-7.2
+	channelTypeDirectTCPIP = "direct-tcpip"
+)
+
+var SSHClient *ssh.Client
+
+func StartAndConnect(ctx context.Context) error {
+	// Create a socketpair(2) for communicating with the helper process
+	socketPair, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return err
+	}
+
+	// Convert file descriptor numbers to *os.File's
+	ourFile := os.NewFile(uintptr(socketPair[0]), "")
+	helperFile := os.NewFile(uintptr(socketPair[1]), "")
+
+	// Launch our executable as a child process
+	//
+	// We're specifying the CommandName argument,
+	// so that the child will jump to Serve()
+	// and will wait for us.
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		cmd := exec.CommandContext(ctx, executable, CommandName)
+
+		cmd.ExtraFiles = []*os.File{
+			helperFile,
+		}
+
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		cmd.WaitDelay = time.Second
+
+		if err := cmd.Run(); !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+	}()
+
+	// Convert *os.File to net.Conn
+	ourConn, err := net.FileConn(ourFile)
+	if err != nil {
+		return err
+	}
+
+	// Check helper connectivity, should be near-instant
+	_ = ourConn.SetDeadline(time.Now().Add(1 * time.Second))
+
+	c, chans, reqs, err := ssh.NewClientConn(ourConn, "127.0.0.1:22", &ssh.ClientConfig{
+		//nolint:gosec // it's safe to ignore the host key here as we're communicating over IPC
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		return err
+	}
+
+	SSHClient = ssh.NewClient(c, chans, reqs)
+
+	return nil
+}
+
+func Serve(ctx context.Context, fd int) error {
+	// Convert file descriptor number to *os.File
+	file := os.NewFile(uintptr(fd), "")
+
+	// Convert *os.File to net.Conn
+	conn, err := net.FileConn(file)
+	if err != nil {
+		return err
+	}
+
+	// Generate a host key to be used by the SSH server
+	_, privateKey, err := ed25519.GenerateKey(cryptorand.Reader)
+	if err != nil {
+		return err
+	}
+
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		return err
+	}
+
+	// Configure the SSH server
+	serverConfig := &ssh.ServerConfig{
+		NoClientAuth: true,
+	}
+	serverConfig.AddHostKey(signer)
+
+	// Start the SSH server, immediately serving the connection
+	sshConn, newChannelCh, requestCh, err := ssh.NewServerConn(conn, serverConfig)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = sshConn.Close()
+	}()
+
+	for {
+		select {
+		case newChannel, ok := <-newChannelCh:
+			if !ok {
+				return nil
+			}
+
+			switch newChannel.ChannelType() {
+			case channelTypeDirectTCPIP:
+				go handleDirectTCPIP(newChannel)
+			default:
+				message := fmt.Sprintf("unsupported channel type requested: %q", newChannel.ChannelType())
+
+				if err := newChannel.Reject(ssh.UnknownChannelType, message); err != nil {
+					return err
+				}
+			}
+		case request, ok := <-requestCh:
+			if !ok {
+				return nil
+			}
+
+			if err := request.Reply(false, nil); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func handleDirectTCPIP(newChannel ssh.NewChannel) {
+	// Unmarshal the payload to determine to which VM the user wants to connect to
+	//
+	// This direct TCP/IP channel's payload is documented
+	// in the RFC 4254 (7.2. TCP/IP Forwarding Channels)[1].
+	//
+	// [1]: https://datatracker.ietf.org/doc/html/rfc4254#section-7.2
+	payload := struct {
+		HostToConnect       string
+		PortToConnect       uint32
+		OriginatorIPAddress string
+		OriginatorPort      uint32
+	}{}
+
+	if err := ssh.Unmarshal(newChannel.ExtraData(), &payload); err != nil {
+		message := fmt.Sprintf("failed to unmarshal payload: %v", err)
+
+		_ = newChannel.Reject(ssh.ConnectionFailed, message)
+	}
+
+	targetConn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", payload.HostToConnect, payload.PortToConnect))
+	if err != nil {
+		panic(err)
+	}
+
+	newChan, requestCh, err := newChannel.Accept()
+	if err != nil {
+		return
+	}
+
+	go func() {
+		defer func() {
+			_ = targetConn.Close()
+			_ = newChan.Close()
+		}()
+
+		_, _ = io.Copy(targetConn, newChan)
+	}()
+
+	go func() {
+		defer func() {
+			_ = targetConn.Close()
+			_ = newChan.Close()
+		}()
+
+		_, _ = io.Copy(newChan, targetConn)
+	}()
+
+	for request := range requestCh {
+		_ = request.Reply(false, nil)
+	}
+}

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package localnetworkhelper
 
 import (

--- a/pkg/localnetworkhelper/localnetworkhelper.go
+++ b/pkg/localnetworkhelper/localnetworkhelper.go
@@ -84,6 +84,12 @@ func StartAndConnect(ctx context.Context) error {
 
 	SSHClient = ssh.NewClient(c, chans, reqs)
 
+	// Now that the helper process is started,
+	// we can close our end of the socketpair(2)
+	if err := helperFile.Close(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -23,7 +23,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestLocalNetworkHelper(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Start the local network helper process and connect to it
 	require.NoError(t, localnetworkhelper.StartAndConnect(ctx))

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -1,0 +1,59 @@
+package localnetworkhelper_test
+
+import (
+	"bytes"
+	"context"
+	cryptrand "crypto/rand"
+	"github.com/cirruslabs/cirrus-cli/pkg/localnetworkhelper"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if len(os.Args) == 2 && os.Args[1] == localnetworkhelper.CommandName {
+		_ = localnetworkhelper.Serve(context.Background(), 3)
+
+		return
+	}
+
+	m.Run()
+}
+
+func TestLocalNetworkHelper(t *testing.T) {
+	ctx := context.Background()
+
+	// Start the local network helper process and connect to it
+	require.NoError(t, localnetworkhelper.StartAndConnect(ctx))
+
+	// Verify that the SSH server in the local network helper process works
+	// by establishing a regular TCP connection through that SSH server
+	// to our fixture TCP server and reading a chunk of bytes from it
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Send d ata
+	sent := make([]byte, 1*1024*1024)
+	_, err = cryptrand.Read(sent)
+	require.NoError(t, err)
+
+	go func() {
+		conn, err := lis.Accept()
+		require.NoError(t, err)
+
+		_, err = io.Copy(conn, bytes.NewReader(sent))
+		require.NoError(t, err)
+
+		require.NoError(t, conn.Close())
+	}()
+
+	// Receive data
+	conn, err := localnetworkhelper.SSHClient.DialContext(ctx, "tcp", lis.Addr().String())
+	require.NoError(t, err)
+
+	received, err := io.ReadAll(conn)
+	require.NoError(t, err)
+	require.EqualValues(t, sent, received)
+}

--- a/pkg/localnetworkhelper/localnetworkhelper_test.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package localnetworkhelper_test
 
 import (

--- a/pkg/localnetworkhelper/localnetworkhelper_unsupported.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_unsupported.go
@@ -5,7 +5,10 @@ package localnetworkhelper
 import (
 	"context"
 	"fmt"
+	"golang.org/x/crypto/ssh"
 )
+
+var SSHClient *ssh.Client
 
 func StartAndConnect(ctx context.Context) error {
 	return fmt.Errorf("macOS \"Local Network\" helper is not supported on this platform")

--- a/pkg/localnetworkhelper/localnetworkhelper_unsupported.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_unsupported.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+const CommandName = "doesn't matter"
+
 var SSHClient *ssh.Client
 
 func StartAndConnect(ctx context.Context) error {

--- a/pkg/localnetworkhelper/localnetworkhelper_unsupported.go
+++ b/pkg/localnetworkhelper/localnetworkhelper_unsupported.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package localnetworkhelper
+
+import (
+	"context"
+	"fmt"
+)
+
+func StartAndConnect(ctx context.Context) error {
+	return fmt.Errorf("macOS \"Local Network\" helper is not supported on this platform")
+}
+
+func Serve(ctx context.Context, fd int) error {
+	return fmt.Errorf("macOS \"Local Network\" helper is not supported on this platform")
+}

--- a/pkg/privdrop/privdrop.go
+++ b/pkg/privdrop/privdrop.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package privdrop
 
 import (

--- a/pkg/privdrop/privdrop.go
+++ b/pkg/privdrop/privdrop.go
@@ -1,0 +1,49 @@
+package privdrop
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"os"
+	userpkg "os/user"
+	"strconv"
+)
+
+var ErrFailed = errors.New("failed to drop privileges")
+
+func Drop(username string) error {
+	user, err := userpkg.Lookup(username)
+	if err != nil {
+		return fmt.Errorf("%w: failed to lookup username %q: %v",
+			ErrFailed, username, err)
+	}
+
+	gid, err := strconv.Atoi(user.Gid)
+	if err != nil {
+		return fmt.Errorf("%w: failed to parse %s's group ID %q: %v",
+			ErrFailed, user.Name, user.Gid, err)
+	}
+
+	if err := unix.Setregid(gid, gid); err != nil {
+		return fmt.Errorf("%w: failed to set real and effective group ID to %d: %v",
+			ErrFailed, gid, err)
+	}
+
+	if err := os.Setenv("HOME", user.HomeDir); err != nil {
+		return fmt.Errorf("%w: failed to set new HOME to %q: %v",
+			ErrFailed, user.HomeDir, err)
+	}
+
+	uid, err := strconv.Atoi(user.Uid)
+	if err != nil {
+		return fmt.Errorf("%w: failed to parse %s's user ID %q: %v",
+			ErrFailed, user.Name, user.Uid, err)
+	}
+
+	if err := unix.Setreuid(uid, uid); err != nil {
+		return fmt.Errorf("%w: failed to set real and effective user ID to %d: %v",
+			ErrFailed, uid, err)
+	}
+
+	return nil
+}

--- a/pkg/privdrop/privdrop_unsupported.go
+++ b/pkg/privdrop/privdrop_unsupported.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package privdrop
+
+import "fmt"
+
+func Drop(username string) error {
+	return fmt.Errorf("privilege dropping is not implemented on this platform")
+}


### PR DESCRIPTION
And implement privilege separation and dropping, which can be achieved by passing the `--user` command-line argument to `cirrus worker run`.

Closes https://github.com/cirruslabs/cirrus-cli/pull/816.