### PR TITLE
Remove old build directive (// +build)

### DIFF
--- a/internal/commands/internal/test/test.go
+++ b/internal/commands/internal/test/test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || windows
-// +build linux darwin windows
 
 package test
 

--- a/internal/commands/internal/test/test_unsupported.go
+++ b/internal/commands/internal/test/test_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !windows
-// +build !linux,!darwin,!windows
 
 package test
 

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || windows
-// +build linux darwin windows
 
 package commands
 

--- a/internal/commands/run_test.go
+++ b/internal/commands/run_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package commands_test
 

--- a/internal/commands/run_unsupported.go
+++ b/internal/commands/run_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !windows
-// +build !linux,!darwin,!windows
 
 package commands
 

--- a/internal/commands/serve.go
+++ b/internal/commands/serve.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package commands
 

--- a/internal/commands/serve_unsupported.go
+++ b/internal/commands/serve_unsupported.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package commands
 

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package evaluator_test
 

--- a/internal/executor/executor_linux_test.go
+++ b/internal/executor/executor_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package executor_test
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package executor_test
 

--- a/internal/executor/heuristic/heuristic.go
+++ b/internal/executor/heuristic/heuristic.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || windows
-// +build linux darwin windows
 
 package heuristic
 

--- a/internal/executor/heuristic/heuristic_unsupported.go
+++ b/internal/executor/heuristic/heuristic_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !windows
-// +build !linux,!darwin,!windows
 
 package heuristic
 

--- a/internal/executor/instance/containerbackend/docker.go
+++ b/internal/executor/instance/containerbackend/docker.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || windows
-// +build linux darwin windows
 
 package containerbackend
 

--- a/internal/executor/instance/containerbackend/docker_unsupported.go
+++ b/internal/executor/instance/containerbackend/docker_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !windows
-// +build !linux,!darwin,!windows
 
 package containerbackend
 

--- a/internal/executor/instance/containerbackend/podman.go
+++ b/internal/executor/instance/containerbackend/podman.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package containerbackend
 

--- a/internal/executor/instance/persistentworker/isolation/parallels/copy.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/copy.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package parallels
 

--- a/internal/executor/instance/persistentworker/isolation/parallels/vmkiller_unsupported.go
+++ b/internal/executor/instance/persistentworker/isolation/parallels/vmkiller_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package parallels
 

--- a/internal/executor/platform/auto.go
+++ b/internal/executor/platform/auto.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package platform
 

--- a/internal/executor/platform/auto_windows.go
+++ b/internal/executor/platform/auto_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package platform
 

--- a/pkg/larker/fs/normalize.go
+++ b/pkg/larker/fs/normalize.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fs
 


### PR DESCRIPTION
To fix linter errors.

Done with `golangci-lint run --fix`.