### PR TITLE
OpenTelemetry: provide our hand-crafted resource to logger provider

### DIFF
--- a/internal/opentelemetry/opentelemetry.go
+++ b/internal/opentelemetry/opentelemetry.go
@@ -92,6 +92,7 @@ func Init(ctx context.Context) (func(), error) {
 		return nil, err
 	}
 	logProvider := log.NewLoggerProvider(
+		log.WithResource(resource),
 		log.WithProcessor(
 			log.NewBatchProcessor(logExporter),
 		),


### PR DESCRIPTION
Otherwise logs from Cirrus CLI show up as `unknown_service:cirrus` service.