### PR TITLE
Worker: fix gRPC's NOT_FOUND error handling

### DIFF
--- a/internal/worker/upstream/upstream.go
+++ b/internal/worker/upstream/upstream.go
@@ -10,8 +10,10 @@ import (
 	"github.com/cirruslabs/cirrus-cli/pkg/grpchelper"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"time"
 )
 
@@ -218,6 +220,11 @@ func (upstream *Upstream) SetDisabled(ctx context.Context, disabled bool) error 
 
 	response, err := upstream.rpcClient.UpdateStatus(ctx, request, grpc.PerRPCCredentials(upstream))
 	if err != nil {
+		// Ignore the error in case the worker is not registered yet
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
+
 		return fmt.Errorf("%w: failed to set disabled state on upstream %s: %v",
 			ErrFailed, upstream.Name(), err)
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -23,8 +23,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"math"
 	"os"
@@ -420,9 +418,6 @@ func (worker *Worker) Pause(ctx context.Context, wait bool) error {
 
 	for _, upstream := range worker.upstreams {
 		if err := upstream.SetDisabled(subCtx, true); err != nil {
-			if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
-				continue
-			}
 			return err
 		}
 	}
@@ -460,9 +455,6 @@ func (worker *Worker) Resume(ctx context.Context) error {
 
 	for _, slot := range worker.upstreams {
 		if err := slot.SetDisabled(subCtx, false); err != nil {
-			if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
-				continue
-			}
 			return err
 		}
 	}


### PR DESCRIPTION
`SetDisabled()` converts the gRPC's `err` into string when returning it, so using `status.FromError()` on that `err` makes no sense.

To fix this we simply apply DRY and handle the `NOT_FOUND` in `SetDisabled()` by returning `nil`.

Introduced in https://github.com/cirruslabs/cirrus-cli/pull/911.