### PR TITLE
Agent: fix inverted logic used to enable Chacha

### DIFF
--- a/internal/agent/executor/executor.go
+++ b/internal/agent/executor/executor.go
@@ -466,7 +466,7 @@ func (executor *Executor) tryChachaTransport() (http.RoundTripper, error) {
 		return nil, nil
 	}
 
-	chachaAddr, ok := executor.env.Lookup("CIRRUS_CHACHA_ADDR")
+	chachaAddr, ok := os.LookupEnv("CIRRUS_CHACHA_ADDR")
 	if !ok {
 		return nil, fmt.Errorf("failed to initialize Chacha transport: " +
 			"Chacha is enabled, but no CIRRUS_CHACHA_ADDR is set")
@@ -482,7 +482,7 @@ func (executor *Executor) tryChachaTransport() (http.RoundTripper, error) {
 		Proxy: http.ProxyURL(chachaURL),
 	}
 
-	if chachaCert, ok := executor.env.Lookup("CIRRUS_CHACHA_CERT"); ok {
+	if chachaCert, ok := os.LookupEnv("CIRRUS_CHACHA_CERT"); ok {
 		certPool := x509.NewCertPool()
 
 		if certPool.AppendCertsFromPEM([]byte(chachaCert)) {

--- a/internal/agent/executor/executor.go
+++ b/internal/agent/executor/executor.go
@@ -242,7 +242,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 		transport = http_cache.DefaultTransport()
 
 		// Try Chacha transport
-		chachaTransport, err := executor.tryChachaTransport(transport)
+		chachaTransport, err := executor.tryChachaTransport()
 		if err != nil {
 			log.Printf("%v", err)
 		}
@@ -459,8 +459,10 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 	}
 }
 
-func (executor *Executor) tryChachaTransport(baseTransport http.RoundTripper) (http.RoundTripper, error) {
-	if _, ok := executor.env.Lookup("CIRRUS_CHACHA_ENABLED"); ok {
+func (executor *Executor) tryChachaTransport() (http.RoundTripper, error) {
+	if _, ok := executor.env.Lookup("CIRRUS_CHACHA_ENABLED"); !ok {
+		log.Printf("not initializing Chacha transport because CIRRUS_CHACHA_ENABLED is not set")
+
 		return nil, nil
 	}
 


### PR DESCRIPTION
Also pick up `CIRRUS_CHACHA_{ADDR,CERT}` from OS environment variables instead of executor's environment.