### PR TITLE
Introduce "progressreader" package for composable cache download logging

### DIFF
--- a/internal/agent/http_cache/azureblob/getblob.go
+++ b/internal/agent/http_cache/azureblob/getblob.go
@@ -3,7 +3,9 @@ package azureblob
 import (
 	"fmt"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/client"
+	"github.com/cirruslabs/cirrus-cli/internal/agent/progressreader"
 	"github.com/cirruslabs/cirrus-cli/pkg/api"
+	"github.com/dustin/go-humanize"
 	"io"
 	"log"
 	"net/http"
@@ -78,39 +80,19 @@ func (azureBlob *AzureBlob) getBlob(writer http.ResponseWriter, request *http.Re
 	}
 
 	startProxyingAt := time.Now()
-	bytesRead, err := copyWithProgress(resp.Body, writer, key)
+	// we usually proxy large files so let's use a larger buffer
+	largeBuffer := make([]byte, PROXY_DOWNLOAD_BUFFER_SIZE)
+	progressReader := progressreader.New(resp.Body, PROXY_DOWNLOAD_PROGRESS_LOG_INTERVAL, func(bytes int64, duration time.Duration) {
+		rate := float64(bytes) / duration.Seconds()
+
+		log.Printf("Proxying cache entry download for %s: %d bytes read in %s (%s/s)",
+			key, bytes, duration, humanize.Bytes(uint64(rate)))
+	})
+	bytesRead, err := io.CopyBuffer(writer, progressReader, largeBuffer)
 	if err != nil {
 		proxyingDuration := time.Since(startProxyingAt)
 		fail(writer, request, http.StatusInternalServerError, "failed to proxy cache entry download",
 			"err", err, "duration", proxyingDuration, "read", bytesRead, "key", key)
 		return
 	}
-}
-
-func copyWithProgress(reader io.Reader, writer io.Writer, key string) (int64, error) {
-	startedAt := time.Now()
-	progressLoggedAt := startedAt
-	// we usually proxy large files so let's use a larger buffer
-	largeBuffer := make([]byte, PROXY_DOWNLOAD_BUFFER_SIZE)
-	bytesRead := int64(0)
-	for {
-		n, proxyErr := reader.Read(largeBuffer)
-		if n > 0 {
-			if _, writeErr := writer.Write(largeBuffer[:n]); writeErr != nil {
-				proxyErr = writeErr
-				break
-			}
-			bytesRead += int64(n)
-		}
-		if proxyErr == io.EOF {
-			proxyErr = nil
-			break
-		}
-		if time.Since(progressLoggedAt) > PROXY_DOWNLOAD_PROGRESS_LOG_INTERVAL {
-			currentSpeed := float64(bytesRead) / 1024 / 1024 / time.Since(startedAt).Seconds()
-			log.Printf("Proxying cache entry download for %s: %d bytes read in %s (avg speed %.2f Mb/s)\n", key, bytesRead, time.Since(startedAt), currentSpeed)
-			progressLoggedAt = time.Now()
-		}
-	}
-	return bytesRead, nil
 }

--- a/internal/agent/progressreader/progressreader.go
+++ b/internal/agent/progressreader/progressreader.go
@@ -1,0 +1,40 @@
+package progressreader
+
+import (
+	"io"
+	"time"
+)
+
+type LogFunc func(bytes int64, duration time.Duration)
+
+type Reader struct {
+	inner             io.Reader
+	lastLog           time.Time
+	interval          time.Duration
+	logFunc           LogFunc
+	bytesSinceLastLog int64
+}
+
+func New(inner io.Reader, interval time.Duration, logFunc LogFunc) *Reader {
+	return &Reader{
+		inner:    inner,
+		lastLog:  time.Now(),
+		interval: interval,
+		logFunc:  logFunc,
+	}
+}
+
+func (reader *Reader) Read(p []byte) (int, error) {
+	n, err := reader.inner.Read(p)
+
+	reader.bytesSinceLastLog += int64(n)
+
+	if durationSinceLastLog := time.Since(reader.lastLog); durationSinceLastLog >= reader.interval {
+		reader.logFunc(reader.bytesSinceLastLog, durationSinceLastLog)
+
+		reader.lastLog = time.Now()
+		reader.bytesSinceLastLog = 0
+	}
+
+	return n, err
+}

--- a/internal/agent/progressreader/progressreader_test.go
+++ b/internal/agent/progressreader/progressreader_test.go
@@ -1,0 +1,30 @@
+package progressreader_test
+
+import (
+	"github.com/cirruslabs/cirrus-cli/internal/agent/progressreader"
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+	"io"
+	"log"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestProgressReader(t *testing.T) {
+	// Manual invocation only
+	t.Skip()
+
+	resp, err := http.Get("http://speedtest.ams1.nl.leaseweb.net/100mb.bin")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	progressReader := progressreader.New(resp.Body, time.Second, func(bytes int64, duration time.Duration) {
+		rate := float64(bytes) / duration.Seconds()
+
+		log.Printf("%d bytes read in %s (%s/s)", bytes, duration, humanize.Bytes(uint64(rate)))
+	})
+
+	_, err = io.Copy(io.Discard, progressReader)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
I think we can further improve the implementation by re-using the `io.CopyBuffer`'s logic and supplying our own `io.Reader` that wraps the original one.