### PR TITLE
Move metrics endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/cirruslabs/chacha v0.16.3
 	github.com/cirruslabs/cirrus-ci-annotations v0.10.0
-	github.com/cirruslabs/omni-cache v0.9.0
+	github.com/cirruslabs/omni-cache v1.0.0
 	github.com/cirruslabs/terminal v0.16.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/google/go-github/v59 v59.0.0

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/cirruslabs/go-java-glob v0.1.0 h1:qC4Fzrq2sXKTLLsBb7ih7BNdCjCR6ZJAAK4
 github.com/cirruslabs/go-java-glob v0.1.0/go.mod h1:+4vLmYqEnKtVAdeYsP5GCcPBcTuWsqi6P9bO6HraGFE=
 github.com/cirruslabs/omni-cache v0.9.0 h1:uyk2UHj2ZcKi5bKHbkN7oTMLJEe3QVzbXCpgmEtjRY4=
 github.com/cirruslabs/omni-cache v0.9.0/go.mod h1:DUJR/8GYjN9XKDFmn9MMB/A8fCuBVIqweggZKBpxmP8=
+github.com/cirruslabs/omni-cache v1.0.0 h1:A153LMnIAaMiBaBW2ruuA2kbHHzrzjVYrWD/Mt2o30w=
+github.com/cirruslabs/omni-cache v1.0.0/go.mod h1:DUJR/8GYjN9XKDFmn9MMB/A8fCuBVIqweggZKBpxmP8=
 github.com/cirruslabs/terminal v0.16.0 h1:RUHtBccwykpGI1pKb9aKqtMQnnz6DyzJZiQyI2e81zw=
 github.com/cirruslabs/terminal v0.16.0/go.mod h1:NYC5TZrMSZFaNwXv8OTk1kwOOgkpeB1Snp2sP6e17e4=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/internal/agent/executor/metrics_protocol.go
+++ b/internal/agent/executor/metrics_protocol.go
@@ -33,7 +33,7 @@ type metricsProtocol struct {
 }
 
 func (protocol *metricsProtocol) Register(registrar *protocols.Registrar) error {
-	registrar.HTTP().HandleFunc("GET /metrics", protocol.handleMetrics)
+	registrar.HTTP().HandleFunc("GET /metrics/resources", protocol.handleMetrics)
 	return nil
 }
 


### PR DESCRIPTION
To align with https://github.com/cirruslabs/omni-cache/pull/27 aka `/metrics/cache` for cache metrics