### PR TITLE
Use `automatic` caching for Tart VMs

### DIFF
--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"


### PR DESCRIPTION
Seems in most of the cases it actually yields better results than forcing caching.