### PR TITLE
http_cache(azureblob): local uploadable functionality for small chunks

### DIFF
--- a/internal/agent/http_cache/azureblob/putblob.go
+++ b/internal/agent/http_cache/azureblob/putblob.go
@@ -128,7 +128,7 @@ func (azureBlob *AzureBlob) putBlock(writer http.ResponseWriter, request *http.R
 		local := contentLength < 5*humanize.MiByte
 
 		if local {
-			log.Printf("using local uploadable because the first observed "+
+			log.Printf("Using local uploadable because the first observed "+
 				"block size for key %q is only %s", key, humanize.IBytes(contentLength))
 		}
 

--- a/internal/agent/http_cache/azureblob/putblob.go
+++ b/internal/agent/http_cache/azureblob/putblob.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/go-chi/render"
 	"io"
+	"log"
 	"net/http"
 	"strconv"
 )
@@ -125,6 +126,11 @@ func (azureBlob *AzureBlob) putBlock(writer http.ResponseWriter, request *http.R
 		// Upload locally if we're observing chunks that are smaller
 		// than S3's minimum part size for multipart uploads
 		local := contentLength < 5*humanize.MiByte
+
+		if local {
+			log.Printf("using local uploadable because the first observed "+
+				"block size for key %q is only %s", key, humanize.IBytes(contentLength))
+		}
 
 		return uploadablepkg.New(local)
 	})

--- a/internal/agent/http_cache/azureblob/putblob.go
+++ b/internal/agent/http_cache/azureblob/putblob.go
@@ -6,7 +6,9 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/agent/client"
 	uploadablepkg "github.com/cirruslabs/cirrus-cli/internal/agent/http_cache/azureblob/uploadable"
 	"github.com/cirruslabs/cirrus-cli/pkg/api"
+	"github.com/dustin/go-humanize"
 	"github.com/go-chi/render"
+	"io"
 	"net/http"
 	"strconv"
 )
