### PR TITLE
Agent(targz): make symlink targets relative to their current directory

### DIFF
--- a/internal/agent/targz/targz.go
+++ b/internal/agent/targz/targz.go
@@ -53,7 +53,7 @@ func archiveSingleFolder(baseFolder string, folderPath string, tarWriter *tar.Wr
 		if header.Typeflag == tar.TypeSymlink {
 			linkDest, _ := os.Readlink(path)
 			if filepath.IsAbs(linkDest) && strings.HasPrefix(linkDest, baseFolder) {
-				linkDest, _ = filepath.Rel(baseFolder, linkDest)
+				linkDest, _ = filepath.Rel(filepath.Dir(path), linkDest)
 			}
 			header.Linkname = filepath.ToSlash(linkDest)
 		}


### PR DESCRIPTION
This way symbolic links pointing to a path that starts with a base directory will continue to work after `Unarchive()`, because these symbolic links will point to location relative to their own location.

Right now they are made relative to the base directory, which is only correct when such a link resides in that base directory.