### PR TITLE
remoteagent: use bounded context when dialing in WaitForSSH()

### DIFF
--- a/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
+++ b/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
@@ -288,7 +288,7 @@ func WaitForSSH(
 		} else {
 			dialer := net.Dialer{}
 
-			netConn, err = dialer.DialContext(ctx, "tcp", addr)
+			netConn, err = dialer.DialContext(boundedCtx, "tcp", addr)
 		}
 		if err != nil {
 			logger.Debugf("failed to dial %s: %v", addr, err)


### PR DESCRIPTION
Otherwise we may wait more than needed (e.g. 30 seconds<sup>1</sup>) due to an exponential backoff.

<sup>1</sup>: trace IDs `cee3874c750c135273f54d25d708ba4d`, `8d80220baf01a503d2460bd8163c6ac6`, etc.