### PR TITLE
Enrich report of a failed cache proxy

### DIFF
--- a/internal/agent/http_cache/azureblob/getblob.go
+++ b/internal/agent/http_cache/azureblob/getblob.go
@@ -78,7 +78,7 @@ func (azureBlob *AzureBlob) getBlob(writer http.ResponseWriter, request *http.Re
 	if err != nil {
 		proxyingDuration := time.Since(startProxyingAt)
 		fail(writer, request, http.StatusInternalServerError, "failed to proxy cache entry download",
-			"key", key, "err", err, "duration", proxyingDuration, "read", bytesRead)
+			"err", err, "duration", proxyingDuration, "read", bytesRead, "key", key)
 
 		return
 	}


### PR DESCRIPTION
Added duration and bytes proxied to help with debugging reported issue with:

"failed to proxy cache entry download"