### PR TITLE
buf.gen.yaml: use versioned remote plugins to avoid surprises

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,9 +1,9 @@
 version: v2
 plugins:
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.3
     out: pkg/
     opt: paths=source_relative
-  - remote: buf.build/grpc/go
+  - remote: buf.build/grpc/go:v1.5.1
     out: pkg/
     opt: paths=source_relative
   # Use local generation, as recommended in https://github.com/bufbuild/plugins/issues/58:


### PR DESCRIPTION
See https://cirrus-ci.com/task/5677166123286528.

Need to release `v0.136.0` after this.