### PR TITLE
Refactor: Introduce `CirrusStoreBackend` for unified storage operations

### DIFF
--- a/internal/agent/executor/executor.go
+++ b/internal/agent/executor/executor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cirruslabs/cirrus-cli/internal/agent/executor/updatebatcher"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/executor/vaultunboxer"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/http_cache"
+	agentstorage "github.com/cirruslabs/cirrus-cli/internal/agent/storage"
 	"github.com/cirruslabs/cirrus-cli/pkg/api"
 	"github.com/samber/lo"
 )
@@ -219,7 +220,8 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 	if _, ok := executor.env.Lookup("CIRRUS_HTTP_CACHE_HOST"); !ok {
 		transport := http_cache.DefaultTransport()
 
-		httpCacheHost := http_cache.Start(ctx, transport)
+		backend := agentstorage.NewCirrusStoreBackend(client.CirrusClient, client.CirrusTaskIdentification)
+		httpCacheHost := http_cache.Start(ctx, transport, backend)
 
 		executor.env.Set("CIRRUS_HTTP_CACHE_HOST", httpCacheHost)
 	}

--- a/internal/agent/http_cache/azureblob/azureblob.go
+++ b/internal/agent/http_cache/azureblob/azureblob.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	uploadablepkg "github.com/cirruslabs/cirrus-cli/internal/agent/http_cache/azureblob/uploadable"
+	omnistorage "github.com/cirruslabs/omni-cache/pkg/storage"
 	"github.com/getsentry/sentry-go"
 	"github.com/go-chi/render"
 	"github.com/google/uuid"
@@ -31,14 +32,16 @@ type AzureBlob struct {
 	mux                     *http.ServeMux
 	uploadables             *xsync.MapOf[string, *uploadablepkg.Uploadable]
 	httpClient              *http.Client
+	storageBackend          omnistorage.MultipartBlobStorageBackend
 	withUnexpectedEOFReader bool
 }
 
