### PR TITLE
Propagate SENTRY_DSN to agent running in Tart/Vetu

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
   - dupl
   - errcheck
   - exhaustive
-  - exportloopref
   - gocognit
   - gocritic
   - gocyclo

--- a/internal/agent/main.go
+++ b/internal/agent/main.go
@@ -159,6 +159,11 @@ func Run(args []string) {
 		}
 	}()
 
+	// Prevent SENTRY_DSN propagation to scripts
+	if err := os.Unsetenv("SENTRY_DSN"); err != nil {
+		log.Printf("Failed to unset SENTRY_DSN: %v", err)
+	}
+
 	// Connect to the RPC server
 	md := metadata.New(map[string]string{
 		"org.cirruslabs.task-id":       *taskIdPtr,

--- a/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
+++ b/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -120,6 +121,11 @@ func WaitForAgent(
 	err = sess.Shell()
 	if err != nil {
 		return fmt.Errorf("%w: failed to start a shell: %v", ErrFailed, err)
+	}
+
+	// Passthrough SENTRY_DSN when it's set
+	if sentryDSN, ok := os.LookupEnv("SENTRY_DSN"); ok {
+		env["SENTRY_DSN"] = sentryDSN
 	}
 
 	for key, value := range env {


### PR DESCRIPTION
To get Sentry events for potential GHA cache v2 errors.

See https://github.com/cirruslabs/cirrus-cli/pull/790#pullrequestreview-2327970226.