### PR TITLE
Persistent Worker: introduce "tuning" section to configuration file

### DIFF
--- a/internal/executor/instance/instance.go
+++ b/internal/executor/instance/instance.go
@@ -3,6 +3,10 @@ package instance
 import (
 	"errors"
 	"fmt"
+	"path"
+	"runtime"
+	"strings"
+
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/abstract"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/container"
 	"github.com/cirruslabs/cirrus-cli/internal/executor/instance/persistentworker"
@@ -16,9 +20,6 @@ import (
 	"golang.org/x/text/language"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
-	"path"
-	"runtime"
-	"strings"
 )
 
 var (
@@ -96,7 +97,7 @@ func NewFromProto(
 			Arguments:  instance.Arguments,
 		}, nil
 	case *api.PersistentWorkerInstance:
-		return persistentworker.New(instance.Isolation, security.NoSecurityAllowAllVolumes(), nil, logger)
+		return persistentworker.New(instance.Isolation, security.NoSecurityAllowAllVolumes(), nil, nil, logger)
 	case *api.DockerBuilder:
 		// Ensures that we're not trying to run e.g. Windows-specific scripts on macOS
 		instanceOS := strings.ToLower(instance.Platform.String())
@@ -112,7 +113,7 @@ func NewFromProto(
 			Type: &api.Isolation_None_{
 				None: &api.Isolation_None{},
 			},
-		}, security.NoSecurity(), nil, logger)
+		}, security.NoSecurity(), nil, nil, logger)
 	case *api.MacOSInstance:
 		return tart.New(instance.Image, instance.User, instance.Password, 22,
 			instance.Cpu, instance.Memory, tart.WithLogger(logger))

--- a/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
+++ b/internal/executor/instance/persistentworker/isolation/vetu/vetu.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/executor/platform"
 	"github.com/cirruslabs/cirrus-cli/internal/logger"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/resourcemodifier"
+	"github.com/cirruslabs/cirrus-cli/internal/worker/tuning"
 	"github.com/cirruslabs/cirrus-cli/pkg/api"
 	"github.com/cirruslabs/echelon"
 	"github.com/getsentry/sentry-go"