-func New(httpClient *http.Client, opts ...Option) *AzureBlob {
+func New(storageBackend omnistorage.MultipartBlobStorageBackend, httpClient *http.Client, opts ...Option) *AzureBlob {
 	azureBlobContainer := &AzureBlob{
-		mux:         http.NewServeMux(),
-		uploadables: xsync.NewMapOf[string, *uploadablepkg.Uploadable](),
-		httpClient:  httpClient,
+		mux:            http.NewServeMux(),
+		uploadables:    xsync.NewMapOf[string, *uploadablepkg.Uploadable](),
+		httpClient:     httpClient,
+		storageBackend: storageBackend,
 	}
 
 	// Apply opts

--- a/internal/agent/http_cache/ghacache/ghacache_test.go
+++ b/internal/agent/http_cache/ghacache/ghacache_test.go
@@ -3,10 +3,11 @@ package ghacache_test
 import (
 	"bytes"
 	"context"
-	"github.com/cirruslabs/cirrus-cli/internal/agent/client"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/http_cache"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/http_cache/ghacache/cirruscimock"
+	agentstorage "github.com/cirruslabs/cirrus-cli/internal/agent/storage"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
+	"github.com/cirruslabs/cirrus-cli/pkg/api"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -20,9 +21,10 @@ func TestGHA(t *testing.T) {
 
 	ctx := context.Background()
 
-	client.InitClient(cirruscimock.ClientConn(t), "test", "test")
+	conn := cirruscimock.ClientConn(t)
+	backend := agentstorage.NewCirrusStoreBackend(api.NewCirrusCIServiceClient(conn), api.OldTaskIdentification("test", "test"))
 
-	httpCacheURL := "http://" + http_cache.Start(ctx, http_cache.DefaultTransport()) + "/"
+	httpCacheURL := "http://" + http_cache.Start(ctx, http_cache.DefaultTransport(), backend) + "/"
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"ac":  `[]`,

--- a/internal/agent/http_cache/ghacache/uploadable/uploadable_test.go
+++ b/internal/agent/http_cache/ghacache/uploadable/uploadable_test.go
@@ -2,7 +2,7 @@ package uploadable_test
 
 import (
 	"github.com/cirruslabs/cirrus-cli/internal/agent/http_cache/ghacache/uploadable"
-	"github.com/cirruslabs/cirrus-cli/pkg/api"
+	omnistorage "github.com/cirruslabs/omni-cache/pkg/storage"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -17,10 +17,10 @@ func TestPartsAreOrdered(t *testing.T) {
 	parts, size, err := uploadable.Finalize()
 	require.NoError(t, err)
 
-	require.Equal(t, []*api.MultipartCacheUploadCommitRequest_Part{
-		{PartNumber: 1, Etag: "etag-1"},
-		{PartNumber: 2, Etag: "etag-2"},
-		{PartNumber: 3, Etag: "etag-3"},
+	require.Equal(t, []omnistorage.MultipartUploadPart{
+		{PartNumber: 1, ETag: "etag-1"},
+		{PartNumber: 2, ETag: "etag-2"},
+		{PartNumber: 3, ETag: "etag-3"},
 	}, parts)
 	require.EqualValues(t, 100, size)
 }

--- a/internal/agent/http_cache/http_cache_test.go
+++ b/internal/agent/http_cache/http_cache_test.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cirruslabs/cirrus-cli/internal/agent/client"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/http_cache"
 	"github.com/cirruslabs/cirrus-cli/internal/agent/http_cache/ghacache/cirruscimock"
+	agentstorage "github.com/cirruslabs/cirrus-cli/internal/agent/storage"
 	"github.com/cirruslabs/cirrus-cli/internal/testutil"
+	"github.com/cirruslabs/cirrus-cli/pkg/api"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -18,9 +19,10 @@ import (
 func TestHTTPCache(t *testing.T) {
 	testutil.NeedsContainerization(t)
 
-	client.InitClient(cirruscimock.ClientConn(t), "test", "test")
+	conn := cirruscimock.ClientConn(t)
+	backend := agentstorage.NewCirrusStoreBackend(api.NewCirrusCIServiceClient(conn), api.OldTaskIdentification("test", "test"))
 
-	httpCacheObjectURL := "http://" + http_cache.Start(context.Background(), http_cache.DefaultTransport()) +
+	httpCacheObjectURL := "http://" + http_cache.Start(context.Background(), http_cache.DefaultTransport(), backend) +
 		"/cache/" + uuid.NewString() + "/test.txt"
 
 	// Ensure that the cache entry does not exist

--- a/internal/agent/storage/cirrus_storage.go
+++ b/internal/agent/storage/cirrus_storage.go
@@ -1,0 +1,136 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/cirruslabs/cirrus-cli/pkg/api"
+	omnistorage "github.com/cirruslabs/omni-cache/pkg/storage"
+)
+
+type CacheBackend interface {
+	omnistorage.MultipartBlobStorageBackend
+
+	CacheInfo(ctx context.Context, key string, prefixes []string) (*api.CacheInfo, error)
+	DeleteCache(ctx context.Context, key string) error
+}
+
+type CirrusStoreBackend struct {
+	client             api.CirrusCIServiceClient
+	taskIdentification *api.TaskIdentification
+}
+
+func NewCirrusStoreBackend(client api.CirrusCIServiceClient, taskIdentification *api.TaskIdentification) *CirrusStoreBackend {
+	return &CirrusStoreBackend{
+		client:             client,
+		taskIdentification: taskIdentification,
+	}
+}
+
+func (c *CirrusStoreBackend) DownloadURLs(ctx context.Context, key string) ([]*omnistorage.URLInfo, error) {
+	response, err := c.client.GenerateCacheDownloadURLs(ctx, &api.CacheKey{
+		TaskIdentification: c.taskIdentification,
+		CacheKey:           key,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	urls := make([]*omnistorage.URLInfo, 0, len(response.Urls))
+
+	for _, url := range response.Urls {
+		urls = append(urls, &omnistorage.URLInfo{URL: url})
+	}
+
+	return urls, nil
+}
+
+func (c *CirrusStoreBackend) UploadURL(ctx context.Context, key string, metadate map[string]string) (*omnistorage.URLInfo, error) {
+	response, err := c.client.GenerateCacheUploadURL(ctx, &api.CacheKey{
+		TaskIdentification: c.taskIdentification,
+		CacheKey:           key,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &omnistorage.URLInfo{
+		URL:          response.Url,
+		ExtraHeaders: response.ExtraHeaders,
+	}, nil
+}
+
+func (c *CirrusStoreBackend) CreateMultipartUpload(ctx context.Context, key string, metadata map[string]string) (uploadID string, err error) {
+	response, err := c.client.MultipartCacheUploadCreate(ctx, &api.CacheKey{
+		TaskIdentification: c.taskIdentification,
+		CacheKey:           key,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return response.UploadId, nil
+}
+
+func (c *CirrusStoreBackend) UploadPartURL(ctx context.Context, key string, uploadID string, partNumber uint32, contentLength uint64) (*omnistorage.URLInfo, error) {
+	response, err := c.client.MultipartCacheUploadPart(ctx, &api.MultipartCacheUploadPartRequest{
+		CacheKey: &api.CacheKey{
+			TaskIdentification: c.taskIdentification,
+			CacheKey:           key,
+		},
+		UploadId:      uploadID,
+		PartNumber:    partNumber,
+		ContentLength: contentLength,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &omnistorage.URLInfo{
+		URL:          response.Url,
+		ExtraHeaders: response.ExtraHeaders,
+	}, nil
+}
+
+func (c *CirrusStoreBackend) CommitMultipartUpload(ctx context.Context, key string, uploadID string, parts []omnistorage.MultipartUploadPart) error {
+	apiParts := make([]*api.MultipartCacheUploadCommitRequest_Part, 0, len(parts))
+
+	for _, part := range parts {
+		apiParts = append(apiParts, &api.MultipartCacheUploadCommitRequest_Part{
+			PartNumber: part.PartNumber,
+			Etag:       part.ETag,
+		})
+	}
+
+	_, err := c.client.MultipartCacheUploadCommit(ctx, &api.MultipartCacheUploadCommitRequest{
+		CacheKey: &api.CacheKey{
+			TaskIdentification: c.taskIdentification,
+			CacheKey:           key,
+		},
+		UploadId: uploadID,
+		Parts:    apiParts,
+	})
+
+	return err
+}
+
+func (c *CirrusStoreBackend) CacheInfo(ctx context.Context, key string, prefixes []string) (*api.CacheInfo, error) {
+	response, err := c.client.CacheInfo(ctx, &api.CacheInfoRequest{
+		TaskIdentification: c.taskIdentification,
+		CacheKey:           key,
+		CacheKeyPrefixes:   prefixes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Info, nil
+}
+
+func (c *CirrusStoreBackend) DeleteCache(ctx context.Context, key string) error {
+	_, err := c.client.DeleteCache(ctx, &api.DeleteCacheRequest{
+		TaskIdentification: c.taskIdentification,
+		CacheKey:           key,
+	})
+
+	return err
+}


### PR DESCRIPTION
Replaced direct client calls with backend interactions in preparation to move logic into omni-cache