### PR TITLE
Disable Tart prunning when clonning temporary VMs

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cirruslabs/echelon"
 	"github.com/getsentry/sentry-go"
 	"go.opentelemetry.io/otel/trace"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -63,8 +64,16 @@ func NewVMClonedFrom(
 
 	cloneLogger := logger.Scoped("clone virtual machine")
 	cloneLogger.Infof("Cloning virtual machine %s...", from)
+	cloneEnv := vm.env
+	if cloneEnv == nil {
+		cloneEnv = map[string]string{}
+	} else {
+		cloneEnv = maps.Clone(cloneEnv)
+	}
 
-	if _, _, err := CmdWithLogger(ctx, vm.env, cloneLogger, "clone", from, vm.ident); err != nil {
+	cloneEnv["TART_NO_AUTO_PRUNE"] = ""
+
+	if _, _, err := CmdWithLogger(ctx, cloneEnv, cloneLogger, "clone", from, vm.ident); err != nil {
 		cloneLogger.Finish(false)
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- ensure TART_NO_AUTO_PRUNE is set only for Tart VM clones

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b220ce50883298bb49305716812fd