### PR TITLE
Agent(http_cache/azureblob): do not set Content-Length when Chacha is on

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: 2
+
 run:
   timeout: 5m
 
@@ -16,45 +18,11 @@ linters-settings:
     excludes:
       - G115
 
+formatters:
+  enable-all: true
+
 linters:
-  enable:
-  - asciicheck
-  - bodyclose
-  - dupl
-  - errcheck
-  - exhaustive
-  - gocognit
-  - gocritic
-  - gocyclo
-  - godot
-  - godox
-  - gofmt
-  - goheader
-  - gomodguard
-  - goprintffuncname
-  - gosec
-  - gosimple
-  - govet
-  - ineffassign
-  - lll
-  - makezero
-  - misspell
-  - nakedret
-  - nestif
-  - noctx
-  - nolintlint
-  - predeclared
-  - rowserrcheck
-  - sqlclosecheck
-  - staticcheck
-  - stylecheck
-  - testpackage
-  - tparallel
-  - typecheck
-  - unconvert
-  - unparam
-  - unused
-  - whitespace
+  enable-all: true
 
   disable:
     # We don't have high-performance requirements at this moment, so sacrificing
@@ -71,8 +39,6 @@ linters:
 
     # Style linters that are total nuts.
     - wsl
-    - gofumpt
-    - goimports
     - funlen
 
     # Enough parallelism for now.
@@ -96,9 +62,6 @@ linters:
     # [1]: https://github.com/mgechev/revive/issues/244#issuecomment-560512162
     - revive
 
-    # Unfortunately too much false-positives, e.g. for a 0700 umask or number 10 when using strconv.FormatInt()
-    - gomnd
-
     # Needs package whitelists
     - depguard
 
@@ -109,10 +72,13 @@ linters:
     # Work around https://github.com/golangci/golangci-lint/pull/4698
     - gochecknoinits
 
+    # We don't care about some of the errors
+    - errcheck
+
+    # Remove after we stop using deprecated Protocol Buffer fields in api/cirrus_ci_service.proto
+    - staticcheck
+
 issues:
   # Don't hide multiple issues that belong to one class since GitHub annotations can handle them all nicely.
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  exclude-dirs:
-    - internal/agent

--- a/internal/agent/executor/executor.go
+++ b/internal/agent/executor/executor.go
@@ -237,6 +237,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 
 		// Default transport
 		var transport http.RoundTripper
+		var chachaEnabled bool
 
 		transport = http_cache.DefaultTransport()
 
@@ -248,9 +249,10 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 		if chachaTransport != nil {
 			// Use Chacha transport with a fallback to the default transport
 			transport = fallbackroundtripper.New(chachaTransport, transport)
+			chachaEnabled = true
 		}
 
-		httpCacheHost := http_cache.Start(transport, httpCacheOpts...)
+		httpCacheHost := http_cache.Start(transport, chachaEnabled, httpCacheOpts...)
 
 		executor.env.Set("CIRRUS_HTTP_CACHE_HOST", httpCacheHost)
 

--- a/internal/agent/http_cache/azureblob/azureblob.go
+++ b/internal/agent/http_cache/azureblob/azureblob.go
@@ -29,13 +29,15 @@ type AzureBlob struct {
 	mux                          *http.ServeMux
 	uploadables                  *xsync.MapOf[string, *uploadablepkg.Uploadable]
 	potentiallyCachingHTTPClient *http.Client
+	chachaEnabled                bool
 }
 
-func New(potentiallyCachingHTTPClient *http.Client) *AzureBlob {
+func New(potentiallyCachingHTTPClient *http.Client, chachaEnabled bool) *AzureBlob {
 	azureBlobContainer := &AzureBlob{
 		mux:                          http.NewServeMux(),
 		uploadables:                  xsync.NewMapOf[string, *uploadablepkg.Uploadable](),
 		potentiallyCachingHTTPClient: potentiallyCachingHTTPClient,
+		chachaEnabled:                chachaEnabled,
 	}
 
 	azureBlobContainer.mux.HandleFunc("GET /{key...}", azureBlobContainer.getBlobAbstract)

--- a/internal/agent/http_cache/azureblob/getblob.go
+++ b/internal/agent/http_cache/azureblob/getblob.go
@@ -87,8 +87,12 @@ func (azureBlob *AzureBlob) getBlob(writer http.ResponseWriter, request *http.Re
 		return
 	}
 
-	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
-		writer.Header().Set("Content-Length", contentLength)
+	// Chacha doesn't support Range requests yet, and not disclosing Content-Length
+	// to the Azure Blob Client makes it not use the Range requests
+	if !azureBlob.chachaEnabled {
+		if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+			writer.Header().Set("Content-Length", contentLength)
+		}
 	}
 
 	writer.WriteHeader(resp.StatusCode)

--- a/internal/agent/http_cache/azureblob/headblob.go
+++ b/internal/agent/http_cache/azureblob/headblob.go
@@ -57,8 +57,12 @@ func (azureBlob *AzureBlob) headBlob(writer http.ResponseWriter, request *http.R
 		return
 	}
 
-	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
-		writer.Header().Set("Content-Length", contentLength)
+	// Chacha doesn't support Range requests yet, and not disclosing Content-Length
+	// to the Azure Blob Client makes it not use the Range requests
+	if !azureBlob.chachaEnabled {
+		if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+			writer.Header().Set("Content-Length", contentLength)
+		}
 	}
 
 	writer.WriteHeader(resp.StatusCode)

