### PR TITLE
blockIDToIndex → blockIDToPartNumber

### DIFF
--- a/internal/agent/http_cache/azureblob/blockid.go
+++ b/internal/agent/http_cache/azureblob/blockid.go
@@ -11,7 +11,7 @@ import (
 // [1]: https://github.com/Azure/azure-sdk-for-js/blob/fc4cbf0e10e15cbbe7cf873294db7d6e2bd02851/sdk/storage/storage-blob/src/utils/utils.common.ts#L486-L487
 const maxBlockIndexLength = 6
 
-func blockIDToIndex(blockIDRaw string) (int, error) {
+func blockIDToPartNumber(blockIDRaw string) (int, error) {
 	// Decode the Base64-encoded block ID
 	blockIDBytes, err := base64.StdEncoding.DecodeString(blockIDRaw)
 	if err != nil {
@@ -33,5 +33,6 @@ func blockIDToIndex(blockIDRaw string) (int, error) {
 		return 0, err
 	}
 
-	return blockIndex, nil
+	// Part numbers start with 1
+	return blockIndex + 1, nil
 }

--- a/internal/agent/http_cache/azureblob/blockid_test.go
+++ b/internal/agent/http_cache/azureblob/blockid_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestBlockIDToIndex(t *testing.T) {
-	blockIndex, err := blockIDToIndex("Yzg4ODM0YjYtZmI3MC00OWNmLWJlYmEtNDliODFjNDE0MWM3MDAwMDAwMDAwMDAx")
+func TestBlockIDToPartNumber(t *testing.T) {
+	partNumber, err := blockIDToPartNumber("Yzg4ODM0YjYtZmI3MC00OWNmLWJlYmEtNDliODFjNDE0MWM3MDAwMDAwMDAwMDAx")
 	require.NoError(t, err)
-	require.Equal(t, 1, blockIndex)
+	require.Equal(t, 2, partNumber)
 }


### PR DESCRIPTION
The former approach is too error-prone and without this change results in "received a block list pointing to a non-existent block" because of a missing "+ 1" when calling `GetPart()` in `putBlockList()`.