### PR TITLE
Agent: fix "extendedTimeoutCtx" not respecting "timeoutCtx"'s timeout

### DIFF
--- a/internal/agent/contextops/contextops.go
+++ b/internal/agent/contextops/contextops.go
@@ -1,0 +1,17 @@
+package contextops
+
+import "context"
+
+func And(inputCtxs ...context.Context) context.Context {
+	outputCtx, outputCtxCancel := context.WithCancel(context.Background())
+
+	go func() {
+		defer outputCtxCancel()
+
+		for _, inputCtx := range inputCtxs {
+			<-inputCtx.Done()
+		}
+	}()
+
+	return outputCtx
+}

--- a/internal/agent/contextops/contextops_test.go
+++ b/internal/agent/contextops/contextops_test.go
@@ -1,0 +1,24 @@
+package contextops_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cirruslabs/cirrus-cli/internal/agent/contextops"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnd(t *testing.T) {
+	firstCtx, firstCtxCancel := context.WithCancel(context.Background())
+	firstCtxCancel()
+
+	secondCtx, secondCtxCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer secondCtxCancel()
+
+	waitStart := time.Now()
+	<-contextops.And(firstCtx, secondCtx).Done()
+	waitStop := time.Now()
+
+	require.GreaterOrEqual(t, waitStop.Sub(waitStart), 15*time.Second)
+}

--- a/internal/agent/executor/executor.go
+++ b/internal/agent/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/cirrusenv"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/client"
+	"github.com/cirruslabs/cirrus-cli/internal/agent/contextops"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/environment"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/executor/metrics"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/executor/terminalwrapper"
@@ -336,7 +337,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 				defer extendedTimeoutCtxCancel()
 			}
 
-			stepCtx = extendedTimeoutCtx
+			stepCtx = contextops.And(timeoutCtx, extendedTimeoutCtx)
 		} else {
 			stepCtx = timeoutCtx
 		}


### PR DESCRIPTION
The idea is to wait for both the `timeoutCtx` (has large timeout, but can be cancelled) and `extendedTimeoutCtx` (has small timeout).