### PR TITLE
Pre-pull: implement jitter

### DIFF
--- a/internal/worker/prepull.go
+++ b/internal/worker/prepull.go
@@ -21,7 +21,7 @@ func (pull TartPrePull) NeedsPrePull() bool {
 
 	if jitterNanoseconds := pull.Jitter.Nanoseconds(); jitterNanoseconds > 0 {
 		//nolint:gosec // G404 is not applicable as we don't need cryptographically secure numbers here
-		nextPullAt.Add(time.Duration(rand.Int64N(jitterNanoseconds)))
+		nextPullAt = nextPullAt.Add(time.Duration(rand.Int64N(jitterNanoseconds)))
 	}
 
 	return time.Now().After(nextPullAt)

--- a/internal/worker/prepull.go
+++ b/internal/worker/prepull.go
@@ -1,10 +1,14 @@
 package worker
 
-import "time"
+import (
+	"math/rand/v2"
+	"time"
+)
 
 type TartPrePull struct {
 	Images        []string      `yaml:"images"`
 	CheckInterval time.Duration `yaml:"check-interval"`
+	Jitter        time.Duration `yaml:"jitter"`
 	LastCheck     time.Time
 }
 
@@ -13,5 +17,11 @@ func (pull TartPrePull) NeedsPrePull() bool {
 		return true
 	}
 
-	return time.Now().After(pull.LastCheck.Add(pull.CheckInterval))
+	nextPullAt := pull.LastCheck.Add(pull.CheckInterval)
+
+	if jitterNanoseconds := pull.Jitter.Nanoseconds(); jitterNanoseconds > 0 {
+		nextPullAt.Add(time.Duration(rand.Int64N(jitterNanoseconds)))
+	}
+
+	return time.Now().After(nextPullAt)
 }

--- a/internal/worker/prepull.go
+++ b/internal/worker/prepull.go
@@ -20,6 +20,7 @@ func (pull TartPrePull) NeedsPrePull() bool {
 	nextPullAt := pull.LastCheck.Add(pull.CheckInterval)
 
 	if jitterNanoseconds := pull.Jitter.Nanoseconds(); jitterNanoseconds > 0 {
+		//nolint:gosec // G404 is not applicable as we don't need cryptographically secure numbers here
 		nextPullAt.Add(time.Duration(rand.Int64N(jitterNanoseconds)))
 	}
 

--- a/internal/worker/prepull_test.go
+++ b/internal/worker/prepull_test.go
@@ -1,0 +1,37 @@
+package worker_test
+
+import (
+	"github.com/cirruslabs/cirrus-cli/internal/worker"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestNeedsPrePullDefaultConfiguration(t *testing.T) {
+	// When LastCheck is not set, NeedsPrePull() should always be true
+	require.True(t, worker.TartPrePull{}.NeedsPrePull())
+}
+
+func TestNeedsPrePullCustomConfiguration(t *testing.T) {
+	prePull := worker.TartPrePull{
+		CheckInterval: 3 * time.Second,
+		Jitter:        3 * time.Second,
+	}
+
+	// Since LastCheck defaults to "January 1, year 1, 00:00:00.000000000 UTC",
+	// the result of the first call to NeedsPrePull() should always be true
+	require.True(t, prePull.NeedsPrePull())
+
+	// Let's imagine that we've actually performed the pre-pull check
+	prePull.LastCheck = time.Now()
+
+	// Right after performing the check the result of NeedsPrePull() should be false
+	require.False(t, prePull.NeedsPrePull())
+
+	// Now we're likely still in the CheckInterval,
+	// wait CheckInterval + Jitter to get past it
+	time.Sleep(prePull.CheckInterval + prePull.Jitter)
+
+	// Now we're past the CheckInterval, NeedsPrePull() should be again true
+	require.True(t, prePull.NeedsPrePull())
+}


### PR DESCRIPTION
So that when multiple Persistent Workers are started around the same time, the pre-pull will still commence at slightly different times on these workers.