### PR TITLE
Larker: remove stray fmt.Printf() call

### DIFF
--- a/pkg/larker/larker.go
+++ b/pkg/larker/larker.go
@@ -289,8 +289,6 @@ func (larker *Larker) Hook(
 }
 
 func logsWithErrorAttached(logs []byte, err error) []byte {
-	fmt.Printf("%T\n", err)
-
 	ee, ok := errors.Unwrap(err).(*starlark.EvalError)
 	if !ok {
 		return logs


### PR DESCRIPTION
It should not be here.