### PR TITLE
Worker: ensure that worker.localNetworkHelper is passed to Warmup()

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -311,7 +311,8 @@ func (worker *Worker) tryCreateStandby(ctx context.Context) error {
 	worker.logger.Debugf("warming-up the standby instance")
 
 	runConfig := &runconfig.RunConfig{
-		Chacha: worker.chacha,
+		Chacha:             worker.chacha,
+		LocalNetworkHelper: worker.localNetworkHelper,
 	}
 
 	if err := standbyInstance.(abstract.WarmableInstance).Warmup(ctx, "standby", nil, lazyPull,


### PR DESCRIPTION
Otherwise we get `connect: no route to host` error.