### PR TITLE
Bump default agent version from 0.127.1 to 0.143.2

### DIFF
--- a/internal/executor/platform/platform.go
+++ b/internal/executor/platform/platform.go
@@ -11,7 +11,7 @@ const (
 	agentImageBase = "ghcr.io/cirruslabs/cirrus-cli:v"
 
 	// DefaultAgentVersion represents the default version of the https://github.com/cirruslabs/cirrus-ci-agent to use.
-	DefaultAgentVersion = "0.127.1"
+	DefaultAgentVersion = "0.143.2"
 )
 
 type CopyCommand struct {


### PR DESCRIPTION
Could help with https://github.com/cirruslabs/cirrus-cli/issues/882.

By fixing https://github.com/cirruslabs/cirrus-cli/pull/801, for example.