### PR TITLE
Tart executor: set --root-disk-opts="caching=cached,sync=none"

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -178,7 +178,7 @@ func (vm *VM) Start(
 	go func() {
 		defer vm.wg.Done()
 
-		args := []string{"--no-graphics", "--no-clipboard", "--no-audio"}
+		args := []string{"--no-graphics", "--no-clipboard", "--no-audio", "--root-disk-opts", "caching=cached,sync=none"}
 
 		if softnet {
 			args = append(args, "--net-softnet")


### PR DESCRIPTION
By default, to improve performance.