### PR TITLE
Call os.Chown() in the right place when creating a static directory

### DIFF
--- a/internal/agent/cirrusenv/cirrusenv_windows_test.go
+++ b/internal/agent/cirrusenv/cirrusenv_windows_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCirrusEnvConcurrentAccess(t *testing.T) {
-	ce, err := cirrusenv.New(42)
+	ce, err := cirrusenv.New("42")
 	require.NoError(t, err)
 	defer ce.Close()
 

--- a/internal/executor/agent/agent.go
+++ b/internal/executor/agent/agent.go
@@ -24,10 +24,23 @@ func RetrieveBinary(
 		return "", err
 	}
 
-	agentCacheDir := filepath.Join(cacheDir, "cirrus", "agent")
+	cirrusCacheDir := filepath.Join(cacheDir, "cirrus")
+	agentCacheDir := filepath.Join(cirrusCacheDir, "agent")
 
 	if err := os.MkdirAll(agentCacheDir, 0755); err != nil {
 		return "", err
+	}
+
+	// Make sure that the cache directories belong to the privilege-dropped
+	// user and group, in case privilege dropping was requested
+	if chownTo := privdrop.ChownTo; chownTo != nil {
+		if err := os.Chown(cirrusCacheDir, chownTo.UID, chownTo.GID); err != nil {
+			return "", err
+		}
+
+		if err := os.Chown(agentCacheDir, chownTo.UID, chownTo.GID); err != nil {
+			return "", err
+		}
 	}
 
 	var agentSuffix string

--- a/internal/executor/instance/persistentworker/pwdir/pwdir.go
+++ b/internal/executor/instance/persistentworker/pwdir/pwdir.go
@@ -10,15 +10,15 @@ func StaticTempDirWithDynamicFallback() (string, error) {
 	// Prefer static directory for non-Cirrus CI caches efficiency (e.g. ccache)
 	staticTempDir := filepath.Join(os.TempDir(), "cirrus-build")
 	if err := os.Mkdir(staticTempDir, 0700); err == nil {
-		return staticTempDir, nil
-	}
-
-	// Make sure that the agent binary belongs to the privilege-dropped
-	// user and group, in case privilege dropping was requested
-	if chownTo := privdrop.ChownTo; chownTo != nil {
-		if err := os.Chown(staticTempDir, chownTo.UID, chownTo.GID); err != nil {
-			return "", err
+		// Make sure that static directory belongs to the privilege-dropped
+		// user and group, in case privilege dropping was requested
+		if chownTo := privdrop.ChownTo; chownTo != nil {
+			if err := os.Chown(staticTempDir, chownTo.UID, chownTo.GID); err != nil {
+				return "", err
+			}
 		}
+
+		return staticTempDir, nil
 	}
 
 	tempDir, err := os.MkdirTemp("", "cirrus-build-")
@@ -26,7 +26,7 @@ func StaticTempDirWithDynamicFallback() (string, error) {
 		return "", err
 	}
 
-	// Make sure that the agent binary belongs to the privilege-dropped
+	// Make sure that the temporary directory belongs to the privilege-dropped
 	// user and group, in case privilege dropping was requested
 	if chownTo := privdrop.ChownTo; chownTo != nil {
 		if err := os.Chown(tempDir, chownTo.UID, chownTo.GID); err != nil {


### PR DESCRIPTION
Note the `err == nil`.