@@ -44,6 +45,7 @@ type Vetu struct {
 	bridgedInterface     string
 	hostNetworking       bool
 	resourceModifier     *resourcemodifier.Modifier
+	tuning               *tuning.Tuning
 	syncTimeOverSSH      bool
 	standardOutputToLogs bool
 
@@ -58,6 +60,7 @@ func New(
 	cpu uint32,
 	memory uint32,
 	resourceModifier *resourcemodifier.Modifier,
+	tuning *tuning.Tuning,
 	opts ...Option,
 ) (*Vetu, error) {
 	vetu := &Vetu{
@@ -68,6 +71,7 @@ func New(
 		cpu:              cpu,
 		memory:           memory,
 		resourceModifier: resourceModifier,
+		tuning:           tuning,
 	}
 
 	// Apply options
@@ -125,7 +129,7 @@ func (vetu *Vetu) bootVM(
 	tmpVMName := vmNamePrefix + identToBeInjected + uuid.NewString()
 
 	vm, err := NewVMClonedFrom(ctx, vetu.vmName, tmpVMName, lazyPull, env, vetu.standardOutputToLogs,
-		vetu.resourceModifier, logger)
+		vetu.resourceModifier, vetu.tuning, logger)
 	if err != nil {
 		return fmt.Errorf("%w: failed to create VM cloned from %q: %v", ErrFailed, vetu.vmName, err)
 	}

--- a/internal/executor/instance/persistentworker/persistentworker.go
+++ b/internal/executor/instance/persistentworker/persistentworker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/logger"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/resourcemodifier"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/security"
+	"github.com/cirruslabs/cirrus-cli/internal/worker/tuning"
 	"github.com/cirruslabs/cirrus-cli/pkg/api"
 )
 
@@ -24,6 +25,7 @@ func New(
 	isolation *api.Isolation,
 	security *security.Security,
 	resourceModifier *resourcemodifier.Modifier,
+	tuning *tuning.Tuning,
 	logger logger.Lightweight,
 ) (abstract.Instance, error) {
 	if isolation == nil {
@@ -74,7 +76,7 @@ func New(
 	case *api.Isolation_Tart_:
 		return newTart(iso, security, logger)
 	case *api.Isolation_Vetu_:
-		return newVetu(iso, security, resourceModifier, logger)
+		return newVetu(iso, security, resourceModifier, tuning, logger)
 	default:
 		return nil, fmt.Errorf("%w: unsupported isolation type %T", ErrInvalidIsolation, iso)
 	}
@@ -137,6 +139,7 @@ func newVetu(
 	iso *api.Isolation_Vetu_,
 	security *security.Security,
 	resourceModifier *resourcemodifier.Modifier,
+	tuning *tuning.Tuning,
 	logger logger.Lightweight,
 ) (*vetu.Vetu, error) {
 	vetuPolicy := security.VetuPolicy()
@@ -174,5 +177,5 @@ func newVetu(
 	}
 
 	return vetu.New(iso.Vetu.Image, iso.Vetu.User, iso.Vetu.Password, uint16(iso.Vetu.Port),
-		iso.Vetu.Cpu, iso.Vetu.Memory, resourceModifier, opts...)
+		iso.Vetu.Cpu, iso.Vetu.Memory, resourceModifier, tuning, opts...)
 }

--- a/internal/worker/options.go
+++ b/internal/worker/options.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/worker/chacha"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/resourcemodifier"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/security"
+	"github.com/cirruslabs/cirrus-cli/internal/worker/tuning"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/upstream"
 	"github.com/cirruslabs/cirrus-cli/pkg/api"
 	"github.com/sirupsen/logrus"
@@ -51,6 +52,12 @@ func WithStandby(standby *api.StandbyInstanceParameters) Option {
 func WithResourceModifiersManager(resourceModifiersManager *resourcemodifier.Manager) Option {
 	return func(e *Worker) {
 		e.resourceModifierManager = resourceModifiersManager
+	}
+}
+
+func WithTuning(tuning *tuning.Tuning) Option {
+	return func(e *Worker) {
+		e.tuning = tuning
 	}
 }
 

--- a/internal/worker/task.go
+++ b/internal/worker/task.go
@@ -119,7 +119,7 @@ func (worker *Worker) getInstance(
 
 	// Otherwise proceed with creating a new instance
 	return persistentworker.New(isolation, worker.security,
-		worker.resourceModifierManager.Acquire(resourcesToUse), worker.logger)
+		worker.resourceModifierManager.Acquire(resourcesToUse), worker.tuning, worker.logger)
 }
 
 func (worker *Worker) runTask(

--- a/internal/worker/tuning/tuning.go
+++ b/internal/worker/tuning/tuning.go
@@ -1,0 +1,17 @@
+package tuning
+
+type Tuning struct {
+	Vetu Vetu `yaml:"vetu"`
+}
+
+type Vetu struct {
+	MTU int `yaml:"mtu"`
+}
+
+func (t *Tuning) GetVetu() Vetu {
+	if t == nil {
+		return Vetu{}
+	}
+
+	return t.Vetu
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/worker/chacha"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/resourcemodifier"
 	"github.com/cirruslabs/cirrus-cli/internal/worker/security"
+	"github.com/cirruslabs/cirrus-cli/internal/worker/tuning"
 	upstreampkg "github.com/cirruslabs/cirrus-cli/internal/worker/upstream"
 	"github.com/cirruslabs/cirrus-cli/pkg/api"
 	"github.com/cirruslabs/echelon"
@@ -44,6 +45,7 @@ type Worker struct {
 
 	security                *security.Security
 	resourceModifierManager *resourcemodifier.Manager
+	tuning                  *tuning.Tuning
 
 	userSpecifiedLabels    map[string]string
 	userSpecifiedResources map[string]float64
@@ -257,7 +259,7 @@ func (worker *Worker) tryCreateStandby(ctx context.Context) error {
 	worker.logger.Debugf("creating a new standby instance with isolation %s", worker.standbyParameters.Isolation)
 
 	standbyInstance, err := persistentworker.New(worker.standbyParameters.Isolation, worker.security,
-		worker.resourceModifierManager.Acquire(worker.standbyParameters.Resources), worker.logger)
+		worker.resourceModifierManager.Acquire(worker.standbyParameters.Resources), worker.tuning, worker.logger)
 	if err != nil {
 		worker.logger.Errorf("failed to create a standby instance: %v", err)
 


### PR DESCRIPTION
Currently it only allows to pass a specific `--net-host-mtu` to `vetu run`.