### PR TITLE
Add support for tart arguments through cirrus CLI

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -63,6 +63,7 @@ var (
 
 // Tart-related flags.
 var tartLazyPull bool
+var tartRunArgs []string
 
 // Tart-related flags (experimental).
 var tartNoUnmount bool
@@ -199,11 +200,12 @@ func run(cmd *cobra.Command, args []string) error {
 		DockerfileImagePush:     dockerfileImagePush,
 	}))
 
-	// Tart-related options
-	executorOpts = append(executorOpts, executor.WithTartOptions(options.TartOptions{
-		LazyPull:  lazyPull || tartLazyPull,
+    // Tart-related options
+    executorOpts = append(executorOpts, executor.WithTartOptions(options.TartOptions{
+        LazyPull: lazyPull || tartLazyPull,
 		NoUnmount: tartNoUnmount,
-	}))
+        RunArgs:  tartRunArgs,
+    }))
 
 	// Vetu-related options
 	executorOpts = append(executorOpts, executor.WithVetuOptions(options.VetuOptions{
@@ -303,9 +305,11 @@ func newRunCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&dockerfileImagePush, "dockerfile-image-push",
 		false, "whether to push the image produced by the Dockerfile as CI environment feature")
 
-	// Tart-related flags
-	cmd.PersistentFlags().BoolVar(&tartLazyPull, "tart-lazy-pull", false,
+    // Tart-related flags
+    cmd.PersistentFlags().BoolVar(&tartLazyPull, "tart-lazy-pull", false,
 		"attempt to pull Tart VM images only if they are missing locally (helpful in case of registry rate limits)")
+    cmd.PersistentFlags().StringArrayVar(&tartRunArgs, "tart-arg", []string{},
+        "additional arguments to pass to 'tart run' (e.g., --disk=/path.sparseimage)")
 
 	// Tart-related flags (experimental)
 	cmd.PersistentFlags().BoolVar(&tartNoUnmount, "tart-no-unmount", false,

--- a/internal/executor/instance/persistentworker/isolation/tart/options.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/options.go
@@ -49,3 +49,9 @@ func WithSyncTimeOverSSH() Option {
 		tart.syncTimeOverSSH = true
 	}
 }
+
+func WithRunArgs(args []string) Option {
+    return func(tart *Tart) {
+        tart.extraRunArgs = append(tart.extraRunArgs, args...)
+    }
+}

--- a/internal/executor/instance/persistentworker/isolation/tart/tart.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/tart.go
@@ -56,6 +56,7 @@ type Tart struct {
 	display         string
 	volumes         []*api.Isolation_Tart_Volume
 	syncTimeOverSSH bool
+    extraRunArgs    []string
 
 	vm              *VM
 	initializeHooks []remoteagent.WaitForAgentHook
@@ -302,7 +303,7 @@ func (tart *Tart) bootVM(
 		})
 	}
 
-	vm.Start(ctx, tart.softnet, tart.softnetAllow, tart.nested, directoryMounts)
+    vm.Start(ctx, tart.softnet, tart.softnetAllow, tart.nested, directoryMounts, tart.extraRunArgs)
 
 	// Wait for the VM to start and get it's DHCP address
 	bootLogger := logger.Scoped("boot virtual machine")
@@ -348,7 +349,11 @@ func (tart *Tart) Run(ctx context.Context, config *runconfig.RunConfig) (err err
 	if tart.vm != nil && config.DirtyMode {
 		return fmt.Errorf("%w: dirty mode is not supported for a warmed instance", ErrFailed)
 	}
-	if tart.vm == nil {
+    if tart.vm == nil {
+        // propagate extra run args from run config
+        if len(config.TartOptions.RunArgs) != 0 {
+            tart.extraRunArgs = append(tart.extraRunArgs, config.TartOptions.RunArgs...)
+        }
 		automountProjectDir := ""
 		if config.DirtyMode && config.ProjectDir != "" {
 			automountProjectDir = config.ProjectDir

--- a/internal/executor/instance/persistentworker/isolation/tart/vm.go
+++ b/internal/executor/instance/persistentworker/isolation/tart/vm.go
@@ -161,7 +161,8 @@ func (vm *VM) Start(
 	softnet bool,
 	softnetAllow []string,
 	nested bool,
-	directoryMounts []directoryMount,
+    directoryMounts []directoryMount,
+    extraRunArgs []string,
 ) {
 	vm.wg.Add(1)
 
@@ -202,7 +203,12 @@ func (vm *VM) Start(
 			args = append(args, "--dir", dirArgumentValue)
 		}
 
-		args = append(args, vm.ident)
+        // Extra arguments first, then VM ident at the end
+        if len(extraRunArgs) > 0 {
+            args = append(args, extraRunArgs...)
+        }
+
+        args = append(args, vm.ident)
 
 		stdout, stderr, err := Cmd(vm.runningVMCtx, vm.env, "run", args...)
 		if localHub := sentry.GetHubFromContext(ctx); localHub != nil {

--- a/internal/executor/instance/persistentworker/persistentworker.go
+++ b/internal/executor/instance/persistentworker/persistentworker.go
@@ -131,8 +131,8 @@ func newTart(iso *api.Isolation_Tart_, security *security.Security, logger logge
 		opts = append(opts, tart.WithSyncTimeOverSSH())
 	}
 
-	return tart.New(iso.Tart.Image, iso.Tart.User, iso.Tart.Password, uint16(iso.Tart.Port),
-		iso.Tart.Cpu, iso.Tart.Memory, opts...)
+    return tart.New(iso.Tart.Image, iso.Tart.User, iso.Tart.Password, uint16(iso.Tart.Port),
+        iso.Tart.Cpu, iso.Tart.Memory, opts...)
 }
 
 func newVetu(

--- a/internal/executor/options/tart.go
+++ b/internal/executor/options/tart.go
@@ -1,6 +1,7 @@
 package options
 
 type TartOptions struct {
-	LazyPull  bool
+	LazyPull bool
 	NoUnmount bool
+    RunArgs  []string
 }


### PR DESCRIPTION
Facing a common issue with flaking behaviour of the virtio-fs file system when used for CI operations,
(i.e. https://github.com/openai/tart/issues/567), this PR adds a possibility to pass down to `tart` from `cirrus CLI` main interface flag for mounting disk image attached to the host.

This allows to completely resolve the issue with the flaking behaviour of the default-mounted virtio-fs-based drive within the guest macOS image, and provides better performance overall.