### PR TITLE
README.md: add macOS Sequoia note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 [![Build Status](https://api.cirrus-ci.com/github/cirruslabs/cirrus-cli.svg?branch=main)](https://cirrus-ci.com/github/cirruslabs/cirrus-cli)
 
+> [!IMPORTANT]
+>
+> **macOS 15 (Sequoia)**
+>
+> The  [newly introduced "Local Network" permission](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy) in macOS Sequoia requires accepting a GUI pop-up on each host machine that runs `cirrus run` or `cirrus worker run` and Tart VMs.
+>
+> To work around this, upgrade to Cirrus CLI 0.143.0 or newer and invoke the `cirrus run` or `cirrus worker run` as `root` with an additional `--user` command-line argument, which takes a name of your regular, non-privileged user on the host machine.
+>
+> This will cause the Cirrus CLI to start a small `cirrus localnetworkhelper` process in the background and then drop the privileges to the specified user.
+>
+>The helper process is privileged and needed to establish network connections on behalf of the Cirrus CLI without triggering a GUI pop-up.
+>
+>This approach is more secure than simply running `cirrus run` or `cirrus worker run` as `root`, because only a small part of Cirrus CLI runs privileged and the only functionality that this part has is establishing new connections.
+
 Cirrus CLI is a tool for running containerized tasks reproducibly in any environment. Most commonly, Cirrus tasks are used as part of continuous integration workflows 
 but can also be used as part of local development process as a [hermetic replacement of helper scripts/Makefiles](https://medium.com/cirruslabs/using-cirrus-cli-instead-of-makefiles-for-generating-grpc-87b949a67449).
 Cirrus CLI runs your tasks locally the same way they are executed in CI or on your colleague's machine. Immutability of containers ensures


### PR DESCRIPTION
To explain the "Local Network" workaround [that we now have](https://github.com/cirruslabs/cirrus-cli/pull/891).