@@ -120,8 +122,25 @@ func (azureBlob *AzureBlob) putBlock(writer http.ResponseWriter, request *http.R
 
 	// Retrieve an already existing uploadable or compute a new one
 	uploadable, _ := azureBlob.uploadables.LoadOrCompute(key, func() *uploadablepkg.Uploadable {
-		return uploadablepkg.New()
+		// Upload locally if we're observing chunks that are smaller
+		// than S3's minimum part size for multipart uploads
+		local := contentLength < 5*humanize.MiByte
+
+		return uploadablepkg.New(local)
 	})
+
+	if uploadable.Local() {
+		if err := uploadable.AppendPartLocal(partNumber, request.Body); err != nil {
+			fail(writer, request, http.StatusInternalServerError, "failed to upload part locally",
+				"key", key, "blockid", blockID, "err", err)
+
+			return
+		}
+
+		writer.WriteHeader(http.StatusCreated)
+
+		return
+	}
 
 	// Retrieve an already existing uploadable ID or compute a new one
 	uploadID, err := uploadable.IDOrCompute(func() (string, error) {
@@ -233,6 +252,7 @@ func (azureBlob *AzureBlob) putBlockList(writer http.ResponseWriter, request *ht
 		return
 	}
 
+	var localPartReaders []io.Reader
 	var protoParts []*api.MultipartCacheUploadCommitRequest_Part
 
 	for _, blockID := range blockList.Latest {
@@ -253,10 +273,55 @@ func (azureBlob *AzureBlob) putBlockList(writer http.ResponseWriter, request *ht
 			return
 		}
 
-		protoParts = append(protoParts, &api.MultipartCacheUploadCommitRequest_Part{
-			PartNumber: uint32(partNumber),
-			Etag:       part.ETag,
+		if uploadable.Local() {
+			localPartReaders = append(localPartReaders, part.File())
+		} else {
+			protoParts = append(protoParts, &api.MultipartCacheUploadCommitRequest_Part{
+				PartNumber: partNumber,
+				Etag:       part.ETag(),
+			})
+		}
+	}
+
+	if uploadable.Local() {
+		generateCacheUploadURLResponse, err := client.CirrusClient.GenerateCacheUploadURL(request.Context(), &api.CacheKey{
+			TaskIdentification: client.CirrusTaskIdentification,
+			CacheKey:           key,
 		})
+		if err != nil {
+			fail(writer, request, http.StatusInternalServerError, "failed to generate cache upload URL "+
+				"for local part upload", "key", key, "uploadid", uploadID, "err", err)
+
+			return
+		}
+
+		uploadReq, err := http.NewRequest(http.MethodPut, generateCacheUploadURLResponse.Url, io.MultiReader(localPartReaders...))
+		if err != nil {
+			fail(writer, request, http.StatusInternalServerError, "failed to create request to cache upload URL "+
+				"for local part upload", "key", key, "uploadid", uploadID, "err", err)
+
+			return
+		}
+
+		uploadResp, err := http.DefaultClient.Do(uploadReq)
+		if err != nil {
+			fail(writer, request, http.StatusInternalServerError, "failed to perform request to cache upload URL "+
+				"for local part upload", "key", key, "uploadid", uploadID, "err", err)
+
+			return
+		}
+
+		if uploadResp.StatusCode != http.StatusOK {
+			fail(writer, request, http.StatusInternalServerError, "failed to create request to cache upload URL "+
+				"for local part upload, got unexpected HTTP status", "key", key, "uploadid", uploadID,
+				"http_status_code", uploadResp.StatusCode, "http_status", uploadResp.Status)
+
+			return
+		}
+
+		writer.WriteHeader(http.StatusCreated)
+
+		return
 	}
 
 	_, err := client.CirrusClient.MultipartCacheUploadCommit(request.Context(), &api.MultipartCacheUploadCommitRequest{

--- a/internal/agent/http_cache/ghacachev2/ghacachev2_test.go
+++ b/internal/agent/http_cache/ghacachev2/ghacachev2_test.go
@@ -1,13 +1,16 @@
 package ghacachev2_test
 
 import (
+	"bytes"
 	"context"
+	cryptorand "crypto/rand"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/client"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/http_cache"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/http_cache/ghacache/cirruscimock"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
 	"github.com/cirruslabs/cirrus-cli/pkg/api/gharesults"
+	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"io"
@@ -94,4 +97,95 @@ func TestGHACacheV2(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 5, n)
 	require.Equal(t, []byte("World"), buf)
+}
+
+func TestGHACacheV2UploadStream(t *testing.T) {
+	testutil.NeedsContainerization(t)
+
+	testCases := []struct {
+		Name      string
+		BlockSize int64
+	}{
+		{
+			Name:      "normal-chunks",
+			BlockSize: 5 * humanize.MiByte,
+		},
+		{
+			Name:      "small-chunks",
+			BlockSize: 1 * humanize.MiByte,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			client.InitClient(cirruscimock.ClientConn(t), "test", "test")
+
+			httpCacheURL := "http://" + http_cache.Start(t.Context(), http_cache.DefaultTransport(), false)
+
+			client := gharesults.NewCacheServiceJSONClient(httpCacheURL, &http.Client{})
+
+			cacheKey := uuid.NewString()
+			cacheValue := make([]byte, 50*humanize.MiByte)
+			_, err := cryptorand.Read(cacheValue)
+			require.NoError(t, err)
+
+			// Ensure that an entry for our cache key is not present
+			getCacheEntryDownloadURLRes, err := client.GetCacheEntryDownloadURL(t.Context(),
+				&gharesults.GetCacheEntryDownloadURLRequest{
+					Key: cacheKey,
+				},
+			)
+			require.NoError(t, err)
+			require.False(t, getCacheEntryDownloadURLRes.Ok)
+
+			// Upload an entry for our cache key
+			createCacheEntryRes, err := client.CreateCacheEntry(t.Context(), &gharesults.CreateCacheEntryRequest{
+				Key: cacheKey,
+			})
+			require.NoError(t, err)
+			require.True(t, createCacheEntryRes.Ok)
+
+			// Feed the returned pre-signed upload URL to Azure Blob client
+			//
+			// Unfortunately azblob.ParseURL() just drops the rest of the path,
+			// and has no ServiceURL() convenience method, so we have to manually
+			// add the "://" and "/_azureblob" below.
+			url, err := azblob.ParseURL(createCacheEntryRes.SignedUploadUrl)
+			require.NoError(t, err)
+
+			blockBlobClient, err := azblob.NewClientWithNoCredential(
+				url.Scheme+"://"+url.Host+"/_azureblob",
+				nil,
+			)
+			require.NoError(t, err)
+
+			r := bytes.NewReader(cacheValue)
+
+			_, err = blockBlobClient.UploadStream(t.Context(), url.ContainerName, url.BlobName, r,
+				&azblob.UploadStreamOptions{
+					BlockSize: testCase.BlockSize,
+				},
+			)
+			require.NoError(t, err)
+
+			// Ensure that an entry for our cache key is present
+			// and matches to what we've previously put in the cache
+			getCacheEntryDownloadURLResp, err := client.GetCacheEntryDownloadURL(t.Context(),
+				&gharesults.GetCacheEntryDownloadURLRequest{
+					Key: cacheKey,
+				},
+			)
+			require.NoError(t, err)
+			require.True(t, getCacheEntryDownloadURLResp.Ok)
+			require.Equal(t, cacheKey, getCacheEntryDownloadURLResp.MatchedKey)
+
+			downloadResp, err := http.Get(getCacheEntryDownloadURLResp.SignedDownloadUrl)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, downloadResp.StatusCode)
+
+			downloadRespBodyBytes, err := io.ReadAll(downloadResp.Body)
+			require.NoError(t, err)
+			require.Equal(t, cacheValue, downloadRespBodyBytes)
+		})
+	}
 }


### PR DESCRIPTION
To work around [github.com/tonistiigi/go-actions-cache](https://github.com/tonistiigi/go-actions-cache) use 1 MiB chunks [by default](https://github.com/tonistiigi/go-actions-cache/blob/378c5ed1ddd9f4bd9371b02deeca46c9b6fae2fa/cache_v2.go#L70).