### PR TITLE
Update to go-m1cpu 0.2.1 to avoid M5 segfault

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ require (
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
-	github.com/shoenig/go-m1cpu v0.1.7 // indirect
+	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/i
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shirou/gopsutil/v4 v4.26.2 h1:X8i6sicvUFih4BmYIGT1m2wwgw2VG9YgrDTi7cIRGUI=
 github.com/shirou/gopsutil/v4 v4.26.2/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
-github.com/shoenig/go-m1cpu v0.1.7 h1:C76Yd0ObKR82W4vhfjZiCp0HxcSZ8Nqd84v+HZ0qyI0=
-github.com/shoenig/go-m1cpu v0.1.7/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
+github.com/shoenig/go-m1cpu v0.2.1 h1:yqRB4fvOge2+FyRXFkXqsyMoqPazv14Yyy+iyccT2E4=
+github.com/shoenig/go-m1cpu v0.2.1/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
 github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
 github.com/shoenig/test v1.7.0/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=


### PR DESCRIPTION
When running `cirrus` on an M5 CPU, the program segfaults immediately:

```
SIGSEGV: segmentation violation
PC=0x18db1b1a8 m=0 sigcode=2 addr=0x0
signal arrived during cgo execution

goroutine 1 gp=0x140000021c0 m=0 mp=0x106f57020 [syscall, locked to thread]:
runtime.cgocall(0x105b6e960, 0x140000a6e08)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/cgocall.go:167 +0x44 fp=0x140000a6dd0 sp=0x140000a6d90 pc=0x104da39d4
github.com/shoenig/go-m1cpu._Cfunc_initialize()
        _cgo_gotypes.go:150 +0x2c fp=0x140000a6e00 sp=0x140000a6dd0 pc=0x105472a7c
github.com/shoenig/go-m1cpu.init.0()
        /Users/admin/go/pkg/mod/github.com/shoenig/go-m1cpu@v0.1.6/cpu.go:148 +0x1c fp=0x140000a6e10 sp=0x140000a6e00 pc=0x105472abc
runtime.doInit1(0x106e82040)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/proc.go:7670 +0xc4 fp=0x140000a6f40 sp=0x140000a6e10 pc=0x104d834f4
runtime.doInit(...)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/proc.go:7637
runtime.main()
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/proc.go:256 +0x338 fp=0x140000a6fd0 sp=0x140000a6f40 pc=0x104d73668
runtime.goexit({})
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140000a6fd0 sp=0x140000a6fd0 pc=0x104daf024
```

It appears that this is caused by a bug in go-m1cpu that has been [fixed in 0.2.1](https://github.com/shoenig/go-m1cpu/releases/tag/v0.2.1). This PR updates the dependency to prevent the segfault and allow running the binary. 

Tested and confirmed on an M5 CPU.