--- a/internal/agent/http_cache/ghacache/ghacache_test.go
+++ b/internal/agent/http_cache/ghacache/ghacache_test.go
@@ -22,7 +22,7 @@ func TestGHA(t *testing.T) {
 
 	client.InitClient(cirruscimock.ClientConn(t), "test", "test")
 
-	httpCacheURL := "http://" + http_cache.Start(http_cache.DefaultTransport()) + "/"
+	httpCacheURL := "http://" + http_cache.Start(http_cache.DefaultTransport(), false) + "/"
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"ac":  `[]`,

--- a/internal/agent/http_cache/ghacachev2/ghacachev2_test.go
+++ b/internal/agent/http_cache/ghacachev2/ghacachev2_test.go
@@ -22,7 +22,7 @@ func TestGHACacheV2(t *testing.T) {
 
 	client.InitClient(cirruscimock.ClientConn(t), "test", "test")
 
-	httpCacheURL := "http://" + http_cache.Start(http_cache.DefaultTransport())
+	httpCacheURL := "http://" + http_cache.Start(http_cache.DefaultTransport(), false)
 
 	client := gharesults.NewCacheServiceJSONClient(httpCacheURL, &http.Client{})
 

--- a/internal/agent/http_cache/http_cache.go
+++ b/internal/agent/http_cache/http_cache.go
@@ -45,7 +45,7 @@ func DefaultTransport() *http.Transport {
 	}
 }
 
-func Start(potentiallyCachingTransport http.RoundTripper, opts ...Option) string {
+func Start(potentiallyCachingTransport http.RoundTripper, chachaEnabled bool, opts ...Option) string {
 	httpClient = &http.Client{
 		Transport: DefaultTransport(),
 		Timeout:   10 * time.Minute,
@@ -88,7 +88,7 @@ func Start(potentiallyCachingTransport http.RoundTripper, opts ...Option) string
 		// Partial Azure Blob Service REST API implementation
 		// needed for the GHA cache API v2 to function properly
 		mux.Handle(azureblob.APIMountPoint+"/", sentryHandler.Handle(http.StripPrefix(azureblob.APIMountPoint,
-			azureblob.New(potentiallyCachingHTTPClient))))
+			azureblob.New(potentiallyCachingHTTPClient, chachaEnabled))))
 
 		// Apply options
 		for _, opt := range opts {

--- a/internal/agent/http_cache/http_cache_test.go
+++ b/internal/agent/http_cache/http_cache_test.go
@@ -18,7 +18,7 @@ func TestHTTPCache(t *testing.T) {
 
 	client.InitClient(cirruscimock.ClientConn(t), "test", "test")
 
-	httpCacheObjectURL := "http://" + http_cache.Start(http_cache.DefaultTransport()) +
+	httpCacheObjectURL := "http://" + http_cache.Start(http_cache.DefaultTransport(), false) +
 		"/cache/" + uuid.NewString() + "/test.txt"
 
 	// Ensure that the cache entry does not exist

--- a/internal/agent/http_cache/tuistcache/tuistcache_test.go
+++ b/internal/agent/http_cache/tuistcache/tuistcache_test.go
@@ -26,7 +26,7 @@ func TestTuistCache(t *testing.T) {
 	tuistCache, err := tuistcache.New()
 	require.NoError(t, err)
 
-	tuistCacheURL := tuistcache.URL(http_cache.Start(http_cache.DefaultTransport(),
+	tuistCacheURL := tuistcache.URL(http_cache.Start(http_cache.DefaultTransport(), false,
 		http_cache.WithTuistCache(tuistCache)))
 
 	tuistCacheClient, err := tuistapi.NewClient(tuistCacheURL)

--- a/internal/agent/main.go
+++ b/internal/agent/main.go
@@ -262,7 +262,7 @@ func reportSignal(ctx context.Context, sig os.Signal, taskId string, clientToken
 }
 
 func dialWithTimeout(ctx context.Context, apiEndpoint string, md metadata.MD) (*grpc.ClientConn, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
 	target, transportSecurity := grpchelper.TransportSettingsAsDialOption(apiEndpoint)


### PR DESCRIPTION
Also adapted `.golangci-lint.yml` to golangci-lint 2.0.