### PR TITLE
Close failed SSH handshakes to prevent socket buildup

### DIFF
--- a/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
+++ b/internal/executor/instance/persistentworker/remoteagent/remoteagent.go
@@ -311,6 +311,7 @@ func WaitForSSH(
 
 		sshConn, chans, reqs, err = ssh.NewClientConn(netConn, addr, sshConfig)
 		if err != nil {
+			_ = netConn.Close()
 			err := fmt.Errorf("%w: failed to connect via SSH: %v", ErrFailed, err)
 
 			logger.Debugf("failed to perform SSH handshake with %s: %v", addr, err)


### PR DESCRIPTION
Investigation:
- Worker heartbeats failed while the host showed heavy TCP retries.
- Checked TCP state counts: netstat -anp tcp | awk '{print }' | sort | uniq -c | sort -nr | head
- Identified top TIME_WAIT/SYN_SENT destinations: netstat -anp tcp | awk '=="TIME_WAIT"{print }' | sort | uniq -c | sort -nr | head netstat -anp tcp | awk '=="SYN_SENT"{print }' | sort | uniq -c | sort -nr | head
- Verified ephemeral port range: sysctl net.inet.ip.portrange.hifirst net.inet.ip.portrange.hilast
- Checked per-process socket usage: lsof -nP -iTCP | awk '{print }' | sort | uniq -c | sort -nr | head

Findings:
- Tart isolation retries SSH connections in a tight loop.
- When the TCP dial succeeds but the SSH handshake fails, the net.Conn was left open.

Fix:
- Close net.Conn on handshake failure so each retry releases its socket.