### PR TITLE
Parser: restore order of container "image:" field declaration

### DIFF
--- a/pkg/parser/instance/container.go
+++ b/pkg/parser/instance/container.go
@@ -35,6 +35,20 @@ func NewCommunityContainer(
 		},
 	}
 
+	imageSchema := schema.String("Docker Image to use.")
+	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
+		// reset dockerfile as CI environment
+		container.proto.Dockerfile = ""
+		container.proto.DockerArguments = nil
+
+		image, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+		container.proto.Image = image
+		return nil
+	})
+
 	dockerfileSchema := schema.String("Relative path to Dockerfile to build container from.")
 	container.OptionalField(nameable.NewSimpleNameable("dockerfile"), dockerfileSchema, func(node *node.Node) error {
 		dockerfile, err := node.GetExpandedStringValue(mergedEnv)
@@ -53,20 +67,6 @@ func NewCommunityContainer(
 			return err
 		}
 		container.proto.DockerArguments = dockerArguments
-		return nil
-	})
-
-	imageSchema := schema.String("Docker Image to use.")
-	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
-		// reset dockerfile as CI environment
-		container.proto.Dockerfile = ""
-		container.proto.DockerArguments = nil
-
-		image, err := node.GetExpandedStringValue(mergedEnv)
-		if err != nil {
-			return err
-		}
-		container.proto.Image = image
 		return nil
 	})
 

--- a/pkg/parser/instance/isolation/container/container.go
+++ b/pkg/parser/instance/isolation/container/container.go
@@ -34,6 +34,22 @@ func NewContainer(mergedEnv map[string]string) *Container {
 		},
 	}
 
+	imageSchema := schema.String("Container image to use.")
+	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
+		// reset dockerfile as CI environment
+		container.proto.Container.Dockerfile = ""
+		container.proto.Container.DockerArguments = nil
+
+		image, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+
+		container.proto.Container.Image = image
+
+		return nil
+	})
+
 	cpuSchema := schema.Number("CPU units for the container to use.")
 	container.OptionalField(nameable.NewSimpleNameable("cpu"), cpuSchema, func(node *node.Node) error {
 		cpu, err := node.GetExpandedStringValue(mergedEnv)
@@ -110,22 +126,6 @@ func NewContainer(mergedEnv map[string]string) *Container {
 			return err
 		}
 		container.proto.Container.DockerArguments = dockerArguments
-		return nil
-	})
-
-	imageSchema := schema.String("Container image to use.")
-	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
-		// reset dockerfile as CI environment
-		container.proto.Container.Dockerfile = ""
-		container.proto.Container.DockerArguments = nil
-
-		image, err := node.GetExpandedStringValue(mergedEnv)
-		if err != nil {
-			return err
-		}
-
-		container.proto.Container.Image = image
-
 		return nil
 	})
 

--- a/pkg/parser/instance/windowscontainer.go
+++ b/pkg/parser/instance/windowscontainer.go
@@ -27,6 +27,20 @@ func NewWindowsCommunityContainer(mergedEnv map[string]string, parserKit *parser
 		},
 	}
 
+	imageSchema := schema.String("Docker Image to use.")
+	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
+		// reset dockerfile as CI environment
+		container.proto.Dockerfile = ""
+		container.proto.DockerArguments = nil
+
+		image, err := node.GetExpandedStringValue(mergedEnv)
+		if err != nil {
+			return err
+		}
+		container.proto.Image = image
+		return nil
+	})
+
 	dockerfileSchema := schema.String("Relative path to Dockerfile to build container from.")
 	container.OptionalField(nameable.NewSimpleNameable("dockerfile"), dockerfileSchema, func(node *node.Node) error {
 		dockerfile, err := node.GetExpandedStringValue(mergedEnv)
@@ -45,20 +59,6 @@ func NewWindowsCommunityContainer(mergedEnv map[string]string, parserKit *parser
 			return err
 		}
 		container.proto.DockerArguments = dockerArguments
-		return nil
-	})
-
-	imageSchema := schema.String("Docker Image to use.")
-	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
-		// reset dockerfile as CI environment
-		container.proto.Dockerfile = ""
-		container.proto.DockerArguments = nil
-
-		image, err := node.GetExpandedStringValue(mergedEnv)
-		if err != nil {
-			return err
-		}
-		container.proto.Image = image
 		return nil
 	})
 


### PR DESCRIPTION
No need to change it since the parsing order is defined by the YAML fields order instead: https://github.com/cirruslabs/cirrus-cli/blob/989bbbe1206ff96a40577edcb69b95a31241a34e/pkg/parser/parseable/parseable.go#L109-L113