### PR TITLE
Parser: preserve "docker_arguments:" on "image:" override

### DIFF
--- a/pkg/parser/instance/container.go
+++ b/pkg/parser/instance/container.go
@@ -39,7 +39,6 @@ func NewCommunityContainer(
 	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
 		// reset dockerfile as CI environment
 		container.proto.Dockerfile = ""
-		container.proto.DockerArguments = nil
 
 		image, err := node.GetExpandedStringValue(mergedEnv)
 		if err != nil {
@@ -146,6 +145,12 @@ func (container *Container) Parse(node *node.Node, parserKit *parserkit.ParserKi
 	}
 	if container.proto.Memory == 0 {
 		container.proto.Memory = defaultMemory
+	}
+
+	// Finally, remove the Docker arguments if "dockerfile:"
+	// was not specified or was overridden by "image:"
+	if container.proto.Dockerfile == "" {
+		container.proto.DockerArguments = nil
 	}
 
 	return container.proto, nil

--- a/pkg/parser/instance/isolation/container/container.go
+++ b/pkg/parser/instance/isolation/container/container.go
@@ -38,7 +38,6 @@ func NewContainer(mergedEnv map[string]string) *Container {
 	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
 		// reset dockerfile as CI environment
 		container.proto.Container.Dockerfile = ""
-		container.proto.Container.DockerArguments = nil
 
 		image, err := node.GetExpandedStringValue(mergedEnv)
 		if err != nil {
@@ -160,6 +159,12 @@ func (container *Container) Parse(node *node.Node, parserKit *parserkit.ParserKi
 	}
 	if container.proto.Container.Memory == 0 {
 		container.proto.Container.Memory = defaultMemory
+	}
+
+	// Finally, remove the Docker arguments if "dockerfile:"
+	// was not specified or was overridden by "image:"
+	if container.proto.Container.Dockerfile == "" {
+		container.proto.Container.DockerArguments = nil
 	}
 
 	return nil

--- a/pkg/parser/instance/windowscontainer.go
+++ b/pkg/parser/instance/windowscontainer.go
@@ -31,7 +31,6 @@ func NewWindowsCommunityContainer(mergedEnv map[string]string, parserKit *parser
 	container.OptionalField(nameable.NewSimpleNameable("image"), imageSchema, func(node *node.Node) error {
 		// reset dockerfile as CI environment
 		container.proto.Dockerfile = ""
-		container.proto.DockerArguments = nil
 
 		image, err := node.GetExpandedStringValue(mergedEnv)
 		if err != nil {
@@ -123,6 +122,12 @@ func (container *WindowsContainer) Parse(
 	}
 	if container.proto.Memory == 0 {
 		container.proto.Memory = defaultMemory
+	}
+
+	// Finally, remove the Docker arguments if "dockerfile:"
+	// was not specified or was overridden by "image:"
+	if container.proto.Dockerfile == "" {
+		container.proto.DockerArguments = nil
 	}
 
 	return container.proto, nil


### PR DESCRIPTION
I think there's one more thing that can be improved to avoid loosing potentially useful information when parsing.