### PR TITLE
ghacachev2: do not escape cache key when not necessary

### DIFF
--- a/internal/agent/http_cache/ghacachev2/ghacachev2.go
+++ b/internal/agent/http_cache/ghacachev2/ghacachev2.go
@@ -96,7 +96,7 @@ func (cache *Cache) FinalizeCacheEntryUpload(ctx context.Context, request *ghare
 }
 
 func httpCacheKey(key string, version string) string {
-	return fmt.Sprintf("%s-%s", url.PathEscape(version), url.PathEscape(key))
+	return fmt.Sprintf("%s-%s", version, key)
 }
 
 func (cache *Cache) azureBlobURL(keyWithVersion string) string {


### PR DESCRIPTION
We already have `url.PathEscape()` in `azureBlobURL()`.

Otherwise [this part of `github.com/tonistiigi/go-actions-cache`](https://github.com/moby/buildkit/blob/a23bc16feff9789f207a7b59220ce79c86444a39/vendor/github.com/tonistiigi/go-actions-cache/cache.go#L440-L443) fails.