### PR TITLE
Handle `SIGTERM`

### DIFF
--- a/cmd/cirrus/main.go
+++ b/cmd/cirrus/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -67,7 +68,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	interruptCh := make(chan os.Signal, 1)
-	signal.Notify(interruptCh, os.Interrupt)
+	signal.Notify(interruptCh, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		select {


### PR DESCRIPTION
There is an OOM happening on Cloud Run but we don't capture anything in Sentry. I believe it's because [Cloud Run sends us `SIGTERM`](https://cloud.google.com/run/docs/container-contract#instance-shutdown) and we don't handle it.